### PR TITLE
fix(core): batch transfers must not parse money with parseFloat

### DIFF
--- a/packages/core/src/wallet/batch-transfer.ts
+++ b/packages/core/src/wallet/batch-transfer.ts
@@ -4,6 +4,7 @@
 import { readFileSync } from 'node:fs';
 import { sendTokensWithKeys, type SendRequest, type TxStage, type WalletKeys } from '../sync/operations.js';
 import { NIGHT_TOKEN_ID } from '../sync/wallet-sync.js';
+import { InvalidAmountError, parseNightAmount } from './night-amount.js';
 
 export interface BatchTransferEntry {
   to: string;
@@ -45,6 +46,15 @@ export function loadBatchFile(path: string): BatchTransferEntry[] {
     if (!entry.amount || typeof entry.amount !== 'string') {
       throw new Error(`Entry ${i}: missing or invalid "amount" (must be string)`);
     }
+    // Amount syntax is a static property of the file, so check it here rather
+    // than discovering it on entry 7 with six transfers already submitted. This
+    // function already refuses the whole file for a missing field; a
+    // meaningless amount is the same kind of defect.
+    try {
+      parseNightAmount(entry.amount);
+    } catch (err) {
+      throw new Error(`Entry ${i}: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
   return parsed;
 }
@@ -53,6 +63,10 @@ export function loadBatchFile(path: string): BatchTransferEntry[] {
  * Execute batch transfers sequentially.
  * Returns summary with per-item results and three-tier exit code:
  *   0 = all succeeded, 1 = some failed, 2 = all failed
+ *
+ * Amounts are validated per entry as well as in `loadBatchFile`, because
+ * `transfer batch @stdin` JSON.parses straight into here and never goes through
+ * the loader.
  */
 export async function executeBatchTransfer(
   facade: any,
@@ -65,14 +79,23 @@ export async function executeBatchTransfer(
 
   for (let i = 0; i < entries.length; i++) {
     const entry = entries[i];
-    const parsed = parseFloat(entry.amount);
-    if (Number.isNaN(parsed) || parsed <= 0) {
+
+    // The same parser `moth transfer` and the daemon use. The previous
+    // `parseFloat` + `Math.round(x * 1_000_000)` accepted an entry it could not
+    // understand as a DIFFERENT amount: "1,5" became 1 NIGHT, "1e3" became 1000,
+    // and "0.0000001" rounded to zero base units and was submitted as a transfer
+    // of nothing that still paid a fee. A batch file is where those arrive —
+    // generated or pasted, with no prompt to read (#66, the #63 bug in this path).
+    let amount: bigint;
+    try {
+      amount = parseNightAmount(entry.amount);
+    } catch (err) {
       results.push({
         index: i,
         to: entry.to,
         amount: entry.amount,
         status: 'error',
-        error: `Invalid amount: ${entry.amount}`,
+        error: err instanceof InvalidAmountError ? err.message : `Invalid amount: ${entry.amount}`,
       });
       continue;
     }
@@ -80,7 +103,7 @@ export async function executeBatchTransfer(
     const req: SendRequest = {
       type: entry.shielded ? 'shielded' : 'unshielded',
       tokenId: NIGHT_TOKEN_ID,
-      amount: BigInt(Math.round(parsed * 1_000_000)),
+      amount,
       to: entry.to,
     };
 
@@ -116,10 +139,17 @@ export async function executeBatchTransfer(
 }
 
 /**
- * Three-tier exit code from batch results.
+ * Three-tier exit code from batch results: 0 all succeeded, 1 partial, 2 all
+ * failed — the contract stated above, in the README, and in the test plan.
+ *
+ * The two failure codes were the wrong way round: a batch where everything
+ * failed returned 1 and one where only some entries failed returned 2. That
+ * inverts the signal automation keys on — a caller treating 2 as "nothing went
+ * out, re-send the file" would re-send a batch whose successful entries had
+ * already been submitted (#67).
  */
 export function batchExitCode(summary: BatchTransferSummary): 0 | 1 | 2 {
   if (summary.failed === 0) return 0;
-  if (summary.succeeded === 0) return 1;
-  return 2;
+  if (summary.succeeded === 0) return 2;
+  return 1;
 }

--- a/packages/core/tests/unit/wallet/batch-transfer.test.ts
+++ b/packages/core/tests/unit/wallet/batch-transfer.test.ts
@@ -1,0 +1,155 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const send = vi.fn();
+
+// The real module pulls the wallet SDK in; only the sender is under test here.
+vi.mock('../../../src/sync/operations.js', () => ({
+  sendTokensWithKeys: (...args: unknown[]) => send(...args),
+}));
+vi.mock('../../../src/sync/wallet-sync.js', () => ({
+  NIGHT_TOKEN_ID: '0'.repeat(64),
+}));
+
+const { batchExitCode, executeBatchTransfer, loadBatchFile } = await import(
+  '../../../src/wallet/batch-transfer.js'
+);
+
+const TO = 'mn_shield-addr_test1abcdef';
+const keys = {} as never;
+
+function batchFile(entries: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'moth-batch-'));
+  const path = join(dir, 'batch.json');
+  writeFileSync(path, JSON.stringify(entries));
+  return path;
+}
+
+beforeEach(() => {
+  send.mockReset();
+  send.mockResolvedValue('0xtxhash');
+});
+
+describe('executeBatchTransfer amounts', () => {
+  it('converts decimal NIGHT to exact base units', async () => {
+    const summary = await executeBatchTransfer({}, keys, 'preprod', [
+      { to: TO, amount: '1' },
+      { to: TO, amount: '1.5' },
+      { to: TO, amount: '0.000001' },
+    ]);
+
+    expect(summary.succeeded).toBe(3);
+    expect(send.mock.calls.map(c => (c[3] as {amount: bigint}[])[0].amount)).toEqual([
+      1_000_000n,
+      1_500_000n,
+      1n,
+    ]);
+  });
+
+  // #66 — every one of these was ACCEPTED by the parseFloat version, as a
+  // different amount than the file asked for. The first two moved money: "1,5"
+  // sent a third of the intended value, and "0.0000001" submitted a transfer of
+  // nothing that still paid a fee.
+  it.each([
+    ['1,5', 'a comma decimal, normal across most of Europe, sent 1 NIGHT'],
+    ['0.0000001', 'rounded to zero base units and was sent as a no-op transfer'],
+    ['1e3', 'scientific notation sent 1000 NIGHT'],
+    ['1abc', 'trailing text was discarded and 1 NIGHT was sent'],
+    ['1.2345678', 'a seventh decimal place was silently rounded away'],
+    ['0', 'zero moves nothing and still pays a fee'],
+    ['-1', 'negative'],
+    ['', 'empty'],
+    ['1.', 'trailing separator'],
+    ['.5', 'no whole part'],
+  ])('refuses %j and submits nothing', async (amount) => {
+    const summary = await executeBatchTransfer({}, keys, 'preprod', [{ to: TO, amount }]);
+
+    expect(summary.succeeded).toBe(0);
+    expect(summary.failed).toBe(1);
+    expect(summary.results[0].status).toBe('error');
+    expect(summary.results[0].error).toContain('Invalid amount');
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it('keeps going after a bad entry, and reports which one it was', async () => {
+    const summary = await executeBatchTransfer({}, keys, 'preprod', [
+      { to: TO, amount: '1' },
+      { to: TO, amount: '1,5' },
+      { to: TO, amount: '2' },
+    ]);
+
+    expect(summary.total).toBe(3);
+    expect(summary.succeeded).toBe(2);
+    expect(summary.results[1].index).toBe(1);
+    expect(summary.results[1].amount).toBe('1,5');
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('honours the shielded flag per entry', async () => {
+    await executeBatchTransfer({}, keys, 'preprod', [
+      { to: TO, amount: '1' },
+      { to: TO, amount: '1', shielded: true },
+    ]);
+
+    expect(send.mock.calls.map(c => (c[3] as {type: string}[])[0].type)).toEqual([
+      'unshielded',
+      'shielded',
+    ]);
+  });
+
+  it('records a sender failure as an error result rather than throwing', async () => {
+    send.mockRejectedValueOnce(new Error('Transaction submission error'));
+    const summary = await executeBatchTransfer({}, keys, 'preprod', [{ to: TO, amount: '1' }]);
+
+    expect(summary.failed).toBe(1);
+    expect(summary.results[0].error).toContain('Transaction submission error');
+  });
+});
+
+describe('batchExitCode', () => {
+  const summary = (succeeded: number, failed: number) =>
+    ({ total: succeeded + failed, succeeded, failed, results: [] });
+
+  // #67 — these two were the wrong way round: all-failed returned 1 and partial
+  // returned 2. A caller treating 2 as "nothing was submitted, re-send the file"
+  // would re-send a batch whose successful entries were already on chain.
+  it('is 0 when everything succeeded', () => {
+    expect(batchExitCode(summary(3, 0))).toBe(0);
+  });
+
+  it('is 1 when some entries failed', () => {
+    expect(batchExitCode(summary(2, 1))).toBe(1);
+  });
+
+  it('is 2 when every entry failed', () => {
+    expect(batchExitCode(summary(0, 3))).toBe(2);
+  });
+});
+
+describe('loadBatchFile', () => {
+  it('accepts a well-formed file', () => {
+    expect(loadBatchFile(batchFile([{ to: TO, amount: '1.5' }]))).toEqual([
+      { to: TO, amount: '1.5' },
+    ]);
+  });
+
+  // Amount syntax is checkable before any money moves, so a file with a typo on
+  // entry 3 is refused whole rather than after two transfers have gone out.
+  it('refuses the whole file for a malformed amount, naming the entry', () => {
+    const path = batchFile([
+      { to: TO, amount: '1' },
+      { to: TO, amount: '2' },
+      { to: TO, amount: '3,5' },
+    ]);
+    expect(() => loadBatchFile(path)).toThrow(/Entry 2/);
+    expect(() => loadBatchFile(path)).toThrow(/Invalid amount/);
+  });
+
+  it('still refuses missing fields', () => {
+    expect(() => loadBatchFile(batchFile([{ amount: '1' }]))).toThrow(/"to" address/);
+    expect(() => loadBatchFile(batchFile([{ to: TO }]))).toThrow(/"amount"/);
+    expect(() => loadBatchFile(batchFile({ to: TO, amount: '1' }))).toThrow(/JSON array/);
+  });
+});


### PR DESCRIPTION
Fixes #66 and #67 — two defects in `executeBatchTransfer`, found while building an end-to-end harness, neither visible to the test suite because nothing tested this function.

## #66 — the #63 bug, still live in the batch path

PR #65 fixed the amount parser in `moth transfer` and shared it with the daemon. The batch path was missed:

```ts
const parsed = parseFloat(entry.amount);
if (Number.isNaN(parsed) || parsed <= 0) { /* rejected */ }
amount: BigInt(Math.round(parsed * 1_000_000)),
```

`parseFloat` keeps whatever prefix it understands, so an entry is accepted as a **different amount** rather than refused:

| entry `amount` | sent as | `moth transfer` with the same string |
| --- | --- | --- |
| `"1,5"` | **1 NIGHT** — a third of the value | refused |
| `"0.0000001"` | **0 base units** — moves nothing, fee still paid | refused |
| `"1e3"` | 1000 NIGHT | refused |
| `"1abc"` | 1 NIGHT | refused |
| `"1.2345678"` | silently rounded to 6dp | refused |

A batch file is where these actually arrive: generated or pasted from a spreadsheet, not typed at a prompt with a confirmation to read. `"1,5"` is a normal decimal across most of Europe.

The `parsed <= 0` guard does not catch the zero case either — `parseFloat("0.0000001")` is `1e-7`, which is greater than zero, so it proceeds and `Math.round(1e-7 * 1e6)` is `0`.

Now uses `parseNightAmount`, the same parser the single-transfer and daemon paths share. `loadBatchFile` also validates amount syntax up front, since that is a static property of the file — a typo on entry 3 refuses the whole file before anything is submitted, rather than surfacing after two transfers have gone out. The per-entry check stays, because `transfer batch @stdin` `JSON.parse`s straight into `executeBatchTransfer` and never reaches the loader.

## #67 — the exit codes for partial and total failure were swapped

```ts
if (summary.failed === 0) return 0;
if (summary.succeeded === 0) return 1;   // every entry failed → 1
return 2;                                 // some entries failed → 2
```

Against its own docstring (`batch-transfer.ts:55`) and README.md:371: *0 all ok, 1 partial, 2 all failed*. `transfer/batch.ts:83` passes the value straight to `this.exit`, so that is what a caller sees.

The three-tier code exists so automation can tell "nothing happened, safe to retry the whole file" from "some of this is already on chain, do not re-send". Inverted, a caller treating 2 as the safe-retry case re-sends a batch whose successful entries have already been submitted, paying those recipients twice. The more careful the caller, the worse the outcome: a script that retries only on the all-failed code is the one that gets it wrong.

## Verified

20 tests, none of which existed before. Reverting the fix fails 11 of them — the five inputs above, `"1."`, `".5"`, the mixed batch, both exit-code cases and the load-time refusal. `0`, `-1` and `""` pass either way, since the old `parsed <= 0` guard already caught those.

Full suite 746 passed / 34 skipped, 6/6 builds, biome clean.

## Why this is a separate PR

The commit was made on `fix/cli-usability` after PR #65 had already merged, so it was stranded on a closed PR's branch and would have been lost. This branch is that commit alone, off `main`. It conflicts with nothing.
