### PR TITLE
fix: normalize npm version detection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,10 +85,10 @@ jobs:
             if [ "$is_private" = "true" ]; then
               continue
             fi
-            published_version=$(npm view "${package_name}@${package_version}" version --json 2>/dev/null || true)
+            published_version=$(npm view "${package_name}@${package_version}" version --json)
             # npm may emit a JSON string with or without quotes depending on
             # the npm version used by the runner; normalize both forms.
-            published_version=${published_version//\"/}
+            published_version=$(printf '%s' "$published_version" | tr -d '"[:space:]')
             if [ "$published_version" != "${package_version}" ]; then
               echo "${package_name}@${package_version} is not published"
               has_unpublished=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,10 @@ jobs:
               continue
             fi
             published_version=$(npm view "${package_name}@${package_version}" version --json 2>/dev/null || true)
-            if [ "$published_version" != "\"${package_version}\"" ]; then
+            # npm may emit a JSON string with or without quotes depending on
+            # the npm version used by the runner; normalize both forms.
+            published_version=${published_version//\"/}
+            if [ "$published_version" != "${package_version}" ]; then
               echo "${package_name}@${package_version} is not published"
               has_unpublished=true
             fi


### PR DESCRIPTION
Fixes the second failure in the stable-publish guard.

The previous comparison expected npm to return a quoted JSON string, but the runner returned `0.12.1` without quotes. Every package was therefore misclassified as unpublished and the workflow still attempted immutable republishing.

This normalizes the npm output before comparison. No Changeset or package release is included.