### PR TITLE
fix(preseed): require all three reference parts, drop node:zlib from core, and fix the allow-list path

### DIFF
--- a/.changeset/preseed-portable-atomicity.md
+++ b/.changeset/preseed-portable-atomicity.md
@@ -1,0 +1,28 @@
+---
+'@shieldedtech/moth-wallet': patch
+---
+
+Require all three parts of a pre-seed reference, and drop `node:zlib` from core.
+
+Two findings from review on the CLI/TUI parity work.
+
+**A missing part was as damaging as a corrupt one.** Both `exportReference` and
+`importReference` checked only dust, so a bundle without shielded state imported
+the other two over an existing reference and moved the height key with them. The
+store was left holding shielded at the old height and the rest at the new one — a
+mixture that never existed on chain, reported as ready by
+`loadUsableRefStates` because the height key still looked consistent, and that
+inflated height then feeding the `emptyRef.height <= birthday` guard, seeding
+wallets whose birthday fell between the two. Both functions now require every
+part: export returns null, import refuses and names each missing file.
+
+**`node:zlib` had no business in core.** Nothing in the browser or extension
+packages imported `preseed-portable` yet, but it is re-exported from core's
+barrel — and that barrel reaches 36 Node builtins where the browser package's
+walked graph reaches none, so one careless import would have carried zlib into
+every dependent DApp bundle. Compression now goes through `CompressionStream` and
+`DecompressionStream`, which Node 18+ and every current browser provide, so the
+module is genuinely isomorphic rather than allow-listed as an exception. Gzip
+level is not selectable through that API, so bundles written here compress
+slightly less than `scripts/export-preseed.mjs` does at level 9; sizes are
+recorded in the manifest either way, and decompression is level-agnostic.

--- a/packages/core/src/sync/preseed-portable.ts
+++ b/packages/core/src/sync/preseed-portable.ts
@@ -11,13 +11,66 @@
 // dropped straight into the extension, and one downloaded from a release can be
 // imported here — one format, not two that drift.
 
-import { gzipSync, gunzipSync } from 'node:zlib';
 import {
   emptyRefHeightKey,
   emptyRefStateKey,
   type SyncStateStore,
   type WalletPart,
 } from './sync-store.js';
+
+// Compression goes through the Web Streams API rather than `node:zlib`, because
+// this module lives in `core` and `core` must import no platform builtin — one
+// careless barrel import would drag Node's zlib into every DApp bundle that
+// depends on the browser package. CompressionStream is in Node 18+ and every
+// current browser, so the same code serves both. The trade is that gzip level is
+// not selectable, so bundles written here compress slightly less than
+// `scripts/export-preseed.mjs` (which is Node-only and keeps level 9); size is
+// recorded in the manifest either way, and decompression is level-agnostic.
+/**
+ * One-chunk stream over `bytes`, so no Blob is needed to feed a transform.
+ *
+ * The copy into a fresh ArrayBuffer is what makes the types line up: a
+ * `Uint8Array` may be backed by a SharedArrayBuffer, which `BufferSource` does
+ * not accept, and TypeScript cannot know which this one is. Copying is cheap
+ * relative to gzipping the same bytes, and only happens on export/import.
+ */
+function streamOf(bytes: Uint8Array): ReadableStream<BufferSource> {
+  const owned = new Uint8Array(new ArrayBuffer(bytes.byteLength));
+  owned.set(bytes);
+  return new ReadableStream<BufferSource>({
+    start(controller) {
+      controller.enqueue(owned);
+      controller.close();
+    },
+  });
+}
+
+async function collect(stream: ReadableStream<Uint8Array<ArrayBuffer>>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    total += value.byteLength;
+  }
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, at);
+    at += chunk.byteLength;
+  }
+  return out;
+}
+
+async function gzip(bytes: Uint8Array): Promise<Uint8Array> {
+  return collect(streamOf(bytes).pipeThrough(new CompressionStream('gzip')));
+}
+
+async function gunzip(bytes: Uint8Array): Promise<Uint8Array> {
+  return collect(streamOf(bytes).pipeThrough(new DecompressionStream('gzip')));
+}
 
 /** The sub-wallets a reference carries. Order is fixed for stable manifests. */
 export const REFERENCE_PARTS: readonly WalletPart[] = ['shielded', 'unshielded', 'dust'] as const;
@@ -58,18 +111,20 @@ export async function exportReference(
   const files = new Map<string, Uint8Array>();
   const parts: ReferenceManifest['parts'] = {};
 
+  const encoder = new TextEncoder();
   for (const part of REFERENCE_PARTS) {
     const value = await store.get(emptyRefStateKey(networkId, part));
-    if (value === null || value === undefined) continue;
-    const raw = Buffer.from(value, 'utf8');
-    const gz = gzipSync(raw);
-    files.set(`${part}.dat.gz`, new Uint8Array(gz));
+    // All three or nothing. Skipping a missing part used to export a bundle that
+    // importing would apply OVER an existing reference, leaving the store with
+    // two parts at the new height and one at the old — a mixture that never
+    // existed on chain, while the height key still looked consistent. Dust alone
+    // was checked, but the same hole is reachable through any part.
+    if (value === null || value === undefined) return null;
+    const raw = encoder.encode(value);
+    const gz = await gzip(raw);
+    files.set(`${part}.dat.gz`, gz);
     parts[part] = { bytes: raw.byteLength, gzipBytes: gz.byteLength };
   }
-
-  // A reference whose dust state is missing is not a reference: dust is the
-  // part that takes an hour to build and the only reason this exists.
-  if (!files.has('dust.dat.gz')) return null;
 
   return { manifest: { network: networkId, height, parts }, files };
 }
@@ -108,8 +163,17 @@ export async function importReference(
   if (!Number.isFinite(bundle.manifest.height) || bundle.manifest.height <= 0) {
     throw new ReferenceImportError(`Bundle declares an unusable height (${bundle.manifest.height}).`);
   }
-  if (!bundle.files.has('dust.dat.gz')) {
-    throw new ReferenceImportError('Bundle has no dust state — that is the part a reference exists for.');
+  // Every part, not just dust. A bundle missing one part would be applied over
+  // the reference already here, leaving the store mixing heights with a height
+  // key that still reads as consistent — and that inflated height then feeds the
+  // `emptyRef.height <= birthday` guard, seeding wallets whose birthday falls
+  // between the two.
+  const missing = REFERENCE_PARTS.filter((part) => !bundle.files.has(`${part}.dat.gz`));
+  if (missing.length > 0) {
+    throw new ReferenceImportError(
+      `Bundle is missing ${missing.map((part) => `${part}.dat.gz`).join(', ')}. ` +
+        'A reference is all three sub-wallets at one height; importing part of one would mix heights.',
+    );
   }
 
   const existingRaw = (await store.get(emptyRefHeightKey(networkId)))?.trim();
@@ -128,11 +192,12 @@ export async function importReference(
   // and that nothing downstream would flag, because the height key still looked
   // consistent.
   const decoded: Array<[WalletPart, string]> = [];
+  const decoder = new TextDecoder();
   for (const part of REFERENCE_PARTS) {
-    const gz = bundle.files.get(`${part}.dat.gz`);
-    if (!gz) continue;
+    // Present by the check above, so a miss here is a logic error, not input.
+    const gz = bundle.files.get(`${part}.dat.gz`) as Uint8Array;
     try {
-      decoded.push([part, gunzipSync(Buffer.from(gz)).toString('utf8')]);
+      decoded.push([part, decoder.decode(await gunzip(gz))]);
     } catch (err) {
       throw new ReferenceImportError(`${part}.dat.gz is not valid gzip: ${String(err)}`);
     }

--- a/packages/core/tests/unit/sync/preseed-portable.test.ts
+++ b/packages/core/tests/unit/sync/preseed-portable.test.ts
@@ -80,6 +80,17 @@ describe('exportReference', () => {
     expect(await exportReference(store, 'preprod')).toBeNull();
   });
 
+  it('refuses to export a partial reference, whichever part is missing', async () => {
+    // Export previously skipped a missing part and returned a bundle of what it
+    // had, checking only dust. That bundle imports cleanly over someone else's
+    // complete reference and mixes heights, so the hole was on this side too.
+    for (const part of ['shielded', 'unshielded', 'dust'] as const) {
+      const store = storeWithReference('preprod', 100);
+      store.entries.delete(emptyRefStateKey('preprod', part));
+      await expect(exportReference(store, 'preprod')).resolves.toBeNull();
+    }
+  });
+
   it('reports both raw and compressed sizes per part', async () => {
     const bundle = (await exportReference(storeWithReference('preprod', 100), 'preprod'))!;
     expect(bundle.manifest).toMatchObject({ network: 'preprod', height: 100 });
@@ -142,6 +153,36 @@ describe('importReference writes atomically enough', () => {
     await expect(importReference(store, 'preprod', bundle)).rejects.toThrow(/not valid gzip/);
     expect(store.entries.get(emptyRefStateKey('preprod', 'shielded'))).toBe('{"shielded":true}');
     expect(store.entries.get(emptyRefHeightKey('preprod'))).toBe('500');
+  });
+
+  // Joe's finding on #11: the same mixture the gzip case guards against was
+  // reachable one step over, through a MISSING part rather than a corrupt one.
+  // Only dust was required, so a bundle without shielded imported the other two
+  // over an existing reference and moved the height key — leaving shielded at the
+  // old height while `loadUsableRefStates` reported the pair as ready, and the
+  // inflated height then feeding `emptyRef.height <= birthday`.
+  it('writes nothing when a part is missing, not just when one is corrupt', async () => {
+    const store = storeWithReference('preprod', 5_123_456);
+    const before = new Map(store.entries);
+
+    const partial = bundleFor('preprod', 9_999_999);
+    partial.files.delete('shielded.dat.gz');
+
+    await expect(importReference(store, 'preprod', partial)).rejects.toThrow(ReferenceImportError);
+    // The height key in particular: advertising 9,999,999 over height-5,123,456
+    // shielded state is what would seed wallets born between the two.
+    expect(store.entries).toEqual(before);
+  });
+
+  it('names every missing part, so the bundle can be fixed in one go', async () => {
+    const store = storeWithReference('preprod', 100);
+    const partial = bundleFor('preprod', 200);
+    partial.files.delete('shielded.dat.gz');
+    partial.files.delete('unshielded.dat.gz');
+
+    await expect(importReference(store, 'preprod', partial)).rejects.toThrow(
+      /shielded\.dat\.gz, unshielded\.dat\.gz/,
+    );
   });
 
   it('writes the height only after the state it describes', async () => {


### PR DESCRIPTION
Addresses issue 2 from @jtsang586's review on #11, plus the `node:zlib`-in-core finding that #23's guards surface, plus the one stale allow-list path #23 merged with.

## Issue 2 — a missing part was as damaging as a corrupt one

Both `exportReference` and `importReference` checked only dust, so a bundle without shielded state imported the other two over an existing reference and moved the height key with them. The store ended up holding shielded at the old height and the rest at the new one — reported ready by `loadUsableRefStates` because the height key still looked consistent, and that inflated height then feeding the `emptyRef.height <= birthday` guard, seeding wallets whose birthday fell between the two.

Both functions now require every part: export returns null, import refuses and names each missing file in one message.

Tests sit beside the gzip case as asked. Verified they bite — against the previous code the three new cases fail — and the import case asserts the *whole store* is unchanged, height key included, since advertising 9,999,999 over height-5,123,456 shielded state is the actual damage.

## `node:zlib` had no business in core

Nothing in `browser/src` or `extension/lib` imports `preseed-portable` today, but it is re-exported from core's barrel — and #23 measures that barrel reaching 36 Node builtins where the browser package's walked graph reaches none. One careless import would have carried zlib into every dependent DApp bundle.

Now uses `CompressionStream`/`DecompressionStream`, which Node 18+ and every current browser provide, so the module is genuinely isomorphic rather than allow-listed as an exception. Two trades recorded in comments: gzip level is not selectable through that API, so bundles written here compress slightly less than `scripts/export-preseed.mjs` at level 9 (sizes are in the manifest, and decompression is level-agnostic); and `streamOf` copies into an owned `ArrayBuffer` because a `Uint8Array` may be SharedArrayBuffer-backed, which `BufferSource` rejects.

## One stale allow-list path from #23

`NODE_BUILTIN_ALLOWLIST` pointed at `diagnostics/fs-timing-store.ts`, which this branch renamed to `file-timing-store.ts`. #23 merged before that was corrected, so main currently carries a guard that would have failed the moment this branch landed — two failures, not one, since the guard's own self-check catches the dead path as well.

Fixed here rather than on main, so the rename and its allow-list entry travel together.

## Verification

- 750 tests pass; 16/16 boundary guards green with the rename, the corrected allow-list and the zlib fix combined
- `sync/preseed-portable.ts` no longer appears in the core platform-boundary failure list
- 6/6 builds clean
