### PR TITLE
fix(release): ignore empty changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,26 +77,29 @@ jobs:
             echo "hasReleases=false" >> "$GITHUB_OUTPUT"
           fi
 
-          CHANGESET_COUNT=$(find .changeset -maxdepth 1 -type f -name '*.md' ! -name README.md | wc -l | tr -d ' ')
-          if [ "${CHANGESET_COUNT:-0}" -gt 0 ]; then
-            echo "hasChangesets=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "hasChangesets=false" >> "$GITHUB_OUTPUT"
-          fi
-
       # Registry, tag, and GitHub Release state survive canceled and partial runs.
       # The same process also dry-runs only packages that still need publication.
       - name: Detect incomplete package releases
-        if: ${{ steps.releases.outputs.hasChangesets == 'false' }}
+        if: ${{ steps.releases.outputs.hasReleases == 'false' }}
         id: package_changes
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/release-packages.mjs --github-output --validate
 
-      # Use the machine-user PAT only while opening or updating the version PR.
-      # It is deliberately absent from the stable publish process below.
+      - name: Verify version PR credential
+        if: ${{ steps.releases.outputs.hasReleases == 'true' }}
+        env:
+          VERSION_PR_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+        shell: bash
+        run: |
+          if [ -z "$VERSION_PR_TOKEN" ]; then
+            echo "::error::MIDNIGHTCI_PACKAGES_WRITE is unavailable; configure it as a repository Actions secret for this public repository."
+            exit 1
+          fi
+
+      # The machine-user PAT makes the generated PR trigger its normal CI.
       - name: Create or update version PR
-        if: ${{ steps.releases.outputs.hasChangesets == 'true' }}
+        if: ${{ steps.releases.outputs.hasReleases == 'true' }}
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d  # v1.9.0
         with:
           # `yarn run` so Yarn Berry runs the package scripts, not its built-in
@@ -111,7 +114,7 @@ jobs:
       # With no Changesets left, publish through npm Trusted Publishing (OIDC),
       # then recover or create tags and GitHub Releases through Changesets.
       - name: Publish stable release
-        if: ${{ steps.releases.outputs.hasChangesets == 'false' && steps.package_changes.outputs.hasReleaseWork == 'true' }}
+        if: ${{ steps.releases.outputs.hasReleases == 'false' && steps.package_changes.outputs.hasReleaseWork == 'true' }}
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d  # v1.9.0
         with:
           publish: yarn run release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,18 +86,9 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/release-packages.mjs --github-output --validate
 
-      - name: Verify version PR credential
-        if: ${{ steps.releases.outputs.hasReleases == 'true' }}
-        env:
-          VERSION_PR_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
-        shell: bash
-        run: |
-          if [ -z "$VERSION_PR_TOKEN" ]; then
-            echo "::error::MIDNIGHTCI_PACKAGES_WRITE is unavailable; configure it as a repository Actions secret for this public repository."
-            exit 1
-          fi
-
-      # The machine-user PAT makes the generated PR trigger its normal CI.
+      # GITHUB_TOKEN keeps release automation secretless. GitHub puts the
+      # generated PR's workflow runs into an approval-required state; a
+      # maintainer approves those runs before the version PR can merge.
       - name: Create or update version PR
         if: ${{ steps.releases.outputs.hasReleases == 'true' }}
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d  # v1.9.0
@@ -107,7 +98,7 @@ jobs:
           # "version" script — the cause of the release failure).
           version: yarn run version && yarn install
           commitMode: github-api
-          github-token: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}
+          github-token: ${{ github.token }}
           title: "chore: version packages"
           commit: "chore: version packages"
 

--- a/NPM_PUBLISHING.md
+++ b/NPM_PUBLISHING.md
@@ -44,6 +44,13 @@ Trusted Publishing releases automatically.
 The workflow uses `MIDNIGHTCI_PACKAGES_WRITE` only for GitHub operations needed
 to open the Changesets PR. npm publishing does not use that secret.
 
+Because this is a public repository, configure a repository-level
+`MIDNIGHTCI_PACKAGES_WRITE` Actions secret. Use a fine-grained token owned by the
+release machine account and limit it to this repository with Contents and Pull
+requests write access. A private-only organization secret is not available to a
+public repository, while a PR created with the default Actions token does not
+trigger the normal pull-request CI.
+
 ## Public release approval
 
 The private open-source governance case recorded its final GO on 2026-08-17.
@@ -89,6 +96,8 @@ intended dist-tag.
   repository and npm package are public.
 - **Release commit mismatch:** rerun the workflow for the commit that introduced
   the package version; never publish that version from a later source revision.
+- **`MIDNIGHTCI_PACKAGES_WRITE is unavailable`:** add the release machine
+  account token as the repository-level Actions secret documented above.
 
 ## Credential cleanup
 

--- a/NPM_PUBLISHING.md
+++ b/NPM_PUBLISHING.md
@@ -41,15 +41,13 @@ Trusted Publishing releases automatically.
 4. After review, merging the version PR makes the same workflow publish the
    stable versions, push tags, and create GitHub Releases.
 
-The workflow uses `MIDNIGHTCI_PACKAGES_WRITE` only for GitHub operations needed
-to open the Changesets PR. npm publishing does not use that secret.
+The workflow uses the repository's built-in `GITHUB_TOKEN` to open the
+Changesets PR. It does not use a PAT, GitHub App credential, or npm token.
 
-Because this is a public repository, configure a repository-level
-`MIDNIGHTCI_PACKAGES_WRITE` Actions secret. Use a fine-grained token owned by the
-release machine account and limit it to this repository with Contents and Pull
-requests write access. A private-only organization secret is not available to a
-public repository, while a PR created with the default Actions token does not
-trigger the normal pull-request CI.
+When `GITHUB_TOKEN` creates or updates the version PR, GitHub creates its
+`pull_request` workflow runs in an approval-required state. A maintainer must
+select **Approve workflows** on the version PR before its required checks run.
+This is GitHub's documented recursion protection for automated pull requests.
 
 ## Public release approval
 
@@ -96,8 +94,8 @@ intended dist-tag.
   repository and npm package are public.
 - **Release commit mismatch:** rerun the workflow for the commit that introduced
   the package version; never publish that version from a later source revision.
-- **`MIDNIGHTCI_PACKAGES_WRITE is unavailable`:** add the release machine
-  account token as the repository-level Actions secret documented above.
+- **Version PR checks await approval:** select **Approve workflows** on the PR,
+  then wait for all required checks before review and merge.
 
 ## Credential cleanup
 

--- a/scripts/test-release-policy.mjs
+++ b/scripts/test-release-policy.mjs
@@ -5,6 +5,7 @@ import {readFileSync} from 'node:fs';
 
 const workflow = readFileSync(new URL('../.github/workflows/release.yml', import.meta.url), 'utf8');
 const rootPackage = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const publishingRunbook = readFileSync(new URL('../NPM_PUBLISHING.md', import.meta.url), 'utf8');
 const credentialPattern = /(?:SHIELDED_NPMJS_TOKEN|NPM_TOKEN|NODE_AUTH_TOKEN)/;
 
 function requirePolicy(condition, message) {
@@ -58,9 +59,28 @@ requirePolicy(
 );
 requirePolicy(
   workflow.includes(
-    "- name: Detect incomplete package releases\n        if: ${{ steps.releases.outputs.hasChangesets == 'false' }}",
+    "- name: Detect incomplete package releases\n        if: ${{ steps.releases.outputs.hasReleases == 'false' }}",
   ),
-  'registry reconciliation must only gate the stable no-changeset path',
+  'registry reconciliation must run whenever no package release is pending',
+);
+requirePolicy(
+  workflow.includes(
+    "- name: Verify version PR credential\n        if: ${{ steps.releases.outputs.hasReleases == 'true' }}",
+  ) &&
+    workflow.includes('VERSION_PR_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}') &&
+    workflow.includes('MIDNIGHTCI_PACKAGES_WRITE is unavailable'),
+  'a real package release must fail clearly when its version-PR credential is unavailable',
+);
+requirePolicy(
+  workflow.includes(
+    "- name: Create or update version PR\n        if: ${{ steps.releases.outputs.hasReleases == 'true' }}",
+  ),
+  'the version PR action must run only for changesets that release packages',
+);
+requirePolicy(
+  !workflow.includes('steps.releases.outputs.hasChangesets') &&
+    !workflow.includes('echo "hasChangesets='),
+  'empty changesets must not select the version-PR path or block stable reconciliation',
 );
 requirePolicy(!workflow.includes('UNPUBLISHED_WORKSPACES'), 'release validation must not shuttle plan JSON through env');
 requirePolicy(!workflow.includes('mapfile'), 'release validation must stay inside the release planner');
@@ -72,6 +92,11 @@ requirePolicy(
 requirePolicy(
   rootPackage.scripts.release === 'node scripts/release-packages.mjs',
   'stable publishing must use the idempotent package reconciler',
+);
+requirePolicy(
+  /repository-level\s+`MIDNIGHTCI_PACKAGES_WRITE`/u.test(publishingRunbook) &&
+    publishingRunbook.includes('public repository'),
+  'the public-repository version-PR credential requirement must be documented',
 );
 
 if (workflow.includes('SHIELDED_NPMJS_TOKEN')) {

--- a/scripts/test-release-policy.mjs
+++ b/scripts/test-release-policy.mjs
@@ -65,17 +65,13 @@ requirePolicy(
 );
 requirePolicy(
   workflow.includes(
-    "- name: Verify version PR credential\n        if: ${{ steps.releases.outputs.hasReleases == 'true' }}",
-  ) &&
-    workflow.includes('VERSION_PR_TOKEN: ${{ secrets.MIDNIGHTCI_PACKAGES_WRITE }}') &&
-    workflow.includes('MIDNIGHTCI_PACKAGES_WRITE is unavailable'),
-  'a real package release must fail clearly when its version-PR credential is unavailable',
+    "- name: Create or update version PR\n        if: ${{ steps.releases.outputs.hasReleases == 'true' }}",
+  ) && workflow.includes('github-token: ${{ github.token }}'),
+  'the version PR action must use the repository GITHUB_TOKEN and run only for releasable changesets',
 );
 requirePolicy(
-  workflow.includes(
-    "- name: Create or update version PR\n        if: ${{ steps.releases.outputs.hasReleases == 'true' }}",
-  ),
-  'the version PR action must run only for changesets that release packages',
+  !workflow.includes('secrets.') && !workflow.includes('MIDNIGHTCI_PACKAGES_WRITE'),
+  'the release workflow must not depend on PATs or repository secrets',
 );
 requirePolicy(
   !workflow.includes('steps.releases.outputs.hasChangesets') &&
@@ -94,9 +90,10 @@ requirePolicy(
   'stable publishing must use the idempotent package reconciler',
 );
 requirePolicy(
-  /repository-level\s+`MIDNIGHTCI_PACKAGES_WRITE`/u.test(publishingRunbook) &&
-    publishingRunbook.includes('public repository'),
-  'the public-repository version-PR credential requirement must be documented',
+  publishingRunbook.includes('Approve workflows') &&
+    publishingRunbook.includes('GITHUB_TOKEN') &&
+    !publishingRunbook.includes('MIDNIGHTCI_PACKAGES_WRITE'),
+  'the secretless version-PR approval step must be documented',
 );
 
 if (workflow.includes('SHIELDED_NPMJS_TOKEN')) {


### PR DESCRIPTION
## Summary

- gate Changesets version-PR creation on releasable package changes, not the presence of any `.changeset/*.md` file
- let empty changesets continue through idempotent registry/release reconciliation without attempting to publish
- create version PRs with the repository's built-in `GITHUB_TOKEN`; no PAT or release secret is required
- document and regression-test the maintainer approval step for generated PR workflow runs

## Root cause

The merge of #26 left an empty changeset. The workflow correctly calculated `hasReleases=false`, but a separate raw file count calculated `hasChangesets=true` and invoked `changesets/action`. Since `moth-wallet` is now public, the private-only organization secret `MIDNIGHTCI_PACKAGES_WRITE` was not injected, so the action failed with `Please add the GITHUB_TOKEN to the changesets action`.

This fixes the unnecessary failure from [run 32173074298](https://github.com/shieldedtech/moth-wallet/actions/runs/32173074298/job/95828579380). The revised workflow does not use `MIDNIGHTCI_PACKAGES_WRITE`, another PAT, or any npm token. GitHub places workflow runs for the generated version PR into an approval-required state; a maintainer selects **Approve workflows** before required CI runs.

## Verification

- `node scripts/test-release-policy.mjs`
- `pre-commit run --all-files`
- `yarn install --immutable`
- `yarn changeset status --since=origin/main`
- `yarn build`
- `yarn workspace @shieldedtech/moth-extension compile`
- `yarn turbo run test`
- `node scripts/release-packages.mjs --github-output --validate` (`Release work: none`)

No PR is merged by this change; human approval remains required.
