### PR TITLE
fix(release): reconcile package state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,26 +55,6 @@ jobs:
       - name: Build Packages
         run: yarn build
 
-      # npm 12 rejects an already-published version even with --dry-run. Only
-      # validate publication when this commit actually changes a package version.
-      - name: Detect package version changes
-        id: package_changes
-        shell: bash
-        run: |
-          set -euo pipefail
-          if git diff --unified=0 "${{ github.event.before }}" "$GITHUB_SHA" -- 'packages/*/package.json' \
-            | rg -q '^[+-][[:space:]]*"version"[[:space:]]*:'; then
-            echo "hasVersionChanges=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "hasVersionChanges=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      # Scorecard recognizes this as the repository's npm packaging workflow.
-      # It is deliberately a dry run: Changesets remains the single publisher.
-      - name: Validate npm package publication
-        if: ${{ steps.package_changes.outputs.hasVersionChanges == 'true' }}
-        run: npm publish --dry-run --workspace packages/core --ignore-scripts
-
       # Detect whether pending changesets actually bump any package — the signal
       # the canary job gates on. (An empty changeset bumps nothing → no canary.)
       - name: Detect releasable changesets
@@ -101,6 +81,15 @@ jobs:
             echo "hasChangesets=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Registry, tag, and GitHub Release state survive canceled and partial runs.
+      # The same process also dry-runs only packages that still need publication.
+      - name: Detect incomplete package releases
+        if: ${{ steps.releases.outputs.hasChangesets == 'false' }}
+        id: package_changes
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/release-packages.mjs --github-output --validate
+
       # Use the machine-user PAT only while opening or updating the version PR.
       # It is deliberately absent from the stable publish process below.
       - name: Create or update version PR
@@ -117,9 +106,9 @@ jobs:
           commit: "chore: version packages"
 
       # With no Changesets left, publish through npm Trusted Publishing (OIDC),
-      # then use the ephemeral Actions token for tags and GitHub Releases.
+      # then recover or create tags and GitHub Releases through Changesets.
       - name: Publish stable release
-        if: ${{ steps.releases.outputs.hasChangesets == 'false' && steps.package_changes.outputs.hasVersionChanges == 'true' }}
+        if: ${{ steps.releases.outputs.hasChangesets == 'false' && steps.package_changes.outputs.hasReleaseWork == 'true' }}
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d  # v1.9.0
         with:
           publish: yarn run release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,4 +31,10 @@ repos:
         entry: node scripts/test-release-policy.mjs
         language: system
         pass_filenames: false
-        files: ^(\.github/workflows/release\.yml|package\.json|scripts/test-release-policy\.mjs)$
+        files: ^(\.github/workflows/release\.yml|package\.json|packages/[^/]+/package\.json|scripts/(test-)?release-(policy|packages)\.mjs)$
+      - id: release-package-reconciliation
+        name: release package reconciliation
+        entry: node scripts/test-release-packages.mjs
+        language: system
+        pass_filenames: false
+        files: ^(package\.json|packages/[^/]+/package\.json|scripts/(test-)?release-packages\.mjs)$

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "turbo run clean",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "changeset publish"
+    "release": "node scripts/release-packages.mjs"
   },
   "resolutions": {
     "@midnight-ntwrk/compact-js": "2.5.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "files": [
     "dist",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "files": [
     "dist"

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   },
   "files": [
     "dist"

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -1,0 +1,453 @@
+// SPDX-FileCopyrightText: Copyright (C) Shielded Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+import {execFileSync, spawnSync} from 'node:child_process';
+import {appendFileSync, globSync, readFileSync, realpathSync} from 'node:fs';
+import {dirname, posix, resolve} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+
+function requireString(value, description) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${description} must be a non-empty string`);
+  }
+  return value;
+}
+
+export function packageDependencies(packageJson) {
+  return {
+    ...packageJson.dependencies,
+    ...packageJson.optionalDependencies,
+    ...packageJson.peerDependencies,
+  };
+}
+
+export function loadPublicWorkspaces(rootDir) {
+  const rootPackage = JSON.parse(readFileSync(resolve(rootDir, 'package.json'), 'utf8'));
+  const workspacePatterns = Array.isArray(rootPackage.workspaces)
+    ? rootPackage.workspaces
+    : rootPackage.workspaces?.packages;
+
+  if (!Array.isArray(workspacePatterns)) {
+    throw new Error('package.json must define workspaces as an array');
+  }
+
+  const manifestPaths = [
+    ...new Set(
+      workspacePatterns.flatMap((pattern) =>
+        globSync(posix.join(requireString(pattern, 'workspace pattern'), 'package.json'), {
+          cwd: rootDir,
+        }),
+      ),
+    ),
+  ].sort();
+
+  return manifestPaths
+    .map((manifestPath) => {
+      const packageJson = JSON.parse(readFileSync(resolve(rootDir, manifestPath), 'utf8'));
+      return {
+        name: requireString(packageJson.name, `${manifestPath} name`),
+        version: requireString(packageJson.version, `${manifestPath} version`),
+        private: packageJson.private === true,
+        access: packageJson.publishConfig?.access,
+        workspace: dirname(manifestPath),
+        dependencies: packageDependencies(packageJson),
+      };
+    })
+    .filter((workspace) => !workspace.private)
+    .map((workspace) => {
+      if (workspace.access !== 'public') {
+        throw new Error(`${workspace.name} must set publishConfig.access to public`);
+      }
+      return workspace;
+    });
+}
+
+export function orderWorkspaces(workspaces) {
+  const byName = new Map(workspaces.map((workspace) => [workspace.name, workspace]));
+  const ordered = [];
+  const visiting = new Set();
+  const visited = new Set();
+
+  function visit(workspace) {
+    if (visited.has(workspace.name)) return;
+    if (visiting.has(workspace.name)) {
+      throw new Error(`circular public workspace dependency involving ${workspace.name}`);
+    }
+
+    visiting.add(workspace.name);
+    for (const dependencyName of Object.keys(workspace.dependencies).sort()) {
+      const dependency = byName.get(dependencyName);
+      if (dependency) visit(dependency);
+    }
+    visiting.delete(workspace.name);
+    visited.add(workspace.name);
+    ordered.push(workspace);
+  }
+
+  for (const workspace of [...workspaces].sort((left, right) => left.name.localeCompare(right.name))) {
+    visit(workspace);
+  }
+  return ordered;
+}
+
+export function createReleasePlan(workspaces, state) {
+  const {
+    tagTargets,
+    publishedVersions,
+    versionCommits,
+    githubReleaseTags,
+    currentCommit,
+  } = state;
+  const publish = [];
+  const tag = [];
+  const release = [];
+
+  for (const workspace of orderWorkspaces(workspaces)) {
+    const releaseTag = `${workspace.name}@${workspace.version}`;
+    const tagTarget = tagTargets.get(releaseTag);
+    const isTagged = tagTarget !== undefined;
+    const hasGitHubRelease = githubReleaseTags.has(releaseTag);
+    const targetSha = requireString(
+      versionCommits.get(workspace.name),
+      `${releaseTag} version commit`,
+    );
+    const versions = publishedVersions.get(workspace.name);
+    if (!(versions instanceof Set)) {
+      throw new Error(`missing registry result for ${workspace.name}`);
+    }
+
+    const isPublished = versions.has(workspace.version);
+    if (hasGitHubRelease && !isTagged) {
+      throw new Error(`${releaseTag} GitHub Release exists but its Git tag is missing`);
+    }
+    if (isTagged && tagTarget !== targetSha) {
+      throw new Error(`${releaseTag} tag target ${tagTarget} does not match version commit ${targetSha}`);
+    }
+    if (isTagged && !isPublished) {
+      throw new Error(`${releaseTag} is tagged in Git but missing from npm`);
+    }
+    if (!isTagged && !isPublished) {
+      if (currentCommit !== targetSha) {
+        throw new Error(
+          `${releaseTag} was introduced by ${targetSha}; refusing to publish it from ${currentCommit}`,
+        );
+      }
+      publish.push({...workspace, releaseTag, targetSha});
+    }
+    if (!isTagged && isPublished) tag.push({...workspace, releaseTag, targetSha});
+    if (isTagged && isPublished && !hasGitHubRelease) {
+      release.push({...workspace, releaseTag, targetSha});
+    }
+  }
+
+  return {publish, tag, release, releaseWork: [...publish, ...tag, ...release]};
+}
+
+export async function fetchPublishedVersions(packageName, options = {}) {
+  const registry = options.registry ?? process.env.NPM_CONFIG_REGISTRY ?? DEFAULT_REGISTRY;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const maxAttempts = options.maxAttempts ?? 1;
+  const retryDelayMs = options.retryDelayMs ?? 1000;
+  const sleepImpl = options.sleepImpl ?? ((milliseconds) => new Promise((done) => setTimeout(done, milliseconds)));
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const packageUrl = new URL(
+      encodeURIComponent(packageName),
+      registry.endsWith('/') ? registry : `${registry}/`,
+    );
+    packageUrl.searchParams.set('cache-bust', `${Date.now()}-${attempt}`);
+    const response = await fetchImpl(packageUrl, {
+      headers: {
+        accept: 'application/vnd.npm.install-v1+json',
+        'cache-control': 'no-cache',
+        pragma: 'no-cache',
+      },
+    });
+
+    let versions;
+    if (response.status === 404) {
+      versions = new Set();
+    } else if (!response.ok) {
+      if (response.status < 500 || attempt === maxAttempts - 1) {
+        throw new Error(`npm registry lookup for ${packageName} failed with HTTP ${response.status}`);
+      }
+    } else {
+      const metadata = await response.json();
+      if (!metadata.versions || typeof metadata.versions !== 'object') {
+        throw new Error(`npm registry response for ${packageName} has no versions map`);
+      }
+      versions = new Set(Object.keys(metadata.versions));
+    }
+
+    if (
+      versions &&
+      (!options.requiredVersion || versions.has(options.requiredVersion) || attempt === maxAttempts - 1)
+    ) {
+      return versions;
+    }
+    await sleepImpl(retryDelayMs * 2 ** attempt);
+  }
+
+  throw new Error(`npm registry lookup for ${packageName} exhausted its retry budget`);
+}
+
+export async function fetchGitHubReleaseTags(releaseTags, options = {}) {
+  const repository = requireString(
+    options.repository ?? process.env.GITHUB_REPOSITORY,
+    'GitHub repository',
+  );
+  if (!/^[^/]+\/[^/]+$/u.test(repository)) {
+    throw new Error('GitHub repository must use owner/name format');
+  }
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const apiUrl = options.apiUrl ?? process.env.GITHUB_API_URL ?? 'https://api.github.com';
+  const token = options.token ?? process.env.GITHUB_TOKEN;
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'x-github-api-version': '2022-11-28',
+    ...(token ? {authorization: `Bearer ${token}`} : {}),
+  };
+
+  const results = await Promise.all(
+    releaseTags.map(async (releaseTag) => {
+      const url = new URL(
+        `/repos/${repository}/releases/tags/${encodeURIComponent(releaseTag)}`,
+        apiUrl,
+      );
+      const response = await fetchImpl(url, {headers});
+      if (response.status === 404) return undefined;
+      if (!response.ok) {
+        throw new Error(`GitHub Release lookup for ${releaseTag} failed with HTTP ${response.status}`);
+      }
+      return releaseTag;
+    }),
+  );
+  return new Set(results.filter(Boolean));
+}
+
+function existingTagTargets(rootDir) {
+  const output = execFileSync('git', ['tag', '--list'], {cwd: rootDir, encoding: 'utf8'});
+  return new Map(
+    output
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .map((tag) => [
+        tag,
+        execFileSync('git', ['rev-parse', '--verify', `refs/tags/${tag}^{commit}`], {
+          cwd: rootDir,
+          encoding: 'utf8',
+        }).trim(),
+      ]),
+  );
+}
+
+function manifestAtRevision(rootDir, revision, manifestPath) {
+  const result = spawnSync('git', ['show', `${revision}:${manifestPath}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) return undefined;
+  return JSON.parse(result.stdout);
+}
+
+export function findVersionIntroduction(workspace, history) {
+  for (const entry of history) {
+    const manifestMatches =
+      entry.manifest?.name === workspace.name && entry.manifest?.version === workspace.version;
+    const parentMatches =
+      entry.parentManifest?.name === workspace.name &&
+      entry.parentManifest?.version === workspace.version;
+    if (manifestMatches && !parentMatches) return requireString(entry.sha, 'version commit');
+  }
+  throw new Error(`could not find the commit that introduced ${workspace.name}@${workspace.version}`);
+}
+
+export function resolveVersionCommit(rootDir, workspace) {
+  const manifestPath = posix.join(workspace.workspace, 'package.json');
+  const commits = execFileSync(
+    'git',
+    ['log', '--first-parent', '--format=%H', '--', manifestPath],
+    {cwd: rootDir, encoding: 'utf8'},
+  )
+    .split(/\r?\n/u)
+    .filter(Boolean);
+
+  const history = commits.map((sha) => {
+    const revision = execFileSync('git', ['rev-list', '--parents', '-n', '1', sha], {
+      cwd: rootDir,
+      encoding: 'utf8',
+    })
+      .trim()
+      .split(/\s+/u);
+    return {
+      sha,
+      manifest: manifestAtRevision(rootDir, sha, manifestPath),
+      parentManifest: revision[1]
+        ? manifestAtRevision(rootDir, revision[1], manifestPath)
+        : undefined,
+    };
+  });
+
+  return findVersionIntroduction(workspace, history);
+}
+
+export function throwSpawnFailure(result, description) {
+  if (result.status === 0) return;
+  const detail = result.error?.message ?? result.stderr?.trim() ?? `exit status ${result.status}`;
+  throw new Error(`${description}: ${detail}`, result.error ? {cause: result.error} : undefined);
+}
+
+function configuredRegistry(rootDir, registryOverride) {
+  if (registryOverride) return new URL(registryOverride).href;
+  if (process.env.NPM_CONFIG_REGISTRY) return new URL(process.env.NPM_CONFIG_REGISTRY).href;
+
+  const result = spawnSync('npm', ['config', 'get', 'registry'], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+  throwSpawnFailure(result, 'failed to resolve the npm registry');
+  return new URL(requireString(result.stdout.trim(), 'npm registry')).href;
+}
+
+export async function calculateReleasePlan(rootDir, options = {}) {
+  const workspaces = loadPublicWorkspaces(rootDir);
+  const tagTargets = options.existingTags ?? existingTagTargets(rootDir);
+  const versionCommits = new Map(
+    workspaces.map((workspace) => [
+      workspace.name,
+      options.versionCommits?.get(workspace.name) ?? resolveVersionCommit(rootDir, workspace),
+    ]),
+  );
+  const registry = configuredRegistry(rootDir, options.registry);
+  const releaseTags = workspaces.map((workspace) => `${workspace.name}@${workspace.version}`);
+  const [publishedEntries, githubReleaseTags] = await Promise.all([
+    Promise.all(
+      workspaces.map(async (workspace) => [
+        workspace.name,
+        await fetchPublishedVersions(workspace.name, {
+          fetchImpl: options.fetchImpl,
+          registry,
+          requiredVersion: workspace.version,
+          maxAttempts: options.registryAttempts ?? 4,
+          retryDelayMs: options.retryDelayMs,
+          sleepImpl: options.sleepImpl,
+        }),
+      ]),
+    ),
+    options.existingReleases
+      ? Promise.resolve(options.existingReleases)
+      : fetchGitHubReleaseTags(releaseTags, {
+          fetchImpl: options.githubFetchImpl,
+          repository: options.repository,
+          token: options.githubToken,
+          apiUrl: options.githubApiUrl,
+        }),
+  ]);
+  const publishedVersions = new Map(publishedEntries);
+
+  const currentCommit =
+    options.currentCommit ??
+    execFileSync('git', ['rev-parse', 'HEAD'], {cwd: rootDir, encoding: 'utf8'}).trim();
+  return {
+    ...createReleasePlan(workspaces, {
+      tagTargets,
+      publishedVersions,
+      versionCommits,
+      githubReleaseTags,
+      currentCommit,
+    }),
+    registry,
+  };
+}
+
+function appendGitHubOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) throw new Error('GITHUB_OUTPUT is required in plan mode');
+  appendFileSync(outputPath, `${name}=${value}\n`);
+}
+
+function createTag(rootDir, releaseTag, targetSha) {
+  const result = spawnSync('git', ['tag', '-a', releaseTag, targetSha, '-m', releaseTag], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+  throwSpawnFailure(result, `failed to create ${releaseTag}`);
+  console.log(`New tag: ${releaseTag}`);
+}
+
+function prereleaseDistTag(version) {
+  const prerelease = version.match(/^\d+\.\d+\.\d+-([0-9A-Za-z-]+)(?:[.-].*)?$/u);
+  return prerelease?.[1];
+}
+
+export function npmPublishArguments(workspace, options = {}) {
+  if (workspace.access !== 'public') {
+    throw new Error(`${workspace.name} must publish with public npm access`);
+  }
+  const registry = new URL(options.registry ?? DEFAULT_REGISTRY).href;
+  const arguments_ = [
+    'publish',
+    '--workspace',
+    workspace.workspace,
+    '--access',
+    'public',
+    '--registry',
+    registry,
+  ];
+  const distTag = prereleaseDistTag(workspace.version);
+  if (distTag) arguments_.push('--tag', distTag);
+  if (options.dryRun) arguments_.push('--dry-run', '--ignore-scripts');
+  return arguments_;
+}
+
+function publishWorkspace(rootDir, workspace, registry, options = {}) {
+  console.log(
+    `${options.dryRun ? 'Validating' : 'Publishing'} ${workspace.name}@${workspace.version}`,
+  );
+  const result = spawnSync('npm', npmPublishArguments(workspace, {registry, ...options}), {
+    cwd: rootDir,
+    stdio: 'inherit',
+  });
+  throwSpawnFailure(
+    result,
+    `npm publish${options.dryRun ? ' dry-run' : ''} failed for ${workspace.name}@${workspace.version}`,
+  );
+}
+
+async function main() {
+  const rootDir = process.cwd();
+  const plan = await calculateReleasePlan(rootDir);
+
+  if (process.argv.includes('--github-output')) {
+    appendGitHubOutput('hasReleaseWork', String(plan.releaseWork.length > 0));
+    appendGitHubOutput('hasUnpublished', String(plan.publish.length > 0));
+    if (process.argv.includes('--validate')) {
+      for (const workspace of plan.publish) {
+        publishWorkspace(rootDir, workspace, plan.registry, {dryRun: true});
+      }
+    }
+    console.log(`Release work: ${plan.releaseWork.map((item) => item.releaseTag).join(', ') || 'none'}`);
+    return;
+  }
+
+  for (const workspace of plan.publish) {
+    publishWorkspace(rootDir, workspace, plan.registry);
+    createTag(rootDir, workspace.releaseTag, workspace.targetSha);
+  }
+  for (const workspace of plan.tag) {
+    console.log(`${workspace.releaseTag} already exists on npm; recovering its Git tag`);
+    createTag(rootDir, workspace.releaseTag, workspace.targetSha);
+  }
+  for (const workspace of plan.release) {
+    console.log(`${workspace.releaseTag} is missing its GitHub Release; recovering it`);
+    console.log(`New tag: ${workspace.releaseTag}`);
+  }
+  if (plan.releaseWork.length === 0) console.log('No release work found');
+}
+
+const entrypoint = process.argv[1] ? realpathSync(resolve(process.argv[1])) : undefined;
+if (entrypoint === realpathSync(fileURLToPath(import.meta.url))) {
+  await main();
+}

--- a/scripts/test-release-packages.mjs
+++ b/scripts/test-release-packages.mjs
@@ -1,0 +1,342 @@
+// SPDX-FileCopyrightText: Copyright (C) Shielded Technologies
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from 'node:assert/strict';
+import {resolve} from 'node:path';
+
+import {
+  createReleasePlan,
+  fetchGitHubReleaseTags,
+  fetchPublishedVersions,
+  findVersionIntroduction,
+  loadPublicWorkspaces,
+  npmPublishArguments,
+  orderWorkspaces,
+  packageDependencies,
+  throwSpawnFailure,
+} from './release-packages.mjs';
+
+const rootDir = resolve(import.meta.dirname, '..');
+const workspaces = loadPublicWorkspaces(rootDir);
+
+assert.deepEqual(
+  workspaces.map((workspace) => workspace.name).sort(),
+  ['@shieldedtech/moth-cli', '@shieldedtech/moth-tui', '@shieldedtech/moth-wallet'],
+  'release discovery must exclude private workspaces and nested template manifests',
+);
+assert.ok(
+  workspaces.every((workspace) => workspace.access === 'public'),
+  'every publishable workspace must explicitly declare public npm access',
+);
+assert.deepEqual(
+  orderWorkspaces(workspaces).map((workspace) => workspace.name),
+  ['@shieldedtech/moth-wallet', '@shieldedtech/moth-tui', '@shieldedtech/moth-cli'],
+  'publish order must put internal dependencies first',
+);
+
+function publishedVersions(overrides = {}) {
+  return new Map(
+    workspaces.map((workspace) => [
+      workspace.name,
+      new Set(overrides[workspace.name] ?? [workspace.version]),
+    ]),
+  );
+}
+
+const releaseCommit = 'version-release-commit';
+const versionCommits = new Map(workspaces.map((workspace) => [workspace.name, releaseCommit]));
+const allTags = new Map(
+  workspaces.map((workspace) => [
+    `${workspace.name}@${workspace.version}`,
+    versionCommits.get(workspace.name),
+  ]),
+);
+const allReleases = new Set(allTags.keys());
+
+function releaseState(overrides = {}) {
+  return {
+    tagTargets: allTags,
+    publishedVersions: publishedVersions(),
+    versionCommits,
+    githubReleaseTags: allReleases,
+    currentCommit: 'later-commit',
+    ...overrides,
+  };
+}
+
+assert.deepEqual(createReleasePlan(workspaces, releaseState()), {
+  publish: [],
+  tag: [],
+  release: [],
+  releaseWork: [],
+});
+
+const core = workspaces.find((workspace) => workspace.name === '@shieldedtech/moth-wallet');
+const tui = workspaces.find((workspace) => workspace.name === '@shieldedtech/moth-tui');
+const cli = workspaces.find((workspace) => workspace.name === '@shieldedtech/moth-cli');
+
+const unpublishedCorePlan = createReleasePlan(
+  workspaces,
+  releaseState({
+    tagTargets: new Map([...allTags].filter(([tag]) => tag !== `${core.name}@${core.version}`)),
+    publishedVersions: publishedVersions({[core.name]: ['0.12.0']}),
+    githubReleaseTags: new Set([...allReleases].filter((tag) => tag !== `${core.name}@${core.version}`)),
+    currentCommit: releaseCommit,
+  }),
+);
+assert.deepEqual(unpublishedCorePlan.publish.map((workspace) => workspace.name), [core.name]);
+assert.deepEqual(unpublishedCorePlan.tag, []);
+
+const partialRetryPlan = createReleasePlan(
+  workspaces,
+  releaseState({
+    tagTargets: new Map([[`${core.name}@${core.version}`, versionCommits.get(core.name)]]),
+    publishedVersions: publishedVersions({
+      [tui.name]: ['0.12.0'],
+      [cli.name]: ['0.12.0'],
+    }),
+    githubReleaseTags: new Set([`${core.name}@${core.version}`]),
+    currentCommit: releaseCommit,
+  }),
+);
+assert.deepEqual(
+  partialRetryPlan.publish.map((workspace) => workspace.name),
+  [tui.name, cli.name],
+  'a partial retry must skip the tagged package and finish in dependency order',
+);
+
+const missingTagPlan = createReleasePlan(
+  workspaces,
+  releaseState({tagTargets: new Map(), githubReleaseTags: new Set()}),
+);
+assert.deepEqual(
+  missingTagPlan.tag.map((workspace) => workspace.name),
+  [core.name, tui.name, cli.name],
+  'published packages with missing Git tags must be recoverable without republishing',
+);
+assert.deepEqual(
+  missingTagPlan.tag.map((workspace) => workspace.targetSha),
+  workspaces.map((workspace) => versionCommits.get(workspace.name)),
+  'recovered tags must target the commit that introduced the package version',
+);
+
+assert.throws(
+  () =>
+    createReleasePlan(
+      workspaces,
+      releaseState({
+        tagTargets: new Map([[`${core.name}@${core.version}`, 'unrelated-later-commit']]),
+      }),
+    ),
+  /does not match version commit/u,
+  'an existing tag on the wrong commit must fail closed',
+);
+
+assert.throws(
+  () =>
+    createReleasePlan(
+      workspaces,
+      releaseState({
+        tagTargets: new Map([[`${core.name}@${core.version}`, versionCommits.get(core.name)]]),
+        publishedVersions: publishedVersions({[core.name]: ['0.12.0']}),
+        githubReleaseTags: new Set(),
+        currentCommit: releaseCommit,
+      }),
+    ),
+  /tagged in Git but missing from npm/u,
+  'a tag without a matching npm version must fail instead of silently skipping release work',
+);
+
+assert.throws(
+  () =>
+    createReleasePlan(
+      workspaces,
+      releaseState({
+        tagTargets: new Map([...allTags].filter(([tag]) => tag !== `${core.name}@${core.version}`)),
+        publishedVersions: publishedVersions({[core.name]: ['0.12.0']}),
+        githubReleaseTags: new Set([...allReleases].filter((tag) => tag !== `${core.name}@${core.version}`)),
+        currentCommit: 'unrelated-later-commit',
+      }),
+    ),
+  /refusing to publish it from unrelated-later-commit/u,
+  'an unpublished version must only be published by the commit that introduced it',
+);
+
+const missingReleasePlan = createReleasePlan(
+  workspaces,
+  releaseState({
+    githubReleaseTags: new Set(
+      [...allReleases].filter((tag) => tag !== `${core.name}@${core.version}`),
+    ),
+  }),
+);
+assert.deepEqual(
+  missingReleasePlan.release.map((workspace) => workspace.name),
+  [core.name],
+  'a missing GitHub Release must be recovered even when npm and the Git tag already exist',
+);
+assert.throws(
+  () =>
+    createReleasePlan(
+      workspaces,
+      releaseState({
+        tagTargets: new Map([...allTags].filter(([tag]) => tag !== `${core.name}@${core.version}`)),
+      }),
+    ),
+  /GitHub Release exists but its Git tag is missing/u,
+  'a release without its tag must fail closed instead of attempting a duplicate release',
+);
+
+assert.equal(
+  findVersionIntroduction(core, [
+    {
+      sha: 'unrelated-later-commit',
+      manifest: {name: core.name, version: core.version},
+      parentManifest: {name: core.name, version: core.version},
+    },
+    {
+      sha: 'actual-version-commit',
+      manifest: {name: core.name, version: core.version},
+      parentManifest: {name: core.name, version: '0.12.0'},
+    },
+  ]),
+  'actual-version-commit',
+  'later package metadata changes must not become the release tag target',
+);
+assert.deepEqual(
+  npmPublishArguments(core),
+  [
+    'publish',
+    '--workspace',
+    core.workspace,
+    '--access',
+    'public',
+    '--registry',
+    'https://registry.npmjs.org/',
+  ],
+  'stable publication must explicitly preserve public package access',
+);
+assert.deepEqual(
+  npmPublishArguments({...core, version: '0.13.0-rc.2'}),
+  [
+    'publish',
+    '--workspace',
+    core.workspace,
+    '--access',
+    'public',
+    '--registry',
+    'https://registry.npmjs.org/',
+    '--tag',
+    'rc',
+  ],
+  'prereleases must publish under their prerelease dist-tag instead of latest',
+);
+assert.deepEqual(
+  npmPublishArguments(core, {dryRun: true}),
+  [
+    'publish',
+    '--workspace',
+    core.workspace,
+    '--access',
+    'public',
+    '--registry',
+    'https://registry.npmjs.org/',
+    '--dry-run',
+    '--ignore-scripts',
+  ],
+  'validation must exercise the same public registry contract without publishing',
+);
+assert.deepEqual(
+  packageDependencies({
+    dependencies: {runtime: '^1.0.0'},
+    optionalDependencies: {optional: '^1.0.0'},
+    peerDependencies: {peer: '^1.0.0'},
+  }),
+  {runtime: '^1.0.0', optional: '^1.0.0', peer: '^1.0.0'},
+  'peer dependencies must participate in public-workspace publish ordering',
+);
+assert.throws(
+  () =>
+    throwSpawnFailure(
+      {status: null, stderr: undefined, error: new Error('spawn git ENOENT')},
+      'failed to create tag',
+    ),
+  /spawn git ENOENT/u,
+  'spawn failures must preserve their real diagnostic when stderr is unavailable',
+);
+
+let requestedUrl;
+const versions = await fetchPublishedVersions('@shieldedtech/moth-wallet', {
+  registry: 'https://registry.example.test/',
+  fetchImpl: async (url) => {
+    requestedUrl = String(url);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({versions: {'0.12.0': {}, '0.12.1': {}}}),
+    };
+  },
+});
+assert.deepEqual([...versions], ['0.12.0', '0.12.1']);
+assert.match(
+  requestedUrl,
+  /^https:\/\/registry\.example\.test\/%40shieldedtech%2Fmoth-wallet\?cache-bust=/u,
+);
+
+let registryAttempts = 0;
+const retriedVersions = await fetchPublishedVersions('@shieldedtech/moth-wallet', {
+  requiredVersion: '0.12.1',
+  maxAttempts: 2,
+  retryDelayMs: 0,
+  sleepImpl: async () => {},
+  fetchImpl: async (url, init) => {
+    registryAttempts += 1;
+    assert.match(String(url), /cache-bust=/u);
+    assert.equal(init.headers['cache-control'], 'no-cache');
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({versions: registryAttempts === 1 ? {'0.12.0': {}} : {'0.12.1': {}}}),
+    };
+  },
+});
+assert.equal(registryAttempts, 2, 'a missing current version must be retried after registry lag');
+assert.ok(retriedVersions.has('0.12.1'));
+
+let releaseUrl;
+assert.deepEqual(
+  await fetchGitHubReleaseTags(['@shieldedtech/moth-wallet@0.12.1', '@shieldedtech/moth-tui@0.12.1'], {
+    repository: 'shieldedtech/moth-wallet',
+    fetchImpl: async (url) => {
+      releaseUrl = String(url);
+      const found = releaseUrl.endsWith(encodeURIComponent('@shieldedtech/moth-wallet@0.12.1'));
+      return {ok: found, status: found ? 200 : 404};
+    },
+  }),
+  new Set(['@shieldedtech/moth-wallet@0.12.1']),
+);
+assert.match(releaseUrl, /%40shieldedtech%2Fmoth-tui%400\.12\.1/u);
+await assert.rejects(
+  fetchGitHubReleaseTags(['@shieldedtech/moth-wallet@0.12.1'], {
+    repository: 'shieldedtech/moth-wallet',
+    fetchImpl: async () => ({ok: false, status: 503}),
+  }),
+  /failed with HTTP 503/u,
+  'GitHub Release lookup failures must fail closed',
+);
+
+assert.deepEqual(
+  await fetchPublishedVersions('@shieldedtech/new-package', {
+    fetchImpl: async () => ({ok: false, status: 404}),
+  }),
+  new Set(),
+);
+await assert.rejects(
+  fetchPublishedVersions('@shieldedtech/moth-wallet', {
+    fetchImpl: async () => ({ok: false, status: 503}),
+  }),
+  /failed with HTTP 503/u,
+  'registry failures must fail closed',
+);
+
+console.log('release package reconciliation checks passed');

--- a/scripts/test-release-policy.mjs
+++ b/scripts/test-release-policy.mjs
@@ -4,6 +4,7 @@
 import {readFileSync} from 'node:fs';
 
 const workflow = readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8');
+const rootPackage = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 const credentialPattern = /(?:SHIELDED_NPMJS_TOKEN|NPM_TOKEN|NODE_AUTH_TOKEN)/;
 
 function requirePolicy(condition, message) {
@@ -23,6 +24,10 @@ for (const packagePath of ['packages/core/package.json', 'packages/tui/package.j
     !Object.values(dependencies).some((range) => range.startsWith('workspace:')),
     `${packageJson.name} must not publish workspace: dependency ranges`,
   );
+  requirePolicy(
+    packageJson.publishConfig?.access === 'public',
+    `${packageJson.name} must explicitly publish with public npm access`,
+  );
 }
 
 function job(name) {
@@ -41,6 +46,28 @@ for (const name of ['release', 'canary']) {
   requirePolicy(!credentialPattern.test(block), `${name} must not receive an npm credential`);
   requirePolicy(block.includes('npm@12.0.2'), `${name} must install the reviewed npm version`);
 }
+
+requirePolicy(
+  workflow.includes('node scripts/release-packages.mjs --github-output --validate'),
+  'release eligibility must use durable npm and Git tag state',
+);
+requirePolicy(
+  workflow.includes(
+    "- name: Detect incomplete package releases\n        if: ${{ steps.releases.outputs.hasChangesets == 'false' }}",
+  ),
+  'registry reconciliation must only gate the stable no-changeset path',
+);
+requirePolicy(!workflow.includes('UNPUBLISHED_WORKSPACES'), 'release validation must not shuttle plan JSON through env');
+requirePolicy(!workflow.includes('mapfile'), 'release validation must stay inside the release planner');
+requirePolicy(!workflow.includes('github.event.before'), 'release eligibility must not depend on one push range');
+requirePolicy(
+  workflow.includes("steps.package_changes.outputs.hasReleaseWork == 'true'"),
+  'stable publishing must require incomplete release work',
+);
+requirePolicy(
+  rootPackage.scripts.release === 'node scripts/release-packages.mjs',
+  'stable publishing must use the idempotent package reconciler',
+);
 
 if (workflow.includes('SHIELDED_NPMJS_TOKEN')) {
   const recovery = job('token-recovery');


### PR DESCRIPTION
## Summary

- reconcile stable release state across npm, Git tags, and GitHub Releases
- recover tags at the commit that introduced the package version, never a later workflow SHA
- publish the three public packages with explicit public access and one resolved registry
- preserve prerelease dist-tags, dependency order, and actionable spawn diagnostics
- retry uncached npm reads and validate pending publishes in the release planner

## Root cause

The push-range detector was not a durable release signal. A canceled run could strand an npm publish, Git tag, or GitHub Release, while a later retry could republish an immutable version or attribute it to the wrong source commit.

## Review fixes

This revision addresses all 10 inline review threads: stable-only registry gating, GitHub Release recovery, correct tag targets, registry lag retries, prerelease dist-tags, public access, peer dependency ordering, spawn errors, package-manifest pre-commit coverage, and in-process dry-run validation.

## Verification

- `yarn install --immutable`
- `yarn build`
- `yarn workspace @shieldedtech/moth-extension compile`
- `yarn turbo run test` (all runnable suites passed)
- `pre-commit run --all-files`
- `actionlint .github/workflows/release.yml`
- live read-only npm/tag/GitHub Release reconciliation: `Release work: none`

This PR is stacked on #26 and targets its branch. After it lands there, #26 needs fresh full CI and human review against `main`.