### PR TITLE
ci: publish coverage and Scorecard metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,17 @@ jobs:
           path: coverage/lcov.info
           if-no-files-found: error
           retention-days: 14
+
+      # Configure CODECOV_TOKEN as a repository secret before enabling public
+      # coverage reporting. The artifact above remains the local evidence path.
+      - name: Publish coverage to Codecov
+        if: ${{ env.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@0f8570b1a125f4937846a11fcfa3bcd548bd8c97  # v4.6.0
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: coverage/lcov.info
+          flags: unittests
+          slug: shieldedtech/moth-wallet
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,11 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      # Configure CODECOV_TOKEN as a repository secret before enabling public
-      # coverage reporting. The artifact above remains the local evidence path.
+      # Private repositories use CODECOV_TOKEN; public repositories may use
+      # Codecov's tokenless GitHub Actions upload path. The artifact above
+      # remains the local evidence path in either case.
       - name: Publish coverage to Codecov
-        if: ${{ env.CODECOV_TOKEN != '' }}
         uses: codecov/codecov-action@0f8570b1a125f4937846a11fcfa3bcd548bd8c97  # v4.6.0
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: coverage/lcov.info
           flags: unittests

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 6 * * 1'
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      checks: read
+      id-token: write
+      issues: read
+      pull-requests: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@55891bbd73f2425e97637d96e306fc9d491d0b21  # v2.4.4
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Scorecard results
+        uses: github/codeql-action/upload-sarif@b1722c1245f90604c2c348f9d1624af97ea8fc6e  # v3.29.0
+        with:
+          sarif_file: scorecard-results.sarif
+
+      - name: Upload Scorecard artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ Built for DApp developers, CI pipelines, and developing AI coding agents.
 
 [![Tests and coverage](https://github.com/shieldedtech/moth-wallet/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/shieldedtech/moth-wallet/actions/workflows/ci.yml)
 [![OSS and security scan](https://github.com/shieldedtech/moth-wallet/actions/workflows/scan.yaml/badge.svg?branch=main)](https://github.com/shieldedtech/moth-wallet/actions/workflows/scan.yaml)
+[![Coverage](https://codecov.io/gh/shieldedtech/moth-wallet/branch/main/graph/badge.svg)](https://codecov.io/gh/shieldedtech/moth-wallet)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/shieldedtech/moth-wallet/badge)](https://scorecard.dev/viewer/?uri=github.com/shieldedtech/moth-wallet)
 
-The security scan includes OpenSSF Scorecard; coverage is published as a CI artifact while its measurement remains advisory.
+Coverage and Scorecard setup details are documented in [`docs/QUALITY_METRICS.md`](docs/QUALITY_METRICS.md).
 
 ## Status: Experimental and Unsupported
 

--- a/docs/QUALITY_METRICS.md
+++ b/docs/QUALITY_METRICS.md
@@ -4,8 +4,9 @@ The repository keeps the raw reports in GitHub Actions artifacts and publishes
 the two public-facing metrics separately:
 
 - **Coverage:** the `Coverage (advisory)` job uploads `coverage/lcov.info` to
-  Codecov when the repository secret `CODECOV_TOKEN` is configured. Codecov
-  supplies the percentage badge and historical coverage view.
+  Codecov. Private repositories authenticate with the repository secret
+  `CODECOV_TOKEN`; public repositories use Codecov's tokenless GitHub Actions
+  path. Codecov supplies the percentage badge and historical coverage view.
 - **OpenSSF Scorecard:** `scorecard.yml` publishes the signed SARIF result to
   the Scorecard API and uploads the same result to GitHub code scanning. The
   Scorecard badge reports a score from 0 to 10, not a percentage.
@@ -13,8 +14,9 @@ the two public-facing metrics separately:
 ## One-time maintainer setup
 
 1. Install the Codecov GitHub App for `shieldedtech/moth-wallet`.
-2. Create the repository's Codecov upload token and store it as the Actions
-   secret `CODECOV_TOKEN`.
+2. For a private repository, create the repository's Codecov upload token and
+   store it as the Actions secret `CODECOV_TOKEN`. This is not required once a
+   repository is public and tokenless uploads are enabled for the organization.
 3. Run the coverage workflow on `main` and confirm that the Codecov report and
    badge resolve.
 4. Run `OpenSSF Scorecard` once from Actions and confirm the published result at

--- a/docs/QUALITY_METRICS.md
+++ b/docs/QUALITY_METRICS.md
@@ -1,0 +1,26 @@
+# Quality metrics
+
+The repository keeps the raw reports in GitHub Actions artifacts and publishes
+the two public-facing metrics separately:
+
+- **Coverage:** the `Coverage (advisory)` job uploads `coverage/lcov.info` to
+  Codecov when the repository secret `CODECOV_TOKEN` is configured. Codecov
+  supplies the percentage badge and historical coverage view.
+- **OpenSSF Scorecard:** `scorecard.yml` publishes the signed SARIF result to
+  the Scorecard API and uploads the same result to GitHub code scanning. The
+  Scorecard badge reports a score from 0 to 10, not a percentage.
+
+## One-time maintainer setup
+
+1. Install the Codecov GitHub App for `shieldedtech/moth-wallet`.
+2. Create the repository's Codecov upload token and store it as the Actions
+   secret `CODECOV_TOKEN`.
+3. Run the coverage workflow on `main` and confirm that the Codecov report and
+   badge resolve.
+4. Run `OpenSSF Scorecard` once from Actions and confirm the published result at
+   the Scorecard viewer URL in the README.
+
+The Scorecard workflow uses GitHub's OIDC token for result publication. No
+long-lived cloud or signing secret is stored in the repository. Coverage remains
+advisory until a measured baseline is accepted and thresholds are deliberately
+introduced.


### PR DESCRIPTION
## Summary

- upload the advisory `lcov.info` report to Codecov when `CODECOV_TOKEN` is configured
- publish OpenSSF Scorecard results through the official action with OIDC and code scanning
- replace pass/fail-only README quality signals with a coverage percentage badge and Scorecard score badge
- document the one-time maintainer setup and secret prerequisite

GitHub artifacts remain the raw evidence path. Codecov provides the historical coverage percentage; Scorecard reports its security score on a 0–10 scale. No secret is committed or created by this PR.

## Required maintainer setup

Configure the Codecov GitHub App and repository Actions secret `CODECOV_TOKEN`, then run the coverage workflow on `main`. Run the Scorecard workflow once and confirm its published result before making the repository public.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/scorecard.yml`
- `pre-commit run --all-files --show-diff-on-failure`
- `git diff --check`
