### PR TITLE
fix(ci): repair Scorecard result publishing

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      actions: read
       checks: read
       id-token: write
       issues: read
@@ -28,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@55891bbd73f2425e97637d96e306fc9d491d0b21  # v2.4.4
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc  # v2.4.4
         with:
           results_file: scorecard-results.sarif
           results_format: sarif


### PR DESCRIPTION
Fixes Scorecard publishing by pinning the dereferenced v2.4.4 commit and granting actions read permission for SARIF upload. Assisted-by: Codex <noreply@openai.com>