### PR TITLE
fix(tui): stop the sync before freeing the keys on quit

### DIFF
--- a/.changeset/tui-quit-race.md
+++ b/.changeset/tui-quit-race.md
@@ -1,0 +1,33 @@
+---
+'@shieldedtech/moth-wallet': patch
+---
+
+Stop the sync before freeing the keys when the TUI quits.
+
+Quitting printed a wall of WASM errors over the exiting terminal, once per live
+sync:
+
+```
+Wallet.Other: Error while applying sync update
+  cause: Error: Dust secret key was cleared
+    at DustLocalState.replayEventsWithChanges
+```
+
+The quit handler called `lockAll()` and then `exit()`, zeroing the
+`DustSecretKey` in the WASM heap while the dust sync was still mid-batch. The
+only `stop()` lived in an unmount cleanup, ran after `exit()`, and was
+fire-and-forget, so the sync's next batch reached for a key that no longer
+existed.
+
+`useBalance` now exposes an awaited `stop()` — unsubscribe, await the facade's
+stop, bounded by a timeout so a sync that will not settle cannot keep the TUI
+open — and both quit paths await it before locking.
+
+Nothing was corrupted: the wallet was exiting and its state was already
+persisted. It simply looked like a crash every time, and would have buried a real
+error.
+
+The non-quit unmount path (Ctrl-C, a crash, the process ending) now stops before
+locking as well, which narrows the window rather than closing it — a React
+cleanup cannot await, so a batch already inside the WASM call can still find the
+key gone.

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -152,8 +152,33 @@ export function App({ networkId: networkIdProp }: AppProps) {
 
   useEffect(() => { persistSettings(); }, [persistSettings]);
 
+  // Quitting frees key material, and the sync must be stopped first: lockAll()
+  // zeroes the dust secret key in WASM, and a dust batch still in flight then
+  // throws `Dust secret key was cleared` from replayEventsWithChanges — once per
+  // live facade, printed over the exiting terminal. Bounded so a sync that will
+  // not settle cannot keep the TUI open.
+  const quit = useCallback(() => {
+    void (async () => {
+      try {
+        await balance.stop();
+      } catch {
+        /* stopping is best-effort; exiting is not optional */
+      }
+      wallet.lockAll();
+      exit();
+    })();
+  }, [balance, wallet, exit]);
+
   useEffect(() => {
-    return () => { wallet.lockAll(); };
+    // Unmount that did not come through `quit` — Ctrl-C, a crash, the process
+    // ending. Ask the sync to stop before freeing the keys. It cannot be awaited
+    // in a cleanup, so this narrows the window rather than closing it: a batch
+    // already inside the WASM call can still find the key gone. The explicit
+    // quit path awaits properly.
+    return () => {
+      void balance.stop().catch(() => {});
+      wallet.lockAll();
+    };
   }, [wallet.lockAll]);
 
   // Onboarding handler — fired by the wizard's final step. Uses a ref so
@@ -260,7 +285,7 @@ export function App({ networkId: networkIdProp }: AppProps) {
       return;
     }
     if (!key.meta) return;
-    if (input === 'q') { wallet.lockAll(); exit(); return; }
+    if (input === 'q') { quit(); return; }
     if (input === 'p') { setPaused(p => !p); logs.info(paused ? 'Resumed' : 'Paused'); return; }
   });
 
@@ -307,7 +332,7 @@ export function App({ networkId: networkIdProp }: AppProps) {
         coins={balance.coins}
         subProgress={balance.subProgress}
         unreadLogs={unreadLogs}
-        onQuit={() => { wallet.lockAll(); exit(); }}
+        onQuit={quit}
         onViewLogs={() => setLastLogsSeen(logs.count)}
         renderSend={(onBack) => (
           <Send wallet={walletState}

--- a/packages/tui/src/hooks/useBalance.ts
+++ b/packages/tui/src/hooks/useBalance.ts
@@ -152,5 +152,28 @@ export function useBalance(
 
   const getFacade = useCallback(() => syncRef.current?.facade ?? null, []);
 
-  return { ...state, refresh, getFacade };
+  /**
+   * Stop syncing and wait for it, before anything frees the keys.
+   *
+   * Quitting called `lockAll()` and `exit()` immediately, which zeroed the dust
+   * secret key in WASM while the dust sync was still mid-batch. The next
+   * `replayEventsWithChanges` then threw `Dust secret key was cleared`, once per
+   * live facade, over the top of the exiting terminal.
+   *
+   * Bounded, because quitting must not hang on a sync that will not settle: after
+   * the deadline it gives up and lets the caller proceed. A key freed under a
+   * still-running sync is noisy; a TUI that will not close is worse.
+   */
+  const stop = useCallback(async (timeoutMs = 3_000): Promise<void> => {
+    if (unsubRef.current) { unsubRef.current(); unsubRef.current = null; }
+    const synced = syncRef.current;
+    syncRef.current = null;
+    if (!synced) return;
+    await Promise.race([
+      synced.stop().catch(() => {}),
+      new Promise<void>((resolve) => setTimeout(resolve, timeoutMs).unref?.()),
+    ]);
+  }, []);
+
+  return { ...state, refresh, getFacade, stop };
 }


### PR DESCRIPTION
Fixes #80.

Quitting the TUI printed a wall of WASM errors over the exiting terminal:

```
Wallet.Other: Error while applying sync update
  cause: Error: Dust secret key was cleared
    at DustLocalState.replayEventsWithChanges (midnight_ledger_wasm_bg.js:3316)
    at applyEventsWithChanges (wallet-sdk-dust-wallet/dist/v1/CoreWallet.js:53)
    at applyUpdate (wallet-sdk-dust-wallet/dist/v1/Sync.js:150)
```

repeated once per live sync.

## Why

```ts
if (input === 'q') { wallet.lockAll(); exit(); return; }
```

`lockAll()` zeroes the key material immediately, including the `DustSecretKey` in the WASM heap. The dust sync is still running: the only `stop()` lived in `useBalance`'s unmount cleanup, ran after `exit()`, and was fire-and-forget —

```ts
if (syncRef.current) { syncRef.current.stop().catch(() => {}); syncRef.current = null; }
```

— so the sync's next batch called `replayEventsWithChanges` with a key that no longer existed.

It repeated because facades accumulate across network switches. A session that visited devnet, preprod and qanet logs three `startWalletSync begin` lines for one wallet, and each live facade produced its own copy.

Nothing is corrupted: the wallet is exiting and its state was already persisted. But it looks like a crash on every quit, and would bury a real error if one were there.

## The change

`useBalance` exposes an awaited `stop()` — unsubscribe, `await synced.stop()`, bounded by a 3-second timeout so a sync that will not settle cannot keep the TUI open. Both quit sites go through one `quit()` that awaits it before `lockAll()` and `exit()`.

## What this does not fix

The non-quit unmount path — Ctrl-C, a crash, the process ending — now fires `stop()` before `lockAll()`, which narrows the window without closing it. A React cleanup cannot await, so a batch already inside the WASM call can still find the key gone. Closing that properly needs either a shutdown flag the sync checks before applying, or an SDK that treats a cleared key as "stop" rather than an error. Recorded in the issue rather than papered over.

## Worth a separate look

The accumulation itself. `startSync` stops the previous sync before starting a new one, yet the log shows three `startWalletSync begin` lines for one wallet across three networks in a session. If those facades really are all still live it is a leak, and three concurrent dust syncs would also explain sync feeling slower than it should. Noted in #80 as needing confirmation rather than assumed.

## Scope

The bug is on `main` today — same two quit handlers, same fire-and-forget stop — so this branch is off `main` and conflicts with nothing.

## Verified

726 tests / 34 skipped, 6/6 builds, biome clean.
