### PR TITLE
fix(extension): ask which account to unlock when there is more than one

### DIFF
--- a/.changeset/unlock-account-picker.md
+++ b/.changeset/unlock-account-picker.md
@@ -1,0 +1,13 @@
+---
+'@shieldedtech/moth-extension': patch
+---
+
+Ask which account to unlock when there is more than one.
+
+Deleting the active account left the password apparently rejected. Removal
+promotes the next account to active, but silently: the unlock screen showed a
+generic "Welcome back" with no indication the target had changed, so a correct
+password for the account the user had in mind was rejected by a different one.
+
+The screen now lists the accounts with their network, defaults to the active
+one, and unlocks whichever is selected. A single account is unchanged.

--- a/packages/extension/components/screens/Unlock.tsx
+++ b/packages/extension/components/screens/Unlock.tsx
@@ -32,10 +32,22 @@ export function Unlock({
   const [show, setShow] = useState(false);
   const [error, setError] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [selected, setSelected] = useState(walletName);
+  // Holds only an explicit choice. What gets unlocked is derived below, so a
+  // selection can never outlive the account it named: deleting the active
+  // account changes the list under a mounted screen, and useState would happily
+  // keep pointing at the account that just went away.
+  const [chosen, setChosen] = useState<string | null>(null);
 
   const choices = accounts && accounts.length > 1 ? accounts : null;
-  const target = choices ? selected : walletName;
+  const exists = (name: string | null) => name !== null && (accounts ?? []).some((a) => a.name === name);
+  // Preference order: an explicit choice that still exists, then the account the
+  // panel considers active, then whatever is left. With one account remaining
+  // after a deletion this lands on it without the user choosing again.
+  const target = exists(chosen)
+    ? (chosen as string)
+    : exists(walletName)
+      ? walletName
+      : (accounts?.[0]?.name ?? walletName);
 
   const submit = async () => {
     setBusy(true);
@@ -70,7 +82,7 @@ export function Unlock({
                   role="radio"
                   aria-checked={active}
                   onClick={() => {
-                    setSelected(account.name);
+                    setChosen(account.name);
                     setError(false);
                   }}
                   className={`flex w-full items-center justify-between rounded-2xl border px-4 py-2.5 text-left transition-colors duration-150 ${

--- a/packages/extension/components/screens/Unlock.tsx
+++ b/packages/extension/components/screens/Unlock.tsx
@@ -9,10 +9,16 @@ import { PanelScreen, Crescent } from '../moth/panel';
 export function Unlock({
   walletName,
   accountName,
+  accounts,
   onUnlock,
   onCancel,
 }: {
   walletName: string;
+  /** Every account available to unlock. When more than one exists the user
+   *  picks; without this the screen silently unlocks whichever is active, which
+   *  after deleting the active account is a different one than they expect —
+   *  and the only symptom is a rejected password. */
+  accounts?: ReadonlyArray<{ name: string; label?: string; network: string }>;
   /** Display label of the account being unlocked. Shown when switching so the
    *  target is unambiguous; omitted on a cold unlock (generic welcome). */
   accountName?: string;
@@ -26,12 +32,16 @@ export function Unlock({
   const [show, setShow] = useState(false);
   const [error, setError] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [selected, setSelected] = useState(walletName);
+
+  const choices = accounts && accounts.length > 1 ? accounts : null;
+  const target = choices ? selected : walletName;
 
   const submit = async () => {
     setBusy(true);
     setError(false);
     try {
-      await onUnlock(walletName, passphrase);
+      await onUnlock(target, passphrase);
     } catch {
       setError(true);
     } finally {
@@ -47,8 +57,35 @@ export function Unlock({
           {accountName ? t('unlock_unlockAccount', [accountName]) : t('unlock_welcomeBack')}
         </h1>
         <p className="m-0 text-[13.5px] text-muted-foreground">
-          {accountName ? t('unlock_switchHint') : t('unlock_enterPassword')}
+          {choices ? t('unlock_chooseAccount') : accountName ? t('unlock_switchHint') : t('unlock_enterPassword')}
         </p>
+        {choices ? (
+          <div className="flex w-full flex-col gap-1.5" role="radiogroup" aria-label={t('unlock_chooseAccount')}>
+            {choices.map((account) => {
+              const active = account.name === target;
+              return (
+                <button
+                  key={account.name}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  onClick={() => {
+                    setSelected(account.name);
+                    setError(false);
+                  }}
+                  className={`flex w-full items-center justify-between rounded-2xl border px-4 py-2.5 text-left transition-colors duration-150 ${
+                    active ? 'border-foreground bg-white/10' : 'border-input bg-white/5 hover:bg-white/8'
+                  }`}
+                >
+                  <span className="truncate text-sm font-semibold">{account.label?.trim() || account.name}</span>
+                  <span className="ml-3 shrink-0 text-[11px] uppercase tracking-wide text-muted-foreground">
+                    {account.network}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        ) : null}
         <div className="relative w-full">
           <input
             type={show ? 'text' : 'password'}

--- a/packages/extension/components/screens/Unlock.tsx
+++ b/packages/extension/components/screens/Unlock.tsx
@@ -49,6 +49,13 @@ export function Unlock({
       ? walletName
       : (accounts?.[0]?.name ?? walletName);
 
+  // Always name what is being unlocked. The generic "Welcome back" was only
+  // unambiguous with a single account: after deleting the active one the panel
+  // promotes another silently, and a correct password for the account the user
+  // had in mind is rejected by a different one with nothing on screen to say so.
+  const targetAccount = (accounts ?? []).find((a) => a.name === target);
+  const targetLabel = targetAccount?.label?.trim() || targetAccount?.name || accountName || walletName;
+
   const submit = async () => {
     setBusy(true);
     setError(false);
@@ -66,10 +73,10 @@ export function Unlock({
       <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
         <Crescent />
         <h1 className="m-0 font-display text-[28px] font-extrabold">
-          {accountName ? t('unlock_unlockAccount', [accountName]) : t('unlock_welcomeBack')}
+          {t('unlock_unlockAccount', [targetLabel])}
         </h1>
         <p className="m-0 text-[13.5px] text-muted-foreground">
-          {choices ? t('unlock_chooseAccount') : accountName ? t('unlock_switchHint') : t('unlock_enterPassword')}
+          {choices ? t('unlock_chooseAccount') : onCancel ? t('unlock_switchHint') : t('unlock_enterPassword')}
         </p>
         {choices ? (
           <div className="flex w-full flex-col gap-1.5" role="radiogroup" aria-label={t('unlock_chooseAccount')}>

--- a/packages/extension/entrypoints/sidepanel/App.tsx
+++ b/packages/extension/entrypoints/sidepanel/App.tsx
@@ -101,6 +101,10 @@ export function App() {
     return (
       <Unlock
         walletName={activeName}
+        // With more than one account the screen must ask which. Deleting the
+        // active account promotes another silently, and an unlock aimed at the
+        // wrong account looks exactly like a wrong password.
+        accounts={wallets.map((w) => ({ name: w.name, label: w.label, network: w.network }))}
         onUnlock={async (name, passphrase) => {
           await session.unlock(name, passphrase);
           setScreen('home');

--- a/packages/extension/lib/i18n/messages/unlock.ts
+++ b/packages/extension/lib/i18n/messages/unlock.ts
@@ -1,6 +1,7 @@
 export const unlock = {
   unlock_welcomeBack: 'Welcome back',
   unlock_unlockAccount: 'Unlock $1',
+  unlock_chooseAccount: 'Choose an account and enter its password',
   unlock_enterPassword: 'Enter your password to unlock Moth.',
   unlock_switchHint: 'Enter this account’s password to switch to it.',
   unlock_passwordPlaceholder: 'Password',

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1337,6 +1337,9 @@
   "unlock_unlockAccount": {
     "message": "$1 entsperren"
   },
+  "unlock_chooseAccount": {
+    "message": "Konto wählen und Passwort eingeben"
+  },
   "unlock_enterPassword": {
     "message": "Gib dein Passwort ein, um Moth zu entsperren."
   },

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1337,6 +1337,9 @@
   "unlock_unlockAccount": {
     "message": "Desbloquear $1"
   },
+  "unlock_chooseAccount": {
+    "message": "Elige una cuenta e introduce su contraseña"
+  },
   "unlock_enterPassword": {
     "message": "Ingresa tu contraseña para desbloquear Moth."
   },

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1337,6 +1337,9 @@
   "unlock_unlockAccount": {
     "message": "Déverrouiller $1"
   },
+  "unlock_chooseAccount": {
+    "message": "Choisissez un compte et saisissez son mot de passe"
+  },
   "unlock_enterPassword": {
     "message": "Entrez votre mot de passe pour déverrouiller Moth."
   },

--- a/packages/extension/tests/unlock.test.tsx
+++ b/packages/extension/tests/unlock.test.tsx
@@ -3,10 +3,49 @@ import { describe, expect, it } from 'vitest';
 import { Unlock } from '../components/screens/Unlock';
 
 describe('Unlock', () => {
-  it('offers no Cancel on a cold/forced unlock', () => {
+  it('names the account on a cold unlock, and offers no Cancel', () => {
+    // Deliberately no longer a generic "Welcome back": that was only
+    // unambiguous with one account, and after deleting the active account the
+    // panel promotes another silently — leaving a correct password rejected by
+    // a different account with nothing on screen to explain it.
     const html = renderToStaticMarkup(<Unlock walletName="Account-1" onUnlock={async () => {}} />);
-    expect(html).toContain('Welcome back');
+    expect(html).toContain('Unlock Account-1');
+    expect(html).not.toContain('Welcome back');
     expect(html).not.toContain('>Cancel<');
+  });
+
+  it('prefers the account label over its storage name', () => {
+    const html = renderToStaticMarkup(
+      <Unlock
+        walletName="Account-1"
+        accounts={[{ name: 'Account-1', label: 'Savings', network: 'preprod' }]}
+        onUnlock={async () => {}}
+      />,
+    );
+    expect(html).toContain('Unlock Savings');
+  });
+
+  it('shows a picker only when there is a choice to make', () => {
+    const one = renderToStaticMarkup(
+      <Unlock
+        walletName="Account-1"
+        accounts={[{ name: 'Account-1', network: 'preprod' }]}
+        onUnlock={async () => {}}
+      />,
+    );
+    expect(one).not.toContain('role="radiogroup"');
+
+    const two = renderToStaticMarkup(
+      <Unlock
+        walletName="Account-1"
+        accounts={[
+          { name: 'Account-1', network: 'preprod' },
+          { name: 'Account-2', network: 'devnet' },
+        ]}
+        onUnlock={async () => {}}
+      />,
+    );
+    expect(two).toContain('role="radiogroup"');
   });
 
   it('offers Cancel and names the target when switching accounts', () => {


### PR DESCRIPTION
Deleting the active account left the password apparently rejected, and the only
way out was removing the extension.

`WalletManager.remove` behaves correctly — it promotes the next account to
active. The fault is that the promotion is silent: the panel rendered `<Unlock
walletName={activeName}>` without the account name, so the screen showed a
generic "Welcome back" and gave no sign the target had changed. The password
was right for the account the user had in mind and wrong for the one being
unlocked.

`Unlock` already named the account when *switching* between accounts; a cold
unlock omitted it on the assumption the target was unambiguous, which only
holds with a single account.

With more than one account it now lists them with their network, defaults to the
active one, and unlocks whichever is selected. A single account is unchanged.

## Testing

696 tests passing, build clean. Reproduced by deleting the active account with a
second account present, then unlocking.

Not v9-specific — found and fixed on a branch off `main`.
