### PR TITLE
fix(cli): show what a transfer can actually spend

### DIFF
--- a/.changeset/spendable-balance.md
+++ b/.changeset/spendable-balance.md
@@ -1,0 +1,34 @@
+---
+'@shieldedtech/moth-wallet': patch
+---
+
+Show what a transfer can actually spend.
+
+A synced wallet reported 500 NIGHT and refused a 10 NIGHT transfer with
+`Insufficient funds`. Both figures were true and neither was reconcilable from
+outside the wallet.
+
+The displayed balance counts coins reserved by transactions in flight, and does
+so deliberately — dropping them flashes the balance to zero mid-send. But the SDK
+spends from `availableUtxos` alone, so the number shown was never the number that
+could be spent, and nothing surfaced the difference.
+
+`moth balance` now prints the split when anything is reserved, and stays quiet
+otherwise:
+
+```
+NIGHT:
+  unshielded: 500.000000  (500000000 STARS)
+    available:  0.000000  ← what a transfer can use
+    reserved:   500.000000  (a transaction in flight holds these)
+```
+
+JSON gains `unshieldedAvailable` and `unshieldedReserved` beside the existing
+fields, so nothing reading it today breaks. The transfer's insufficient-funds
+path names the number that blocked it, and says nothing when a reservation was
+not the cause.
+
+Nothing new is computed — `WalletBalances.coins` already carried the split.
+
+This makes the state visible; it does not stop reservations outliving their
+transactions. A wallet already in that state still needs its sync cache cleared.

--- a/packages/cli/src/commands/balance.ts
+++ b/packages/cli/src/commands/balance.ts
@@ -10,6 +10,7 @@ import {Flags} from '@oclif/core';
 import {BaseCommand} from '../base-command.js';
 import {getPassphrase} from '../adapters/passphrase.js';
 import {
+  unshieldedSplit,
   startWalletSync,
   NIGHT_TOKEN_ID,
   NIGHT_DENOMINATION,
@@ -28,6 +29,14 @@ interface BalanceResult {
       readonly shielded: string; // raw STARS
       readonly total: string; // raw STARS
       readonly totalDecimal: string; // major units, formatted
+      /**
+       * What a transfer can actually use. The figures above count coins
+       * reserved by transactions in flight, because dropping them would flash
+       * the balance to zero mid-send — but the SDK spends from available coins
+       * alone, so a wallet can report a balance it cannot spend (#72).
+       */
+      readonly unshieldedAvailable: string; // raw STARS
+      readonly unshieldedReserved: string; // raw STARS
     };
     readonly dust: string; // raw SPECK
     readonly otherTokens: ReadonlyArray<{
@@ -87,6 +96,8 @@ export default class Balance extends BaseCommand {
         otherTokens.push({tokenId, type: 'shielded', amount: amount.toString()});
       }
 
+      const split = unshieldedSplit(b.coins, NIGHT_TOKEN_ID);
+
       const result: BalanceResult = {
         wallet: walletName,
         network: network.id,
@@ -97,6 +108,8 @@ export default class Balance extends BaseCommand {
             shielded: shNight.toString(),
             total: totalNight.toString(),
             totalDecimal: formatBalance(totalNight, NIGHT_DENOMINATION),
+            unshieldedAvailable: split.available.toString(),
+            unshieldedReserved: split.reserved.toString(),
           },
           dust: b.dust.toString(),
           otherTokens,
@@ -114,6 +127,12 @@ export default class Balance extends BaseCommand {
       this.log('');
       this.log('NIGHT:');
       this.log(`  unshielded: ${formatBalance(unshNight, NIGHT_DENOMINATION)}  (${unshNight.toString()} STARS)`);
+      // Only when it matters. On a wallet with nothing reserved this line is
+      // noise; on one that cannot spend what it shows, it is the whole story.
+      if (split.reserved > 0n) {
+        this.log(`    available:  ${formatBalance(split.available, NIGHT_DENOMINATION)}  ← what a transfer can use`);
+        this.log(`    reserved:   ${formatBalance(split.reserved, NIGHT_DENOMINATION)}  (a transaction in flight holds these)`);
+      }
       this.log(`  shielded:   ${formatBalance(shNight, NIGHT_DENOMINATION)}  (${shNight.toString()} STARS)`);
       this.log(`  total:      ${formatBalance(totalNight, NIGHT_DENOMINATION)}  (${totalNight.toString()} STARS)`);
       this.log('');

--- a/packages/cli/src/commands/transfer.ts
+++ b/packages/cli/src/commands/transfer.ts
@@ -2,6 +2,10 @@ import { Args, Flags } from '@oclif/core';
 import { BaseCommand } from '../base-command.js';
 import { getPassphrase } from '../adapters/passphrase.js';
 import {
+  describeReservation,
+  unshieldedSplit,
+  formatBalance,
+  NIGHT_DENOMINATION,
   sendTokensWithKeys,
   startWalletSync,
   NIGHT_TOKEN_ID,
@@ -145,9 +149,30 @@ export default class Transfer extends BaseCommand {
         to,
       };
 
-      const txHash = await sendTokensWithKeys(syncedWallet.facade, wallet.walletKeys, network.id, [req], (stage) => {
-        process.stderr.write(`Transfer: ${stage}\n`);
-      });
+      let txHash: string;
+      try {
+        txHash = await sendTokensWithKeys(syncedWallet.facade, wallet.walletKeys, network.id, [req], (stage) => {
+          process.stderr.write(`Transfer: ${stage}\n`);
+        });
+      } catch (err) {
+        // "Insufficient funds" on a wallet that just reported a sufficient
+        // balance is not a contradiction: the balance counts coins reserved by
+        // transactions in flight, and only available coins can be spent (#72).
+        // Say which number blocked it rather than leaving the two irreconcilable.
+        const message = err instanceof Error ? err.message : String(err);
+        if (/insufficient funds/i.test(message)) {
+          const split = unshieldedSplit(syncedWallet.balances.coins, tokenId);
+          const detail = describeReservation(split, amount, (raw) =>
+            isNight ? `${formatBalance(raw, NIGHT_DENOMINATION)} NIGHT` : `${raw} base units`,
+          );
+          if (detail) {
+            this.outputError('WALLET_ERROR', `Insufficient available funds. ${detail}`);
+            this.exit(1);
+            return;
+          }
+        }
+        throw err;
+      }
 
       this.outputSuccess({
         txHash,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -148,3 +148,4 @@ export {
   type AuditDecision, type AuditLogOptions,
   type ApiKeyRecord, type ApiKeyGenerated, type ApiKeyAuthResult,
 } from './daemon/index.js';
+export { unshieldedSplit, describeReservation, type SpendableSplit } from './wallet/spendable.js';

--- a/packages/core/src/wallet/spendable.ts
+++ b/packages/core/src/wallet/spendable.ts
@@ -1,0 +1,55 @@
+// What a wallet can actually spend, as opposed to what it holds.
+//
+// The displayed balance counts pending coins on purpose: a send or a DUST
+// registration reserves its own NIGHT UTxOs while the transaction is in flight,
+// and dropping them from the total would flash the balance to zero mid-operation
+// (see the note at wallet-sync.ts:1004). But the SDK spends from availableUtxos
+// alone, so the displayed figure is not the spendable one — and when a reserved
+// transfer never settles, a wallet reports its full balance and can spend none
+// of it.
+//
+// Nothing here computes anything new. `WalletBalances.coins` already carries the
+// split; this only adds it up, so both numbers can be shown side by side rather
+// than one of them being discovered through a failed transfer.
+
+import type {WalletCoinDetails} from '../sync/wallet-sync.js';
+
+export interface SpendableSplit {
+  /** Sum of available (immediately spendable) coins of this token. */
+  readonly available: bigint;
+  /** Sum reserved by transactions in flight — counted in the balance, not spendable. */
+  readonly reserved: bigint;
+  /** available + reserved: the figure `balance` has always shown. */
+  readonly total: bigint;
+}
+
+/** Unshielded split for one token id. */
+export function unshieldedSplit(coins: WalletCoinDetails, tokenId: string): SpendableSplit {
+  const sum = (list: ReadonlyArray<{value: bigint; type: string}>) =>
+    list.reduce((acc, c) => (c.type === tokenId ? acc + c.value : acc), 0n);
+  const available = sum(coins.unshielded.available);
+  const reserved = sum(coins.unshielded.pending);
+  return {available, reserved, total: available + reserved};
+}
+
+/**
+ * A sentence for the case where a wallet holds enough but can spend too little.
+ *
+ * Returns null when the shortfall is not a reservation problem, so callers can
+ * fall through to the plain message rather than explaining something untrue.
+ */
+export function describeReservation(
+  split: SpendableSplit,
+  wanted: bigint,
+  format: (raw: bigint) => string,
+): string | null {
+  if (split.reserved === 0n) return null;
+  if (split.available >= wanted) return null;
+  return (
+    `${format(split.total)} held, ${format(split.available)} available — ` +
+    `${format(split.reserved)} is reserved by a transaction still in flight. ` +
+    'A transfer can only spend the available part. Reservations clear when that ' +
+    'transaction settles; if it never will, clearing the wallet\'s sync cache ' +
+    'drops them and re-reads the chain.'
+  );
+}

--- a/packages/core/tests/unit/wallet/spendable.test.ts
+++ b/packages/core/tests/unit/wallet/spendable.test.ts
@@ -1,0 +1,71 @@
+import {describe, expect, it} from 'vitest';
+import {describeReservation, unshieldedSplit} from '../../../src/wallet/spendable.js';
+import type {WalletCoinDetails} from '../../../src/sync/wallet-sync.js';
+
+const NIGHT = '0'.repeat(64);
+const OTHER = 'a'.repeat(64);
+const coin = (value: bigint, type = NIGHT) => ({value, type, registeredForDustGeneration: false});
+
+const details = (available: bigint[], pending: bigint[], type = NIGHT): WalletCoinDetails => ({
+  shielded: {available: [], pending: []},
+  dust: {available: [], pending: []},
+  unshielded: {
+    available: available.map((v) => coin(v, type)),
+    pending: pending.map((v) => coin(v, type)),
+  },
+}) as WalletCoinDetails;
+
+const fmt = (raw: bigint) => `${raw} STARS`;
+
+describe('unshieldedSplit', () => {
+  it('separates what can be spent from what is reserved', () => {
+    const split = unshieldedSplit(details([100n, 50n], [300n]), NIGHT);
+    expect(split).toEqual({available: 150n, reserved: 300n, total: 450n});
+  });
+
+  // The case that cost an hour of misdiagnosis: 500 NIGHT reported, none of it
+  // spendable, and both numbers true.
+  it('reports zero available when everything is reserved', () => {
+    const split = unshieldedSplit(details([], [500_000_000n]), NIGHT);
+    expect(split.available).toBe(0n);
+    expect(split.total).toBe(500_000_000n);
+  });
+
+  it('counts only the token asked about', () => {
+    const mixed: WalletCoinDetails = {
+      shielded: {available: [], pending: []},
+      dust: {available: [], pending: []},
+      unshielded: {available: [coin(10n, NIGHT), coin(99n, OTHER)], pending: []},
+    } as WalletCoinDetails;
+    expect(unshieldedSplit(mixed, NIGHT).available).toBe(10n);
+    expect(unshieldedSplit(mixed, OTHER).available).toBe(99n);
+  });
+
+  it('is all zeroes for a wallet with no coins', () => {
+    expect(unshieldedSplit(details([], []), NIGHT)).toEqual({available: 0n, reserved: 0n, total: 0n});
+  });
+});
+
+describe('describeReservation', () => {
+  it('explains the shortfall when a reservation caused it', () => {
+    const msg = describeReservation({available: 0n, reserved: 500n, total: 500n}, 10n, fmt);
+    expect(msg).toContain('500 STARS held');
+    expect(msg).toContain('0 STARS available');
+    expect(msg).toContain('reserved');
+  });
+
+  // Staying quiet matters as much as speaking: explaining a reservation that is
+  // not the cause sends the reader after the wrong thing.
+  it('says nothing when nothing is reserved', () => {
+    expect(describeReservation({available: 5n, reserved: 0n, total: 5n}, 10n, fmt)).toBeNull();
+  });
+
+  it('says nothing when the available part already covers the amount', () => {
+    // Reserved coins exist, but they are not why this failed.
+    expect(describeReservation({available: 100n, reserved: 50n, total: 150n}, 10n, fmt)).toBeNull();
+  });
+
+  it('speaks when the total covers it but the available part does not', () => {
+    expect(describeReservation({available: 5n, reserved: 100n, total: 105n}, 10n, fmt)).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #72.

## What it looked like

A synced wallet reporting 500 NIGHT, refusing a 10 NIGHT transfer:

```
02:38:47  ● synced — NIGHT: 500.000000, DUST: 2,500
          Transfer: building
          {"error":{"category":"WALLET_ERROR","message":"Insufficient funds","code":1}}
```

`moth balance --output json` seconds earlier, for the same wallet:

```json
{"synced": true, "balances": {"night": {"unshielded": "500000000", "totalDecimal": "500"}}}
```

Both true. The wallet held 500 NIGHT and could spend none of it.

## Why

The displayed balance counts pending coins, deliberately — `wallet-sync.ts:911`:

> Count booked inputs toward the displayed balance. A send or DUST registration reserves its own NIGHT UTxOs (moved available→pending) while the transaction is in flight, then they settle back to the wallet on apply — so leaving them out flashes the balance down to zero mid-registration.

Sound reasoning. But the SDK spends from `availableUtxos` alone —
`wallet-sdk-unshielded-wallet/dist/v1/CoinsAndBalances.js:22`, reached from `#balanceSegment`, which is where the throw originates. So `balance` shows available + pending while `transfer` can use available alone, and nothing surfaced the split. From outside the wallet the two outputs were irreconcilable, and the natural conclusion — "the sync is wrong" — sends you somewhere else entirely. It cost an hour of misdiagnosis on the e2e harness, where it looked like a pre-seed fault.

## The change

`balance` prints the split, and only when there is something to report — on a wallet with nothing reserved these lines would be noise:

```
NIGHT:
  unshielded: 500.000000  (500000000 STARS)
    available:  0.000000  ← what a transfer can use
    reserved:   500.000000  (a transaction in flight holds these)
```

JSON gains `unshieldedAvailable` and `unshieldedReserved` beside the existing fields, so nothing reading it today breaks.

The transfer's insufficient-funds path names the number that blocked it:

> Insufficient available funds. 500 NIGHT held, 0 NIGHT available — 500 NIGHT is reserved by a transaction still in flight. A transfer can only spend the available part. Reservations clear when that transaction settles; if it never will, clearing the wallet's sync cache drops them and re-reads the chain.

It stays silent when a reservation is not the cause — `describeReservation` returns null when nothing is reserved, or when the available part already covered the amount, so it cannot send a reader after the wrong thing. Two of the eight tests exist for that.

Nothing new is computed: `WalletBalances.coins` already carried the split, `balance` simply never surfaced it.

## Scope

The bug is on `main` today, independent of every open PR, so this branch is off `main` and conflicts with nothing.

It does not stop reservations outliving their transactions — that is **#73**, filed separately because reverting needs care about which failures may still have reached the chain. A wallet already in that state still needs its sync cache cleared.

## Verified

734 tests / 34 skipped, 6/6 builds, biome clean.
