### PR TITLE
docs: enforce DCO contribution policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,8 @@
 name: Bug report
 description: Something is broken or behaving unexpectedly.
 title: "bug: "
-labels: ["bug", "triage"]
+labels: ["status:untriaged"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Contributing code
+    url: https://github.com/shieldedtech/moth-wallet/blob/main/CONTRIBUTING.md
+    about: Read the contribution, DCO, and commit-signing requirements before opening a pull request.
   - name: Questions and discussion
     url: https://github.com/shieldedtech/moth-wallet/blob/main/SUPPORT.md
     about: See SUPPORT.md for how to ask questions — please do not open an issue for questions.

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.yml
@@ -1,7 +1,8 @@
 name: Documentation improvement
 description: Something in the docs is wrong, missing, or unclear.
 title: "docs: "
-labels: ["documentation", "triage"]
+labels: ["documentation", "status:untriaged"]
+type: Task
 body:
   - type: input
     id: location

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,7 +1,8 @@
 name: Feature request
 description: Propose a new feature or enhancement.
 title: "feat: "
-labels: ["enhancement", "triage"]
+labels: ["status:untriaged"]
+type: Feature
 body:
   - type: markdown
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -9,6 +9,7 @@
 - [ ] Useful pull request description
 - [ ] Tests are provided (if possible)
 - [ ] Key commits have useful messages
+- [ ] Every non-merge, non-bot commit has a matching DCO `Signed-off-by` trailer
 - [ ] All check jobs of the CI have succeeded
 - [ ] Self-reviewed the diff
 - [ ] Reviewer requested

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+allowRemediationCommits:
+  individual: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,15 +14,28 @@ git commit --signoff -m "<your message>"
 
 This appends a `Signed-off-by: Your Name <you@example.com>` trailer. We enforce this via the DCO GitHub App — PRs with unsigned commits will not merge.
 
-Set up automatic sign-off:
+Git does not provide a configuration option that automatically signs off ordinary
+commits. Use `--signoff` (or `-s`) on every commit and make sure the trailer name and
+email match the commit author.
+
+### Fixing a missing sign-off
+
+The DCO App allows an author to remediate their own unsigned commits with a follow-up
+commit. Follow the instructions shown by the failed `DCO` check. A contributor may not
+attest for another person's commit, and maintainers must not use the App's override as
+a substitute for the author's attestation.
+
+You can confirm the current commit before pushing:
 
 ```bash
-git config --global format.signOff true
+git log -1 --format='%an <%ae>%n%B'
 ```
 
 ## Signed commits
 
-Commits to `main` must be cryptographically signed. Branch protection enforces this server-side — unsigned commits cannot merge. If you push an unsigned commit and the PR's required check fails with "Unsigned commits", you'll need to re-sign and force-push to your fork branch.
+Commits landing on `main` must also be cryptographically signed. The repository ruleset
+enforces this server-side, separately from the `DCO` status check. If a commit is not
+verified by GitHub, re-sign it and update the contributor branch before requesting review.
 
 ### Quick setup — SSH signing (recommended)
 
@@ -83,7 +96,8 @@ git config --local tag.gpgSign true
 
 - **"error: gpg failed to sign the data"** — usually a stale gpg-agent. `gpgconf --kill gpg-agent` and retry. On macOS: `brew install pinentry-mac` and set `pinentry-program /opt/homebrew/bin/pinentry-mac` in `~/.gnupg/gpg-agent.conf`.
 - **PR shows "Unverified" badge** — your signing key is set in git but not registered on GitHub. Re-check the SSH/GPG key page.
-- **Signed but DCO check fails** — signing and sign-off are different. You also need `--signoff` (or `format.signOff = true`) to add the `Signed-off-by:` trailer.
+- **Signed but DCO check fails** — signing and sign-off are different. You also need
+  `--signoff` (or `-s`) to add a matching `Signed-off-by:` trailer.
 
 GitHub's own guide covers edge cases (Smart Cards, S/MIME, multiple identities): <https://docs.github.com/authentication/managing-commit-signature-verification>.
 

--- a/README.md
+++ b/README.md
@@ -642,6 +642,13 @@ yarn workspace @shieldedtech/moth-wallet test
 
 The project uses Turborepo for build orchestration. The `core` package always builds first since `cli`, `browser`, and `tui` depend on it.
 
+## Contributing
+
+Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Every
+non-merge, non-bot commit must include a matching DCO `Signed-off-by` trailer, and
+commits landing on protected branches must be cryptographically signed. These are
+separate requirements.
+
 ## Acknowledgements
 
 The TUI component draws on architectural patterns and screen designs from [mn-tui](https://github.com/input-output-hk/arc-mn-tui) (Apache-2.0), a terminal wallet manager for Midnight developed by Input Output Global. See [NOTICE](NOTICE) for full attribution details.


### PR DESCRIPTION
## Overview

Align moth-wallet's contributor experience with the installed DCO GitHub App and the repository controls that will enforce it.

This change:

- enables author-owned remediation commits without allowing third-party attestations;
- corrects the DCO guidance and separates sign-off from cryptographic signing;
- adds DCO confirmation to the pull request checklist;
- links the README and issue chooser to the contribution policy; and
- updates issue forms to use native GitHub issue types and the managed `status:untriaged` label instead of retired type/triage labels.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (not applicable: policy and documentation only)
- [x] Key commits have useful messages
- [x] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant)
- [x] Update documentation (if relevant)
- [x] No new todos introduced

## Validation

- `pre-commit run --all-files`
- `yarn changeset status --since=origin/main`
- Existing test baseline: `yarn turbo run test` (12 tasks successful)
- GitHub commit verification: verified signature and matching DCO trailer

## Links

Closes #31

Related: shieldedtech/shielded-iac#2131

<details>
<summary>🤖 Agent handover</summary>

- The installed App publishes the exact check context `DCO`.
- `.github/dco.yml` enables only individual remediation commits; it does not enable third-party remediation.
- `shieldedtech/shielded-iac#2131` adds `DCO` to the required moth-wallet status contexts and enables web commit sign-off.

</details>
