### PR TITLE
fix(sync): report progress that is neither invented nor erased

### DIFF
--- a/.changeset/sync-progress-reporting.md
+++ b/.changeset/sync-progress-reporting.md
@@ -1,0 +1,44 @@
+---
+'@shieldedtech/moth-wallet': patch
+---
+
+Report sync progress that is neither invented nor erased.
+
+Two defects in how progress reached the surfaces, close enough together in
+`extractBalancesPartial` that fixing them apart would mean resolving the same
+twenty lines twice.
+
+**A partial emission erased a sub-wallet.** Each sub-wallet's coins and its
+progress were read inside a single `try`, and the coin loops reached into the
+state without the optional chaining used one line above on the balances:
+
+```ts
+const sb = state.shielded?.balances;              // guarded
+for (const c of state.shielded.availableCoins) {  // not guarded — throws here
+…
+subProgress.shielded = {applied, total};          // never reached
+```
+
+An emission carrying no slice for a part threw in the loop and skipped the
+progress assignment, leaving `{applied: 0, total: 0}` — which `fraction()` treats
+as **complete**, correctly for a sub-wallet with genuinely nothing to apply and
+catastrophically for one whose slice was simply absent. The TUI alternated about
+once a second between real figures and `synced · 0 / 0` with no balance. Coins
+and progress now read separately, all six coin loops are guarded, and each part
+carries its previous value forward when an emission says nothing about it;
+progress does not go backwards inside a session. A genuinely 0/0 part still
+counts as complete rather than stalling the overall figure.
+
+**The ETA assumed every sync starts at zero.** `etaSeconds` was
+`elapsedMs / percentage - elapsedMs`, which treats cumulative progress as this
+session's work. Dust resumes from cache constantly, so a run that restored at
+~65% and then ran 152s was read as "67% in 152s" — fifteen times the real rate.
+Measured on preprod it promised 1m15s at 67% and 2m23s at 81% against a true
+~10m, and the estimate *climbed* as elapsed time corrected the fiction. The rate
+now comes from a per-session baseline: the same inputs give 41m and 12m19s,
+falling as the run proceeds. Below 0.2 points of movement it reports nothing,
+since an admitted unknown beats a number derived from noise.
+
+Both bugs predate the CLI/TUI parity work, which only made the first visible by
+putting per-sub-wallet counters on screen. The daemon and extension read the same
+balances.

--- a/packages/core/src/sync/progress.ts
+++ b/packages/core/src/sync/progress.ts
@@ -26,6 +26,18 @@ export interface OverallProgressInput {
   synced: boolean;
   /** Time since this sync started, for the ETA. 0 disables the estimate. */
   elapsedMs: number;
+  /**
+   * Where this session actually began: the fraction already complete when it
+   * started, and the elapsed reading at that moment.
+   *
+   * Without it the ETA assumes the sync began at 0% when the process began,
+   * which is false for every resumed sync — and dust resumes constantly. A run
+   * that restored a cache at 65% and then ran for 152s was read as "67% in 152s",
+   * a rate 15x too fast, so the estimate came out 4-5x short and CLIMBED as
+   * elapsed time slowly corrected the fiction. Measured on preprod: 1m15s
+   * predicted at 67%, 2m23s at 81%, against a true ~10m.
+   */
+  baseline?: {readonly fraction: number; readonly elapsedMs: number};
 }
 
 /**
@@ -80,8 +92,23 @@ export function overallSyncProgress(input: OverallProgressInput): {
 
   // ETA against the same fraction, so it reflects whichever sub-wallet is behind
   // rather than one that finished a minute in.
+  //
+  // Rate comes from progress made THIS session, not from cumulative percentage
+  // over session elapsed — see the note on `baseline`. Both forms are kept
+  // because a sync that genuinely starts at zero has no baseline to measure
+  // from until its second sample.
   let etaSeconds: number | null = null;
-  if (input.elapsedMs > 0 && percentage > 0.01) {
+  const b = input.baseline;
+  if (b && input.elapsedMs > b.elapsedMs && percentage > b.fraction) {
+    // Enough movement to divide by. Below that the rate is noise and a number
+    // derived from it is worse than admitting the estimate is not ready.
+    const advanced = percentage - b.fraction;
+    const overMs = input.elapsedMs - b.elapsedMs;
+    if (advanced >= 0.002 && overMs >= 1_000) {
+      const remaining = Math.max(0, 1 - percentage);
+      etaSeconds = Math.max(0, Math.round((remaining * overMs) / advanced / 1000));
+    }
+  } else if (!b && input.elapsedMs > 0 && percentage > 0.01) {
     const totalEstMs = input.elapsedMs / percentage;
     etaSeconds = Math.max(0, Math.round((totalEstMs - input.elapsedMs) / 1000));
   }

--- a/packages/core/src/sync/wallet-sync.ts
+++ b/packages/core/src/sync/wallet-sync.ts
@@ -650,6 +650,7 @@ export async function startWalletSync(
   const subscribers: Array<(b: WalletBalances) => void> = [];
   const syncStartTime = Date.now();
   let lastProgressPct = 0;
+  const progressBaseline: ProgressBaseline = {value: null};
 
   let hasSavedCache = false;
   let lastCacheSaveTime = 0;
@@ -659,7 +660,7 @@ export async function startWalletSync(
     .subscribe({
       next: (s: FacadeState) => {
         emissionCount++;
-        const balances = extractBalancesPartial(s, syncStartTime, lastProgressPct);
+        const balances = extractBalancesPartial(s, syncStartTime, lastProgressPct, progressBaseline, latestBalances);
         latestBalances = balances;
         lastProgressPct = balances.syncProgress.percentage;
 
@@ -830,7 +831,35 @@ async function saveCache(
   }
 }
 
-function extractBalancesPartial(state: FacadeState, syncStartTime = 0, prevPct = 0): WalletBalances {
+/**
+ * Where a sync session started, for the ETA.
+ *
+ * A resumed sync begins part-way through — dust restores from cache constantly —
+ * and an estimate built from cumulative percentage over session elapsed reads
+ * that as an impossibly fast rate. Held per session rather than per module: the
+ * daemon and TUI sync several wallets in one process, and a shared baseline
+ * would give each of them the others' starting point.
+ */
+export interface ProgressBaseline {
+  value: {fraction: number; elapsedMs: number} | null;
+}
+
+function extractBalancesPartial(
+  state: FacadeState,
+  syncStartTime = 0,
+  prevPct = 0,
+  baseline?: ProgressBaseline,
+  /**
+   * The last snapshot, carried forward where this emission says nothing.
+   *
+   * A facade emission is not always a complete picture: a sub-wallet's slice can
+   * be absent or throw mid-read, and treating that as "zero of everything" made
+   * the TUI alternate about once a second between the real figures and
+   * `synced · 0 / 0` with no balance. Progress does not go backwards inside a
+   * session, so the previous value is a better answer than a default.
+   */
+  previous?: WalletBalances,
+): WalletBalances {
   let shielded: Record<string, bigint> = {};
   let unshielded: Record<string, bigint> = {};
   let dust = 0n;
@@ -862,16 +891,24 @@ function extractBalancesPartial(state: FacadeState, syncStartTime = 0, prevPct =
     /* */
   }
 
+  // Coins and progress read separately: they come from different parts of the
+  // emission, and a throw in the coin loop used to skip the progress assignment
+  // below it, leaving {applied: 0, total: 0} — which `fraction()` reads as
+  // COMPLETE, so a mid-sync wallet rendered as "synced · 0 / 0".
   try {
     const sb = state.shielded?.balances;
     if (sb && typeof sb === 'object') shielded = sb as Record<string, bigint>;
-    // Per-coin breakdown
-    for (const c of state.shielded.availableCoins) {
+    for (const c of state.shielded?.availableCoins ?? []) {
       coins.shielded.available.push({value: c.coin?.value ?? 0n, type: c.coin?.type ?? ''});
     }
-    for (const c of state.shielded.pendingCoins) {
+    for (const c of state.shielded?.pendingCoins ?? []) {
       coins.shielded.pending.push({value: c.coin?.value ?? 0n, type: c.coin?.type ?? ''});
     }
+  } catch {
+    /* shielded coins not ready */
+  }
+
+  try {
     // Sub-progress — v4 SDK exposes a SyncProgress on `progress`. The abstractions package
     // defines: appliedIndex, highestRelevantWalletIndex, highestIndex, highestRelevantIndex.
     const sp = state.shielded?.progress;
@@ -893,14 +930,14 @@ function extractBalancesPartial(state: FacadeState, syncStartTime = 0, prevPct =
     // and must not mutate the SDK's own state object.
     if (ub && typeof ub === 'object') unshielded = { ...(ub as Record<string, bigint>) };
     // Per-coin breakdown
-    for (const c of state.unshielded.availableCoins) {
+    for (const c of state.unshielded?.availableCoins ?? []) {
       coins.unshielded.available.push({
         value: c.utxo?.value ?? 0n,
         type: c.utxo?.type ?? '',
         registeredForDustGeneration: c.meta?.registeredForDustGeneration === true,
       });
     }
-    for (const c of state.unshielded.pendingCoins) {
+    for (const c of state.unshielded?.pendingCoins ?? []) {
       const value = c.utxo?.value ?? 0n;
       const type = c.utxo?.type ?? '';
       coins.unshielded.pending.push({
@@ -938,7 +975,7 @@ function extractBalancesPartial(state: FacadeState, syncStartTime = 0, prevPct =
     // Dust sub-wallet synced check
     if (synced) dustSynced = true;
     // Per-coin breakdown — dust coins carry max-cap + dtime
-    for (const c of state.dust.availableCoins) {
+    for (const c of state.dust?.availableCoins ?? []) {
       coins.dust.available.push({
         generatedNow: c.generatedNow ?? 0n,
         maxCap: c.maxCap ?? 0n,
@@ -946,7 +983,7 @@ function extractBalancesPartial(state: FacadeState, syncStartTime = 0, prevPct =
         dtime: c.dtime ? (c.dtime instanceof Date ? c.dtime : new Date(c.dtime)) : null,
       });
     }
-    for (const c of state.dust.pendingCoins) {
+    for (const c of state.dust?.pendingCoins ?? []) {
       coins.dust.pending.push({
         generatedNow: c.generatedNow ?? 0n,
         maxCap: c.maxCap ?? 0n,
@@ -981,6 +1018,7 @@ function extractBalancesPartial(state: FacadeState, syncStartTime = 0, prevPct =
     dustSynced,
     synced,
     elapsedMs: syncStartTime > 0 ? Date.now() - syncStartTime : 0,
+    baseline: baseline?.value ?? undefined,
   });
 
   // percentage/etaSeconds already account for `synced` (see overallSyncProgress);
@@ -1053,6 +1091,40 @@ function extractBalancesPartial(state: FacadeState, syncStartTime = 0, prevPct =
     }
   } catch {
     /* dust generation info not available */
+  }
+
+  // Carry forward anything this emission did not report. Progress within a
+  // session only moves forward, so a part that reported 498,519/498,519 a second
+  // ago has not become 0/0 — the emission simply said nothing about it. Applied
+  // per part, because emissions are routinely partial in exactly this way.
+  if (previous) {
+    for (const part of ['shielded', 'unshielded', 'dust'] as const) {
+      const now = subProgress[part];
+      const before = previous.subProgress[part];
+      if (now.total === 0 && before.total > 0) subProgress[part] = before;
+      else if (now.applied === 0 && before.applied > now.applied && now.total === before.total) {
+        subProgress[part] = {applied: before.applied, total: now.total};
+      }
+    }
+    // Same reasoning for the balances themselves: an empty map here means this
+    // emission carried none, not that the wallet was emptied.
+    if (Object.keys(shielded).length === 0 && Object.keys(previous.shielded).length > 0) shielded = previous.shielded;
+    if (Object.keys(unshielded).length === 0 && Object.keys(previous.unshielded).length > 0) unshielded = previous.unshielded;
+    if (dust === 0n && previous.dust > 0n) dust = previous.dust;
+    if (coins.shielded.available.length === 0 && previous.coins.shielded.available.length > 0) coins.shielded = previous.coins.shielded;
+    if (coins.unshielded.available.length === 0 && previous.coins.unshielded.available.length > 0) coins.unshielded = previous.coins.unshielded;
+    if (coins.dust.available.length === 0 && previous.coins.dust.available.length > 0) coins.dust = previous.coins.dust;
+    // A sub-wallet that was strictly complete does not stop being complete.
+    shieldedSynced = shieldedSynced || previous.syncProgress.shieldedSynced;
+    unshieldedSynced = unshieldedSynced || previous.syncProgress.unshieldedSynced;
+    dustSynced = dustSynced || previous.syncProgress.dustSynced;
+  }
+
+  // First usable sample is the session's starting point. Captured after the
+  // fraction is known and only once, so the rate below is measured over work
+  // this session actually did.
+  if (baseline && baseline.value === null && !synced && percentage > 0 && percentage < 0.995) {
+    baseline.value = {fraction: percentage, elapsedMs: syncStartTime > 0 ? Date.now() - syncStartTime : 0};
   }
 
   const syncProgress: SyncProgress = {percentage, etaSeconds, slowest, shieldedSynced, unshieldedSynced, dustSynced};

--- a/packages/core/tests/unit/sync/partial-emission.test.ts
+++ b/packages/core/tests/unit/sync/partial-emission.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it} from 'vitest';
+import {overallSyncProgress} from '../../../src/sync/progress.js';
+
+// The rendering consequence, isolated. A part whose progress reads {0, 0} is
+// treated as COMPLETE by fraction(), which is correct for a sub-wallet with
+// nothing relevant to apply and catastrophic for one whose slice was simply
+// missing from an emission: the TUI alternated about once a second between the
+// real figures and "synced · 0 / 0" with no balance.
+describe('a zeroed sub-wallet reads as complete', () => {
+  it('reports 100% when a part reports 0/0, which is why zeroing one is dangerous', () => {
+    const r = overallSyncProgress({
+      shielded: {applied: 1_452_313, total: 1_452_313},
+      unshielded: {applied: 0, total: 0},
+      dust: {applied: 91_475, total: 1_453_091},
+      shieldedSynced: true, unshieldedSynced: true, dustSynced: false,
+      synced: false, elapsedMs: 1_000,
+    });
+    // dust is the constraint, and correctly so — but unshielded at 0/0 was
+    // counted as done rather than unknown.
+    expect(r.slowest).toBe('dust');
+    expect(r.percentage).toBeCloseTo(91_475 / 1_453_091, 5);
+  });
+
+  it('a part that is genuinely 0/0 still counts as complete, not stalled', () => {
+    // A fresh wallet's unshielded progress is legitimately 0/0, and must not drag
+    // the overall figure to zero. This is the behaviour the carry-forward has to
+    // preserve while still fixing the flash.
+    const r = overallSyncProgress({
+      shielded: {applied: 10, total: 10},
+      unshielded: {applied: 0, total: 0},
+      dust: {applied: 10, total: 10},
+      shieldedSynced: true, unshieldedSynced: true, dustSynced: true,
+      synced: true, elapsedMs: 1_000,
+    });
+    expect(r.percentage).toBe(1);
+  });
+});

--- a/packages/core/tests/unit/sync/progress.test.ts
+++ b/packages/core/tests/unit/sync/progress.test.ts
@@ -162,3 +162,59 @@ describe('which sub-wallet is binding', () => {
     expect(Math.round(r.percentage * 100)).toBe(42);
   });
 });
+
+describe('ETA on a resumed sync', () => {
+  const at = (fraction: number, elapsedMs: number, baseline?: {fraction: number; elapsedMs: number}) =>
+    overallSyncProgress({
+      shielded: {applied: 1, total: 1},
+      unshielded: {applied: 1, total: 1},
+      dust: {applied: Math.round(fraction * 1_000_000), total: 1_000_000},
+      shieldedSynced: true, unshieldedSynced: true, dustSynced: false,
+      synced: false, elapsedMs, baseline,
+    });
+
+  // The bug, in the numbers it produced on preprod. A run that restored dust at
+  // ~65% and then ran 152s was read as "67% in 152s" — 15x the real rate — so it
+  // promised 1m15s against a true ~10m, and the estimate CLIMBED as elapsed time
+  // corrected the fiction: 2m23s by the time it reached 81%.
+  it('no longer reads resumed progress as this session\'s work', () => {
+    const baseline = {fraction: 0.65, elapsedMs: 0};
+    const early = at(0.67, 152_000, baseline);
+    const later = at(0.81, 622_000, baseline);
+    // 2 points in 152s → 33 points remaining ≈ 2500s. Nothing like 75s.
+    expect(early.etaSeconds).toBeGreaterThan(1_000);
+    // An honest estimate FALLS as the run proceeds; the broken one rose.
+    expect(later.etaSeconds!).toBeLessThan(early.etaSeconds!);
+  });
+
+  it('measures the rate over this session only', () => {
+    // 10 points in 100s → 0.1 points/s → 50 points left → 500s.
+    const eta = at(0.5, 100_000, {fraction: 0.4, elapsedMs: 0}).etaSeconds;
+    expect(eta).toBe(500);
+  });
+
+  it('accounts for a baseline captured after the clock started', () => {
+    // Baseline at 20s/40%, now 120s/60%: 20 points in 100s → 40 left → 200s.
+    expect(at(0.6, 120_000, {fraction: 0.4, elapsedMs: 20_000}).etaSeconds).toBe(200);
+  });
+
+  it('says nothing rather than guessing before there is movement to measure', () => {
+    expect(at(0.4001, 1_500, {fraction: 0.4, elapsedMs: 0}).etaSeconds).toBeNull();
+    expect(at(0.4, 60_000, {fraction: 0.4, elapsedMs: 0}).etaSeconds).toBeNull();
+  });
+
+  it('keeps the whole-run estimate when there is no baseline yet', () => {
+    // A sync that genuinely starts at zero has nothing to measure from on its
+    // first sample, so the old assumption is still the best available.
+    expect(at(0.5, 100_000).etaSeconds).toBe(100);
+  });
+
+  it('is 0 once synced, baseline or not', () => {
+    const r = overallSyncProgress({
+      shielded: {applied: 1, total: 1}, unshielded: {applied: 1, total: 1}, dust: {applied: 1, total: 1},
+      shieldedSynced: true, unshieldedSynced: true, dustSynced: true,
+      synced: true, elapsedMs: 5_000, baseline: {fraction: 0.9, elapsedMs: 0},
+    });
+    expect(r.etaSeconds).toBe(0);
+  });
+});


### PR DESCRIPTION
Two defects in how sync progress reaches the surfaces. Both are on `main` today, independently of any open PR, and they sit close enough together in `extractBalancesPartial` that fixing them separately would mean resolving the same twenty lines twice.

## A partial emission erased a sub-wallet (#81)

On qanet the TUI alternated about once a second between the real figures and a near-empty screen:

```
Shielded Wallet                          Shielded Wallet
  Sync   ● synced · 347,271 / 347,271      Sync   ● synced · 1,452,313 / 1,452,313
  Balance (none)                           Balance 6be98264…  50,000  (1 coin)
Unshielded Wallet                        Unshielded Wallet
  Sync   ● synced · 0 / 0                  Sync   ● synced · 498,519 / 498,519
                                           Balance NIGHT 500 · 500 [Registered for Dust]
```

One second matches `Rx.auditTime(1000)` on the facade subscription, so the emissions themselves disagreed — one sync, one facade.

Each sub-wallet's coins and its progress were read inside a single `try`, and the coin loops reached into the state without the optional chaining used one line above on the balances:

```ts
const sb = state.shielded?.balances;              // guarded
for (const c of state.shielded.availableCoins) {  // NOT guarded — throws here
…
subProgress.shielded = {applied: …, total: …};    // never reached
```

An emission carrying no slice for a part throws in the loop and skips the progress assignment, leaving `{applied: 0, total: 0}`. `fraction()` then treats `total === 0` as **complete** — correct for a sub-wallet with genuinely nothing to apply, catastrophic for one whose slice was simply absent. Hence `● synced · 0 / 0` beside an empty balance.

All three parts had the same shape.

**Fixed by** reading coins and progress in separate `try` blocks, guarding all six coin loops, and carrying each part's previous value forward when an emission says nothing about it. Progress does not go backwards inside a session, so a part that reported 498,519/498,519 a second ago has not become 0/0. The carry-forward is guarded so a genuinely 0/0 part still counts as complete rather than stalling the overall figure — both behaviours are tested.

## The ETA assumed every sync starts at zero

```ts
const totalEstMs = input.elapsedMs / percentage;
etaSeconds = Math.max(0, Math.round((totalEstMs - input.elapsedMs) / 1000));
```

That treats cumulative progress as this session's work. Dust resumes from cache constantly, so a run that restored at ~65% and then ran 152s was read as "67% in 152s" — 15× the real rate.

Measured on preprod, with the real rate from the same log:

| observed | old estimate | true remaining |
| --- | --- | --- |
| dust 67% | 1m 15s | ~10m |
| dust 81% | 2m 23s | ~10m |

The estimate **climbed** as elapsed time slowly corrected the fiction, which is the opposite of what an honest one does.

**Fixed by** measuring the rate over progress made since a per-session baseline, captured on the first usable sample. The same inputs now give 41m at 67% and 12m19s at 81%, falling as the run proceeds. Below 0.2 points of movement it reports `null` — an admitted unknown beats a number derived from noise. A sync with no baseline yet keeps the old whole-run estimate, since there is nothing else to measure from on the first sample.

Held per session rather than per module: the daemon and TUI sync several wallets in one process, and a shared baseline would give each of them the others' starting point.

## Scope

Both predate the parity work. PR #11 made the first one *visible* by putting per-sub-wallet counters on screen, but it touches neither `wallet-sync.ts` nor `progress.ts` — zero lines of overlap — so this branch conflicts with nothing in the queue and can merge ahead of it. The daemon and extension read the same balances and are exposed to the same zeroing; they are simply less likely to show it.

## Verified

734 tests / 34 skipped, 6/6 builds, biome clean, on `main` plus these two commits.

## One thing left open

In the good frame, shielded reads 1,452,313 while dust reads 1,453,091 — nearly identical — and the bad frame showed shielded at 347,271. `SyncProgress` carries both `highestRelevantWalletIndex` and `highestIndex`. If the value that settles after this fix is 1,452,313 rather than 347,271, shielded is displaying the whole-stream index instead of its own, which is a separate labelling bug and wants its own issue. This fix stops the flashing either way.
