### PR TITLE
fix(release): align package and extension versions

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,12 +2,24 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    [
+      "@shieldedtech/moth-wallet",
+      "@shieldedtech/moth-browser",
+      "@shieldedtech/moth-cli",
+      "@shieldedtech/moth-tui",
+      "@shieldedtech/moth-extension"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],
+  "privatePackages": {
+    "version": true,
+    "tag": false
+  },
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,6 +89,12 @@ records a final GO decision.
 - **Minor** (1.0.0 → 1.1.0): New features, backwards compatible
 - **Patch** (1.0.0 → 1.0.1): Bug fixes, backwards compatible
 
+The wallet, browser, CLI, TUI, and private extension packages are one fixed
+release group in `.changeset/config.json`. Changesets versions them together so
+the NPM packages and the downloadable extension carry the same release number.
+Private packages are versioned but never published. The historical extension
+`0.11.0` tag is retained; the next aligned release advances from that version.
+
 ## Manual Publishing
 
 Manual publishing is unsupported because it bypasses the reviewed GitHub Actions identity and


### PR DESCRIPTION
## Summary

- make the wallet, browser, CLI, TUI, and private extension one Changesets fixed release group
- version private packages without publishing them, while keeping NPM publication OIDC-only
- document that the historical extension `0.11.0` tag is retained and the next aligned release advances from it

The existing `0.3.0-canary` is a historical snapshot produced before this policy landed. The existing `moth-extension-v0.11.0` tag is not rewritten or deleted. With this policy, the pending release is calculated as the next shared version (`0.12.0`) across the fixed group.

## Validation

- `yarn changeset status` lists the fixed release group at the pending minor bump
- `pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`

This PR changes release policy only. It does not publish packages, create tags, or merge releases.
