### PR TITLE
fix(tui): bound the Wallet State coin lists to the terminal height

### DIFF
--- a/.changeset/state-view-row-bounding.md
+++ b/.changeset/state-view-row-bounding.md
@@ -1,0 +1,50 @@
+---
+'@shieldedtech/moth-tui': patch
+---
+
+Bound the Wallet State view's coin lists to what the terminal can show.
+
+Observed on mainnet, where a shielded wallet holds far more coins than a test
+wallet does. The itemised list ran past its own section and painted over the ones
+beneath it, so the Unshielded and Dust sections printed lines like
+
+```
+▸ Unshielded Wallet
+    Ba29ed4a053c1ec576e7f7684832c062bebc5cf67c0a4a9242f4defebd4b112b94  522  (1 coin)
+```
+
+— that section's `Balance` label with a token row on top of it.
+
+The cause is not formatting. Ink renders a frame in full and has no viewport, so a
+frame taller than the terminal corrupts its redraw and lines overwrite one
+another. `components/Select.tsx` already documents exactly this ("makes Ink
+collapse the two lines onto one") and windows its list against `stdout.rows` to
+avoid it; `StateView` had no equivalent and emitted a row per token plus a row per
+coin, unbounded. `Label` pads with `padEnd` and never truncates, which is what
+identifies the 2-character `Ba` as terminal overwrite rather than a truncation
+bug — and why truncating the label would have fixed nothing.
+
+Each block is now bounded as a whole, with the remainder reported:
+
+```
+    Balance
+      29ed4a05…4b112b94  522  (1 coin)
+      … and 4,312 more
+```
+
+Bounded as a whole because volume arrives from either direction — a wallet with
+many tokens, or a token with many coins — and capping only the inner coin list
+leaves the outer one unbounded. The rows are flattened into one list and one
+budget covers them, so neither shape can overflow. The three sections split the
+terminal's spare height; the `… and N more` line is counted against the budget it
+belongs to.
+
+Long token ids are now middle-elided to fit the terminal width. That is not only
+cosmetic: at 80 columns a full 64-character id wrapped the header onto a second
+line, which cost two rows where the budget assumed one.
+
+`Dust` had the same unbounded shape and is fixed the same way, costing a
+deregistered coin as two rows since it renders its `dtime` on a second line.
+
+The row arithmetic lives in `utils/` as `flattenBalanceRows`, `windowRows`,
+`truncateMiddle` and `balanceBudget`, unit-tested without rendering Ink.

--- a/packages/tui/src/screens/dashboard/StateView.tsx
+++ b/packages/tui/src/screens/dashboard/StateView.tsx
@@ -2,7 +2,7 @@
 // Visual style mirrors midnight-wallet-cli (Apache-2.0). See NOTICE.
 
 import React from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 import { SectionHeader } from '../../components/SectionHeader.js';
 import type { WalletState, NetworkState } from '../../types.js';
 import type { ChainStatus } from '../../hooks/useChainStatus.js';
@@ -11,8 +11,14 @@ import type {
   ShieldedCoinInfo, UnshieldedCoinInfo, DustCoinInfo,
 } from '@shieldedtech/moth-wallet';
 import { NIGHT_TOKEN_ID } from '@shieldedtech/moth-wallet';
-import { formatBalanceForToken, formatDustBalance, groupCoinsForDisplay } from '../../utils/balance.js';
-import { formatTimeRemaining } from '../../utils/display.js';
+import {
+  formatBalanceForToken, formatDustBalance, groupCoinsForDisplay,
+  flattenBalanceRows,
+} from '../../utils/balance.js';
+import {
+  formatTimeRemaining, truncateMiddle, windowRows, balanceBudget,
+  type BalanceBudget,
+} from '../../utils/display.js';
 
 interface StateViewProps {
   wallet: WalletState | null;
@@ -84,11 +90,12 @@ function groupByToken<T extends { value: bigint; type: string }>(coins: readonly
 }
 // Fungible grouping (which folds booked coins into the total) lives in
 // utils/balance.ts as groupCoinsForDisplay so the arithmetic is unit-testable
-// without rendering Ink. groupByToken above still serves the dust block.
+// without rendering Ink. Note groupByToken above no longer serves the dust
+// block — nothing calls it; removing it is a separate cleanup.
 
 /** Shared "Balance" block for shielded + unshielded — grouped by token, nested coins. */
 function FungibleBalanceBlock({
-  available, booked = [], tokenType,
+  available, booked = [], tokenType, budget,
 }: {
   available: readonly (ShieldedCoinInfo | UnshieldedCoinInfo)[];
   /**
@@ -103,6 +110,7 @@ function FungibleBalanceBlock({
    */
   booked?: readonly (ShieldedCoinInfo | UnshieldedCoinInfo)[];
   tokenType: 'shielded' | 'unshielded';
+  budget: BalanceBudget;
 }) {
   if (available.length === 0 && booked.length === 0) {
     return (
@@ -114,34 +122,44 @@ function FungibleBalanceBlock({
   }
 
   const groups = groupCoinsForDisplay(available, booked, tokenType);
+  // Flat row list, then one budget over the whole block — see flattenBalanceRows.
+  const rows = flattenBalanceRows(groups);
+  // The "and N more" line costs a row of its own when there is going to be one.
+  const { shown, hidden } = windowRows(
+    rows,
+    rows.length > budget.maxRows ? budget.maxRows - 1 : budget.maxRows,
+  );
 
   return (
     <Box flexDirection="column">
       <Box><Label>Balance</Label></Box>
       <Box marginLeft={2} flexDirection="column">
-        {groups.map((g) => {
-          const display = g.token === NIGHT_TOKEN_ID && tokenType === 'unshielded' ? 'NIGHT' : g.token;
-          // Itemise for more than one coin, or when a lone coin carries a flag.
-          const itemise = g.coins.length > 1 || g.coins.some((c) => c.registered || c.booked);
-          return (
-            <Box key={g.token} flexDirection="column">
-              <Box>
+        {shown.map((row) => {
+          const g = groups[row.group];
+          if (row.kind === 'group') {
+            const display = g.token === NIGHT_TOKEN_ID && tokenType === 'unshielded'
+              ? 'NIGHT'
+              : truncateMiddle(g.token, budget.tokenWidth);
+            return (
+              <Box key={`g${row.group}`}>
                 <Text>{display}</Text>
                 <Text>  </Text>
                 <Text bold>{formatBalanceForToken(g.total, g.token, tokenType)}</Text>
                 <Text dimColor>  ({pluralCoins(g.coins.length)})</Text>
               </Box>
-              {itemise && g.coins.map((coin, idx) => (
-                <Box key={idx} marginLeft={2}>
-                  <Text dimColor>· </Text>
-                  <Text>{formatBalanceForToken(coin.value, coin.type, tokenType)}</Text>
-                  {coin.registered && <Text color="yellow"> [Registered for Dust]</Text>}
-                  {coin.booked && <Text color="cyan"> [in flight]</Text>}
-                </Box>
-              ))}
+            );
+          }
+          const coin = g.coins[row.coin!];
+          return (
+            <Box key={`g${row.group}c${row.coin}`} marginLeft={2}>
+              <Text dimColor>· </Text>
+              <Text>{formatBalanceForToken(coin.value, coin.type, tokenType)}</Text>
+              {coin.registered && <Text color="yellow"> [Registered for Dust]</Text>}
+              {coin.booked && <Text color="cyan"> [in flight]</Text>}
             </Box>
           );
         })}
+        {hidden > 0 && <Text dimColor>… and {hidden.toLocaleString()} more</Text>}
       </Box>
     </Box>
   );
@@ -149,10 +167,11 @@ function FungibleBalanceBlock({
 
 /** Dust "Balance" block — single DUST token with per-coin generation status. */
 function DustBalanceBlock({
-  totalDust, available,
+  totalDust, available, budget,
 }: {
   totalDust: bigint;
   available: readonly DustCoinInfo[];
+  budget: BalanceBudget;
 }) {
   if (available.length === 0) {
     return (
@@ -164,6 +183,13 @@ function DustBalanceBlock({
     );
   }
   const now = new Date();
+  // A deregistered coin renders a second line, so cost it as two rows.
+  const dustRows = (coin: DustCoinInfo) => (coin.dtime ? 2 : 1);
+  const { shown, hidden } = windowRows(
+    available,
+    available.length > budget.maxRows ? budget.maxRows - 1 : budget.maxRows,
+    dustRows,
+  );
   return (
     <Box flexDirection="column">
       <Box>
@@ -172,7 +198,7 @@ function DustBalanceBlock({
         <Text dimColor> DUST  ({pluralCoins(available.length)})</Text>
       </Box>
       <Box marginLeft={LABEL_WIDTH} flexDirection="column">
-        {available.map((coin, idx) => {
+        {shown.map((coin, idx) => {
           const timeRemaining = formatTimeRemaining(coin.maxCapReachedAt, now);
           const isComplete = coin.generatedNow >= coin.maxCap;
           return (
@@ -193,6 +219,7 @@ function DustBalanceBlock({
             </Box>
           );
         })}
+        {hidden > 0 && <Text dimColor>· … and {hidden.toLocaleString()} more</Text>}
       </Box>
     </Box>
   );
@@ -213,6 +240,13 @@ export function StateView({
   addresses, shieldedBalances: _sb, unshieldedBalances: _ub, dustBalance,
   coins, subProgress,
 }: StateViewProps) {
+  const { stdout } = useStdout();
+  // Ink renders the whole frame at once and has no viewport: a frame taller than
+  // the terminal corrupts its redraw, collapsing lines onto one another (the
+  // note in components/Select.tsx describes the same failure). Coin counts come
+  // from chain state, so every block below is bounded by what the terminal can
+  // actually show.
+  const budget = balanceBudget(stdout?.rows, stdout?.columns);
   const showWallets = isUnlocked && wallet && addresses;
   const headerHint = wallet ? `${network.id} · ${wallet.name}` : network.id;
   const chips = paused ? [{ label: 'PAUSED', color: 'yellow' }] : undefined;
@@ -286,6 +320,7 @@ export function StateView({
               <FungibleBalanceBlock
                 available={coins?.shielded.available ?? []}
                 tokenType="shielded"
+                budget={budget}
               />
               <PendingRow count={coins?.shielded.pending.length ?? 0} />
             </Box>
@@ -304,6 +339,7 @@ export function StateView({
                 available={coins?.unshielded.available ?? []}
                 booked={coins?.unshielded.pending ?? []}
                 tokenType="unshielded"
+                budget={budget}
               />
               <PendingRow count={coins?.unshielded.pending.length ?? 0} />
             </Box>
@@ -321,6 +357,7 @@ export function StateView({
               <DustBalanceBlock
                 totalDust={dustBalance ?? 0n}
                 available={coins?.dust.available ?? []}
+                budget={budget}
               />
               <PendingRow count={coins?.dust.pending.length ?? 0} />
             </Box>

--- a/packages/tui/src/utils/balance.ts
+++ b/packages/tui/src/utils/balance.ts
@@ -96,3 +96,40 @@ export function parseNightAmount(amount: string): bigint {
   const [int, dec = ''] = amount.split('.');
   return BigInt(int || '0') * 1_000_000n + BigInt(dec.padEnd(6, '0').slice(0, 6));
 }
+
+/**
+ * Itemise a group's individual coins? More than one coin, or a lone coin
+ * carrying a flag worth seeing.
+ */
+export function shouldItemise(group: DisplayTokenGroup): boolean {
+  return group.coins.length > 1 || group.coins.some((c) => c.registered || c.booked);
+}
+
+/** One rendered line of the balance block. */
+export interface BalanceRow {
+  kind: 'group' | 'coin';
+  /** Index into the groups array. */
+  group: number;
+  /** Index into that group's coins — set for `coin` rows only. */
+  coin?: number;
+}
+
+/**
+ * Flatten display groups into the exact sequence of lines the balance block
+ * renders: a header per token, then its itemised coins.
+ *
+ * Flattened rather than nested because the block has to be bounded as a whole.
+ * Volume arrives from either direction — a wallet with many tokens or a token
+ * with many coins — and capping only the inner list leaves the outer one
+ * unbounded. One flat list means one row budget (see windowRows), so the block
+ * can never render taller than the terminal whichever way the coins fall.
+ */
+export function flattenBalanceRows(groups: readonly DisplayTokenGroup[]): BalanceRow[] {
+  const rows: BalanceRow[] = [];
+  groups.forEach((group, g) => {
+    rows.push({ kind: 'group', group: g });
+    if (!shouldItemise(group)) return;
+    group.coins.forEach((_coin, c) => rows.push({ kind: 'coin', group: g, coin: c }));
+  });
+  return rows;
+}

--- a/packages/tui/src/utils/display.ts
+++ b/packages/tui/src/utils/display.ts
@@ -14,3 +14,86 @@ export function formatTimeRemaining(targetDate: Date, now: Date = new Date()): s
   if (hours > 0) return `${hours}h ${minutes}m`;
   return `${minutes}m`;
 }
+
+/**
+ * Middle-elide `value` to at most `max` columns: `29ed4a05…4b112b94`.
+ *
+ * Used for raw 64-char token ids. This is not only cosmetic — a row that wraps
+ * costs two terminal lines instead of one, which silently breaks the row
+ * budgeting in `windowRows` and lets a block overflow the screen anyway.
+ */
+export function truncateMiddle(value: string, max: number): string {
+  if (max <= 1) return value.slice(0, Math.max(0, max));
+  if (value.length <= max) return value;
+  const keep = max - 1; // one column for the ellipsis
+  const head = Math.ceil(keep / 2);
+  const tail = keep - head;
+  return `${value.slice(0, head)}…${value.slice(value.length - tail)}`;
+}
+
+/**
+ * Take items until their combined row cost exhausts `budget`.
+ *
+ * Ink has no viewport: a frame taller than the terminal corrupts its redraw,
+ * collapsing lines onto one another (see the note in components/Select.tsx).
+ * Every list that grows with chain state therefore needs a hard row bound, and
+ * the caller renders `hidden` as an "and N more" line.
+ *
+ * `cost` defaults to one row per item; pass it for rows that can render taller.
+ */
+export function windowRows<T>(
+  items: readonly T[],
+  budget: number,
+  cost: (item: T) => number = () => 1,
+): { shown: T[]; hidden: number } {
+  if (budget <= 0) return { shown: [], hidden: items.length };
+  const shown: T[] = [];
+  let used = 0;
+  for (const item of items) {
+    const next = used + cost(item);
+    if (next > budget) break;
+    used = next;
+    shown.push(item);
+  }
+  return { shown, hidden: items.length - shown.length };
+}
+
+/** Row budget and token-id width for one wallet section's balance block. */
+export interface BalanceBudget {
+  /** Item rows the block may render, the "and N more" line included. */
+  maxRows: number;
+  /** Columns a token id may occupy before it is middle-elided. */
+  tokenWidth: number;
+}
+
+/**
+ * Fixed rows the Wallet State view spends before any coin: the section header,
+ * the network block, and each wallet section's heading, address, sync, pending
+ * and margins. Approximate by design — it only has to be close enough that the
+ * coin lists cannot be what pushes the frame past the terminal.
+ */
+const STATE_VIEW_CHROME_ROWS = 26;
+
+/**
+ * Columns a token header spends on everything but the token id: the indent (4),
+ * the gap after it (2), a wide amount (17, e.g. `1234567890.123456`) and the
+ * coin count (14, e.g. `  (1000 coins)`).
+ */
+const HEADER_OVERHEAD_COLUMNS = 37;
+
+/**
+ * Split the terminal's spare height between the wallet sections.
+ *
+ * The floor of 2 means a very short terminal still shows something rather than
+ * an empty block. Such a terminal can still overflow on chrome alone — what
+ * this removes is a wallet's coin count deciding whether it overflows.
+ */
+export function balanceBudget(rows = 24, columns = 80, sections = 3): BalanceBudget {
+  const spare = rows - STATE_VIEW_CHROME_ROWS;
+  return {
+    maxRows: Math.max(2, Math.floor(spare / Math.max(1, sections))),
+    // Reserve the header's fixed columns so it never wraps — a wrapped row costs
+    // two lines and breaks the row budget above.
+    tokenWidth: Math.min(64, Math.max(12, columns - HEADER_OVERHEAD_COLUMNS)),
+  };
+}

--- a/packages/tui/tests/unit/state-view-rows.test.ts
+++ b/packages/tui/tests/unit/state-view-rows.test.ts
@@ -1,0 +1,140 @@
+// Row bounding for the Wallet State view.
+//
+// Ink renders a frame in full and has no viewport. A frame taller than the
+// terminal corrupts its redraw and lines overwrite one another — the failure
+// components/Select.tsx already describes ("makes Ink collapse the two lines
+// onto one"). The Wallet State view had no such bound: every coin got a row.
+//
+// Observed on mainnet, where a shielded wallet holds a large number of coins:
+// the itemised list ran past the section and painted over the ones below it,
+// producing lines like
+//
+//   Ba29ed4a053c1ec576e7f7684832c062bebc5cf67c0a4a9242f4defebd4b112b94  522  (1 coin)
+//
+// — the Unshielded section's `Balance` label with a token row on top of it. Note
+// the label itself cannot produce that string: Label pads with padEnd and never
+// truncates, which is what identifies this as terminal overwrite rather than a
+// formatting bug.
+
+import { describe, expect, it } from 'vitest';
+import { flattenBalanceRows, shouldItemise, type DisplayTokenGroup } from '../../src/utils/balance.js';
+import { balanceBudget, truncateMiddle, windowRows } from '../../src/utils/display.js';
+
+const TOKEN = '29ed4a053c1ec576e7f7684832c062bebc5cf67c0a4a9242f4defebd4b112b94';
+
+const group = (token: string, coins: number): DisplayTokenGroup => ({
+  token,
+  total: BigInt(coins),
+  coins: Array.from({ length: coins }, () => ({ value: 1n, type: token, registered: false, booked: false })),
+});
+
+/** Lines a bounded block actually prints: the items plus the "and N more" line. */
+function renderedRows(groups: DisplayTokenGroup[], maxRows: number): number {
+  const rows = flattenBalanceRows(groups);
+  const budget = rows.length > maxRows ? maxRows - 1 : maxRows;
+  const { shown, hidden } = windowRows(rows, budget);
+  return shown.length + (hidden > 0 ? 1 : 0);
+}
+
+describe('truncateMiddle', () => {
+  it('leaves a value that already fits', () => {
+    expect(truncateMiddle('NIGHT', 20)).toBe('NIGHT');
+  });
+
+  it('elides the middle and keeps both ends recognisable', () => {
+    const short = truncateMiddle(TOKEN, 24);
+    expect(short).toHaveLength(24);
+    expect(short.startsWith('29ed4a05')).toBe(true);
+    expect(short.endsWith('4b112b94')).toBe(true);
+  });
+
+  it('never exceeds the width it was given', () => {
+    for (const max of [1, 2, 5, 12, 41, 64, 100]) {
+      expect(truncateMiddle(TOKEN, max).length).toBeLessThanOrEqual(Math.max(max, 0));
+    }
+  });
+});
+
+describe('windowRows', () => {
+  it('bounds the list and reports the remainder', () => {
+    const { shown, hidden } = windowRows(Array.from({ length: 500 }, (_, i) => i), 6);
+    expect(shown).toHaveLength(6);
+    expect(hidden).toBe(494);
+  });
+
+  it('hides everything when there is no room', () => {
+    expect(windowRows([1, 2, 3], 0)).toEqual({ shown: [], hidden: 3 });
+  });
+
+  it('honours a per-item cost, so a two-line item counts twice', () => {
+    // A deregistered dust coin renders a second line for its dtime.
+    const items = [{ tall: true }, { tall: true }, { tall: false }];
+    const { shown, hidden } = windowRows(items, 3, (i) => (i.tall ? 2 : 1));
+    expect(shown).toHaveLength(1);
+    expect(hidden).toBe(2);
+  });
+});
+
+describe('flattenBalanceRows', () => {
+  it('emits a header only for a single unflagged coin', () => {
+    const rows = flattenBalanceRows([group(TOKEN, 1)]);
+    expect(shouldItemise(group(TOKEN, 1))).toBe(false);
+    expect(rows).toEqual([{ kind: 'group', group: 0 }]);
+  });
+
+  it('emits a header plus one row per coin once itemised', () => {
+    const rows = flattenBalanceRows([group(TOKEN, 3)]);
+    expect(rows).toHaveLength(4);
+    expect(rows[0]).toEqual({ kind: 'group', group: 0 });
+    expect(rows.filter((r) => r.kind === 'coin')).toHaveLength(3);
+  });
+
+  it('counts many tokens as well as many coins', () => {
+    // Capping only the inner coin list would leave this unbounded: the volume
+    // here is in the number of tokens, one header each.
+    const groups = Array.from({ length: 200 }, (_, i) => group(`${i}`.padStart(64, '0'), 1));
+    expect(flattenBalanceRows(groups)).toHaveLength(200);
+  });
+});
+
+describe('a section never renders taller than its budget', () => {
+  it('bounds a wallet holding a huge number of coins in one token', () => {
+    // The mainnet case that broke the view.
+    const { maxRows } = balanceBudget(40, 120);
+    expect(renderedRows([group(TOKEN, 4000)], maxRows)).toBeLessThanOrEqual(maxRows);
+  });
+
+  it('bounds a wallet holding a huge number of tokens', () => {
+    const { maxRows } = balanceBudget(40, 120);
+    const groups = Array.from({ length: 900 }, (_, i) => group(`${i}`.padStart(64, '0'), 2));
+    expect(renderedRows(groups, maxRows)).toBeLessThanOrEqual(maxRows);
+  });
+
+  it('leaves a short wallet untouched', () => {
+    const { maxRows } = balanceBudget(40, 120);
+    expect(renderedRows([group(TOKEN, 2)], maxRows)).toBe(3); // header + 2 coins, no "more" line
+  });
+});
+
+describe('balanceBudget', () => {
+  it('keeps the three sections inside a normal terminal', () => {
+    const rows = 40;
+    const { maxRows } = balanceBudget(rows, 120);
+    expect(maxRows * 3).toBeLessThanOrEqual(rows);
+  });
+
+  it('still shows something on a terminal too short to fit the chrome', () => {
+    expect(balanceBudget(10, 80).maxRows).toBe(2);
+  });
+
+  it('keeps a token header off a second line at 80 columns', () => {
+    const { tokenWidth } = balanceBudget(40, 80);
+    // indent(4) + token + gap(2) + a wide amount + "  (1000 coins)"
+    const worstCase = 4 + tokenWidth + 2 + '1234567890.123456'.length + '  (1000 coins)'.length;
+    expect(worstCase).toBeLessThanOrEqual(80);
+  });
+
+  it('never pads a token id beyond its real length', () => {
+    expect(balanceBudget(40, 400).tokenWidth).toBeLessThanOrEqual(64);
+  });
+});


### PR DESCRIPTION
# Overview

The Wallet State view's coin lists were unbounded, so on a wallet holding many
coins the rendered frame grew taller than the terminal and Ink's redraw corrupted
— sections painting over one another. Observed while running against a chain with
real history, where a shielded wallet holds far more coins than a test wallet
does: the Unshielded and Dust sections printed lines like

```
▸ Unshielded Wallet
    Ba29ed4a053c1ec576e7f7684832c062bebc5cf67c0a4a9242f4defebd4b112b94  522  (1 coin)
```

— that section's `Balance` label with a token row on top of it.

**The cause is not formatting.** Ink renders a frame in full and has no viewport,
so a frame taller than the terminal corrupts its redraw and lines overwrite one
another. `components/Select.tsx` already documents exactly this failure ("makes
Ink collapse the two lines onto one") and windows its list against `stdout.rows`
to avoid it; `StateView` had no equivalent and emitted a row per token plus a row
per coin, without limit. `Label` pads with `padEnd` and never truncates, which is
what identifies the 2-character `Ba` as terminal overwrite rather than a
truncation bug — and why truncating the label would have fixed nothing.

## What changed

Each balance block is now bounded as a whole, with the remainder reported:

```
    Balance
      29ed4a05…4b112b94  522  (1 coin)
      … and 4,312 more
```

- **Bounded as a whole**, not per group. Volume arrives from either direction — a
  wallet with many tokens, or a token with many coins — and capping only the inner
  coin list leaves the outer one unbounded. Rows are flattened into one list so a
  single budget covers them, and neither shape can overflow.
- **The three sections split the terminal's spare height**, and the `… and N more`
  line is counted against the budget it belongs to.
- **Long token ids are middle-elided** to fit the width. Not cosmetic: at 80
  columns a full 64-character id wrapped the header onto a second line, costing
  two rows where the budget assumed one.
- **Dust had the same unbounded shape** and is fixed the same way, costing a
  deregistered coin as two rows since it renders its `dtime` on a second line.

The row arithmetic lives in `utils/` as `flattenBalanceRows`, `windowRows`,
`truncateMiddle` and `balanceBudget`, unit-tested without rendering Ink (16 new
tests). One of those tests caught a real off-by-3 in the column reserve during
development — the worst-case header overhead is 37 columns, not 34.

## Verification

- Full suite: 902 passed, 34 skipped, 0 failed
- `yarn build`: 6/6 tasks, compiled output confirmed to carry the change

Not verified: the live render. There is no Ink test renderer in the tree and this
PR does not add a dependency for one, so the evidence here is the row arithmetic
plus a clean typecheck. Worth a visual check on a wallet with a large coin count
before merge.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [x] Every non-merge, non-bot commit has a matching DCO `Signed-off-by` trailer
- [ ] All check jobs of the CI have succeeded <!-- not yet run at time of opening -->
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant) <!-- not relevant -->
- [x] Update documentation (if relevant) <!-- changeset added -->
- [x] No new todos introduced

## Links

Follow-ups noticed but deliberately left out of scope:

- `groupByToken` (`StateView.tsx`) is dead code — nothing calls it, and the
  comment above it claiming it "still serves the dust block" is wrong.
- The section budget is split evenly across all three sections. It could instead
  give an empty section's rows to a full one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
