### PR TITLE
docs: document moth transfer as it actually works

### DIFF
--- a/.changeset/transfer-usage-docs.md
+++ b/.changeset/transfer-usage-docs.md
@@ -1,0 +1,20 @@
+---
+'@shieldedtech/moth-wallet': patch
+---
+
+Document `moth transfer` as it actually works.
+
+The README showed `moth transfer <amount> NIGHT --to <addr>` on two rows. That form
+does not parse — `transfer` declares one positional and rejects the second with
+`Unexpected argument: NIGHT`. It was the documented invocation, so it was the first
+thing a new user would type.
+
+Corrected to `moth transfer [<amount>] [--to <addr>]`, and the rows now say what
+was previously stated nowhere: the in-process command is NIGHT-only, with the
+token hardcoded and no flag to change it. A row for `moth daemon transfer` covers
+the path that *can* move other tokens, including the distinction between
+`--amount` (raw smallest units, any token) and `--night` (a decimal converted at
+10⁶ STARS, refused for anything but NIGHT).
+
+Docs only. Whether the in-process command should grow token selection is the open
+half of #62.

--- a/README.md
+++ b/README.md
@@ -366,8 +366,9 @@ Every command accepts:
 |---------|-------------|
 | `moth balance` | Show NIGHT (shielded + unshielded) + DUST + non-NIGHT token balances. In-process — spins up its own sync. |
 | `moth wallet status` | Same info but via the daemon's warm snapshot (instant). Requires TUI or `moth daemon serve`. |
-| `moth transfer [<amount>] [NIGHT] [--to <addr>]` | Transfer NIGHT (prompts for missing details) |
-| `moth transfer <amount> NIGHT --to <addr> --shielded` | Shielded transfer |
+| `moth transfer [<amount>] [--to <addr>]` | Transfer NIGHT (prompts for missing details). NIGHT only — the token is not selectable |
+| `moth transfer <amount> --to <addr> --shielded` | Shielded transfer |
+| `moth daemon transfer --to <addr> --token-id <id> --amount <raw>` | Transfer any token through the daemon. `--amount` is raw smallest units; `--night <decimal>` converts at 10⁶ but only for NIGHT |
 | `moth transfer batch <file.json>` | Batch transfer from JSON file (`@stdin` for pipe). Exit: 0 all ok, 1 partial, 2 all failed |
 
 ### Contract Operations


### PR DESCRIPTION
Docs half of #62.

The README documented `moth transfer <amount> NIGHT --to <addr>` on two rows. That form does not parse:

```
$ moth transfer 1 NIGHT --to mn_addr_preprod1qw986g… --wallet probe --network preprod
Error [WALLET_ERROR]: Unexpected argument: NIGHT
```

`transfer` declares a single positional (`amount`) and rejects the second. It was the *documented* invocation, so it is the first thing a new user types.

Corrected to `moth transfer [<amount>] [--to <addr>]`, and the rows now state something that was written nowhere: the in-process command is NIGHT-only, with the token hardcoded and no flag to change it. A new row covers `moth daemon transfer`, which is the path that *can* move other tokens, including the `--amount` (raw base units, any token) versus `--night` (decimal, NIGHT only) distinction.

Docs only — no code. The product half of #62, giving the in-process command token selection, is in #65.

Found while running a full manual pass over the CLI.

