### PR TITLE
fix(tui): publish npm-compatible wallet dependency

### DIFF
--- a/.changeset/fix-published-workspace-range.md
+++ b/.changeset/fix-published-workspace-range.md
@@ -1,0 +1,5 @@
+---
+"@shieldedtech/moth-tui": patch
+---
+
+Fix the published TUI package to use a semver dependency range for `moth-wallet` so npm consumers can install it outside the Yarn workspace.

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@midnight-ntwrk/ledger-v8": "8.1.0",
     "@midnightntwrk/wallet-sdk": "^1.2.0",
-    "@shieldedtech/moth-wallet": "workspace:*",
+    "@shieldedtech/moth-wallet": "^0.12.0",
     "ink": "^7.0.1",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",

--- a/scripts/test-release-policy.mjs
+++ b/scripts/test-release-policy.mjs
@@ -12,6 +12,19 @@ function requirePolicy(condition, message) {
   }
 }
 
+for (const packagePath of ['packages/core/package.json', 'packages/tui/package.json', 'packages/cli/package.json']) {
+  const packageJson = JSON.parse(readFileSync(new URL(`../${packagePath}`, import.meta.url), 'utf8'));
+  const dependencies = {
+    ...packageJson.dependencies,
+    ...packageJson.optionalDependencies,
+    ...packageJson.peerDependencies,
+  };
+  requirePolicy(
+    !Object.values(dependencies).some((range) => range.startsWith('workspace:')),
+    `${packageJson.name} must not publish workspace: dependency ranges`,
+  );
+}
+
 function job(name) {
   const marker = `  ${name}:`;
   const start = workflow.indexOf(marker);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,7 +2953,7 @@ __metadata:
   dependencies:
     "@midnight-ntwrk/ledger-v8": "npm:8.1.0"
     "@midnightntwrk/wallet-sdk": "npm:^1.2.0"
-    "@shieldedtech/moth-wallet": "workspace:*"
+    "@shieldedtech/moth-wallet": "npm:^0.12.0"
     "@types/react": "npm:^19.0.0"
     ink: "npm:^7.0.1"
     ink-spinner: "npm:^5.0.0"


### PR DESCRIPTION
Closes #15

## Summary

The published `@shieldedtech/moth-tui@0.12.0` package contains the Yarn-only
dependency range `@shieldedtech/moth-wallet: workspace:*`. npm consumers cannot
resolve that protocol, so installing `@shieldedtech/moth-cli` fails.

This changes the publishable TUI manifest to an npm-compatible semver range,
refreshes the Yarn lockfile, and adds a release-policy regression check so
publishable packages cannot contain `workspace:` dependency ranges.

## Validation

- `yarn install` completed (with existing peer-dependency warnings).
- `yarn test:release-policy` passed.
- Core build passed, then TUI build passed.
- TUI tests passed: 67 tests.
- `pre-commit run --files ...` passed all applicable hooks.
- Signed commit: `bd8d41f50607c6a379e86b3f81aaace9a7f6bc52`.

## Release

The Changeset prepares a patch release for `@shieldedtech/moth-tui`. After
merge, the normal release workflow must publish the corrected package before
the CLI install is retested.

<details>
<summary>🤖 Agent handover (context for reviewers)</summary>

- Registry evidence: `npm view @shieldedtech/moth-tui@0.12.0 dependencies --json`
  reports `@shieldedtech/moth-wallet: workspace:*`.
- Changed files: `packages/tui/package.json`, `yarn.lock`,
  `scripts/test-release-policy.mjs`, and one Changeset.
- No npm tokens or release workflow credentials were changed.

</details>
