### PR TITLE
feat(network): replace the local network with undeployed everywhere

### DIFF
--- a/.changeset/undeployed-network-option.md
+++ b/.changeset/undeployed-network-option.md
@@ -1,0 +1,43 @@
+---
+'@shieldedtech/moth-wallet': minor
+---
+
+**`undeployed` replaces `local` as the local devnet network.** Every interface now
+offers it, including the extension, which could not select it before.
+
+The two were duplicate presets for the same thing. `undeployed` is the id the
+Midnight tooling, `docs/TESTING.md`, and this repo's own README instructions all
+use for the local stack, and it points at the node port that stack listens on —
+`9944`. `local` pointed at `9933`, which nothing in the documented stack serves,
+so selecting **Local** in the extension connected to a closed port. It has been
+that way since the first commit.
+
+`local` was kept out of the extension's picker by a comment claiming the wallet
+could not derive addresses for `undeployed`. That was false: `mn_addr_undeployed1…`,
+`mn_dust_undeployed1…` and `mn_shield-addr_undeployed1…` have always derived, and
+`address-parity`'s network loop stopping at `qanet` is why nothing contradicted it.
+The loop now covers `undeployed` and `stagenet`, and a new test holds
+`SUPPORTED_NETWORKS` equal to the keys of `DEFAULT_NETWORKS`, so a preset no
+interface can reach — or an offered network with no preset — fails the suite.
+
+**Breaking, with a migration.** `local` is gone from `SUPPORTED_NETWORKS` and
+`DEFAULT_NETWORKS`, and the extension rejects it on save. Read paths resolve it via
+`canonicalNetworkId`, exported from core: the extension's stored selection, a
+wallet's meta record, the TUI's `lastNetwork`, `--network local`, and
+`createMothBrowser({ network: 'local' })` all continue to work and land on
+`undeployed`. Per-network birthdays and endpoint overrides move across with it, so
+a migrated wallet keeps its pre-seed shortcut instead of resyncing from genesis.
+Stored records are rewritten lazily, only when something else is already saving
+them. `local` stays in `ALL_NETWORKS` so addresses already handed out still resolve.
+
+Sync caches are keyed by network, so a migrated account resyncs once under the new
+key — correct, since the node URL genuinely changes — and its old entries are left
+behind rather than cleaned up.
+
+Also fixed alongside: the four localhost indexer fallbacks pointed at
+`http://localhost:8088` without the `/api/v4/graphql` path the indexer client posts
+queries to, and the README's network table listed `devnet` as localhost, omitted
+`undeployed`, and gave qanet hostnames (`rpc.qanet.dev.midnight.network`) that do
+not resolve. Mainnet stays out of both the table and the `--network` reference:
+the CLI refuses it and the extension keeps it out of the picker, so documenting
+its endpoints only invites someone to try.

--- a/README.md
+++ b/README.md
@@ -545,10 +545,15 @@ const prover = new ProofClient('http://localhost:6300');
 
 | Network | Node | Indexer | Proof Server |
 |---------|------|--------|--------------|
-| devnet | `ws://localhost:9944` | `http://localhost:8088` | `http://localhost:6300` |
+| devnet | `https://rpc.devnet.midnight.network` | `https://indexer.devnet.midnight.network/api/v4/graphql` | `http://localhost:6300` |
 | preview | `https://rpc.preview.midnight.network` | `https://indexer.preview.midnight.network/api/v4/graphql` | `http://localhost:6300` |
 | preprod | `https://rpc.preprod.midnight.network` | `https://indexer.preprod.midnight.network/api/v4/graphql` | `http://localhost:6300` |
-| qanet | `https://rpc.qanet.dev.midnight.network` | `https://indexer.qanet.dev.midnight.network/api/v4/graphql` | `http://localhost:6300` |
+| qanet | `https://rpc.qanet.midnight.network` | `https://indexer.qanet.midnight.network/api/v4/graphql` | `http://localhost:6300` |
+| undeployed | `ws://localhost:9944` | `http://localhost:8088/api/v4/graphql` | `http://localhost:6300` |
+
+`undeployed` is the local devnet stack — see [§2. Fund the Wallet](#2-fund-the-wallet-local-devnet-only) for bringing one up.
+
+Mainnet is deliberately absent. Moth is an unaudited reference wallet for development and testing, so it is not a network to use it on: the CLI refuses to run against mainnet, and the extension keeps it out of the picker.
 
 Default network is `devnet`. Endpoints can be overridden at multiple levels (highest precedence first):
 

--- a/docs/spec/wallet-service/COMMANDS.md
+++ b/docs/spec/wallet-service/COMMANDS.md
@@ -46,7 +46,7 @@ Every command accepts these. Defaults shown.
 | Flag | Short | Default | Purpose |
 |---|---|---|---|
 | `--output` | `-o` | `text` | `text` or `json` |
-| `--network` | `-n` | `devnet` | One of `mainnet`, `devnet`, `preview`, `preprod`, `qanet`, `local`. (`undeployed` also has a built-in preset for the local dev stack, but the wallet can't derive addresses for it, so it isn't a first-class network choice.) See [01-architecture.md §5](./01-architecture.md). |
+| `--network` | `-n` | `devnet` | One of `devnet`, `preview`, `preprod`, `qanet`, `undeployed`. `undeployed` is the local devnet stack (node on `9944`, indexer on `8088`). Not restricted to that list — endpoints are overridable, so a custom id is a valid target and gets the localhost defaults. `local` was an earlier name for `undeployed` and still resolves to it. `mainnet` parses but every command refuses it: Moth is unaudited and not for real funds. |
 | `--wallet` | `-w` | active | Wallet name from `~/.moth/wallets/` |
 | `--verbose` | `-v` | off | Debug output to stderr |
 | `--timeout` | `-t` | varies | Per-op timeout (seconds) |

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -46,6 +46,7 @@ export { ProofClient } from '@shieldedtech/moth-wallet/proof/client';
 export { WalletError, NetworkError, ProofError } from '@shieldedtech/moth-wallet/types/errors';
 export { ExitCode } from '@shieldedtech/moth-wallet/types/exit-codes';
 export {
+  canonicalNetworkId,
   DEFAULT_NETWORKS,
   SUPPORTED_NETWORKS,
   serverProver,
@@ -94,6 +95,7 @@ export {
 export type { SwapInput, WalletKeys } from '@shieldedtech/moth-wallet/sync/operations';
 
 import {
+  canonicalNetworkId,
   DEFAULT_NETWORKS,
   resolveProverConfig,
   serverProver,
@@ -130,12 +132,14 @@ export interface MothBrowserConfig {
  * ```
  */
 export function createMothBrowser(config: MothBrowserConfig = {}) {
-  const networkId = config.network ?? 'mainnet';
+  const networkId = canonicalNetworkId(config.network ?? 'mainnet');
 
   const base = DEFAULT_NETWORKS[networkId] ?? {
     id: networkId,
     nodeUrl: 'ws://localhost:9944',
-    indexerUrl: 'http://localhost:8088',
+    // The GraphQL path is part of the endpoint, not decoration: the indexer
+    // client posts queries to it, and the bare origin is not a GraphQL endpoint.
+    indexerUrl: 'http://localhost:8088/api/v4/graphql',
     prover: serverProver(),
   };
 

--- a/packages/cli/src/base-command.ts
+++ b/packages/cli/src/base-command.ts
@@ -6,6 +6,7 @@ import {
   WalletError,
   type WalletErrorCategory,
   WalletManager,
+  canonicalNetworkId,
   DEFAULT_NETWORKS,
   type NetworkConfig,
   resolveProverConfig,
@@ -104,7 +105,10 @@ export abstract class BaseCommand extends Command {
     network: Flags.string({
       char: 'n',
       default: 'devnet',
-      description: 'Target network',
+      // Deliberately not an `options` list: endpoints are overridable, so a
+      // network this build has never heard of is a legitimate target and must
+      // not be rejected by the flag parser.
+      description: 'Target network: devnet, preview, preprod, qanet, undeployed (local stack), or a custom id',
     }),
     wallet: Flags.string({
       char: 'w',
@@ -182,6 +186,10 @@ export abstract class BaseCommand extends Command {
       nodeUrl?: string;
     },
   ): Promise<NetworkConfig> {
+    // A renamed network may still be in someone's script or shell history, so the
+    // flag value is resolved before anything reads a preset from it.
+    networkId = canonicalNetworkId(networkId);
+
     // Block mainnet usage — this is a reference wallet
     if (networkId === 'mainnet') {
       process.stderr.write(
@@ -202,7 +210,9 @@ export abstract class BaseCommand extends Command {
     const base = DEFAULT_NETWORKS[networkId] ?? {
       id: networkId,
       nodeUrl: 'ws://localhost:9944',
-      indexerUrl: 'http://localhost:8088',
+      // The GraphQL path is part of the endpoint, not decoration: the indexer
+      // client posts queries to it, and the bare origin is not a GraphQL endpoint.
+      indexerUrl: 'http://localhost:8088/api/v4/graphql',
       prover: serverProver(),
     };
 

--- a/packages/cli/src/commands/tui.ts
+++ b/packages/cli/src/commands/tui.ts
@@ -1,3 +1,4 @@
+import { canonicalNetworkId } from '@shieldedtech/moth-wallet';
 import { BaseCommand } from '../base-command.js';
 
 export default class Tui extends BaseCommand {
@@ -11,7 +12,9 @@ export default class Tui extends BaseCommand {
     const { flags } = await this.parse(Tui);
 
     const walletName = await this.resolveWalletName(flags).catch(() => 'none');
-    const networkId = flags.network;
+    // The TUI is handed the flag value directly rather than a resolved config,
+    // so a renamed id is resolved here instead.
+    const networkId = canonicalNetworkId(flags.network);
 
     // Dynamic imports — TUI, React, and Ink loaded only when this command runs
     const { render } = await import('ink');

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,9 @@
 export * from './types/index.js';
 export type { NetworkConfig, NetworkEndpoints, ProverConfig } from './types/network.js';
 export {
+  canonicalNetworkId,
   DEFAULT_NETWORKS,
+  SUPPORTED_NETWORKS,
   validateNetworkUrl,
   validateNetworkConfig,
   serverProver,

--- a/packages/core/src/types/network.ts
+++ b/packages/core/src/types/network.ts
@@ -126,21 +126,47 @@ export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
     indexerUrl: 'http://localhost:8088/api/v4/graphql',
     prover: serverProver(),
   },
-  local: {
-    id: 'local',
-    nodeUrl: 'ws://localhost:9933',
-    indexerUrl: 'http://localhost:8088/api/v4/graphql',
-    prover: serverProver(),
-  },
 };
 
 /**
- * Networks the wallet fully supports — it derives addresses for these and can
- * build and submit transactions on them. Mirrors `ALL_NETWORKS` in
- * wallet/address.ts; keep the two in sync. Mainnet is first because it is the
+ * Networks the wallet offers as a choice — it derives addresses for these, and
+ * can build and submit transactions on them. Mainnet is first because it is the
  * default network.
  *
- * Note this is a subset of `DEFAULT_NETWORKS`: `undeployed` has a preset but the
- * wallet can't derive addresses for it, so it is not offered as a choice.
+ * This list and the keys of `DEFAULT_NETWORKS` are the same set, and a test
+ * holds them equal: a preset with no entry here is a network the UI cannot
+ * reach, and an entry here with no preset falls through to a localhost guess.
+ *
+ * `ALL_NETWORKS` in wallet/address.ts is deliberately WIDER — it is the set of
+ * bech32m prefixes a wallet may hold an address for, which includes retired and
+ * unoffered ids. Do not narrow it to match this list.
  */
-export const SUPPORTED_NETWORKS = ['mainnet', 'devnet', 'preview', 'preprod', 'qanet', 'local'] as const;
+export const SUPPORTED_NETWORKS = ['mainnet', 'devnet', 'preview', 'preprod', 'qanet', 'undeployed'] as const;
+
+/**
+ * Network ids that were renamed, mapped to what they are now called.
+ *
+ * `local` was a second preset for the same local devnet stack as `undeployed`,
+ * pointing at a node port nothing in that stack listens on. It reached storage
+ * as a wallet's network and as the extension's selected network, so read paths
+ * canonicalise rather than leaving a stored `local` to miss every preset and
+ * fall through to a localhost guess.
+ */
+const RENAMED_NETWORK_IDS = new Map<string, string>([['local', 'undeployed']]);
+
+/**
+ * Resolve a stored or user-supplied network id to the id in use today.
+ *
+ * Apply this wherever a network id is READ from persistence or from a flag —
+ * never when writing one, so the mapping stays a migration rather than a
+ * permanent alias.
+ *
+ * A Map rather than an object literal because the input is arbitrary: network
+ * ids are not restricted to a known list (endpoints are overridable, so a custom
+ * id is a legitimate target), and an object lookup answers `toString` and
+ * `constructor` from `Object.prototype` — returning a function where a string is
+ * declared, which would then reach setNetworkId(), socket paths and JSON output.
+ */
+export function canonicalNetworkId(id: string): string {
+  return RENAMED_NETWORK_IDS.get(id) ?? id;
+}

--- a/packages/core/src/wallet/address.ts
+++ b/packages/core/src/wallet/address.ts
@@ -15,6 +15,16 @@ import {createKeystore} from '@midnightntwrk/wallet-sdk/unshielded';
 import {setNetworkId} from '@midnight-ntwrk/midnight-js/network-id';
 import type {WalletAddresses} from '../types/wallet.js';
 
+/**
+ * Every bech32m prefix a wallet may hold an address for.
+ *
+ * Deliberately WIDER than `SUPPORTED_NETWORKS` in types/network.ts, and not to
+ * be narrowed to match it. Two kinds of id live here without being a network the
+ * wallet offers: `stagenet`, which has no preset, and `local`, which was renamed
+ * to `undeployed`. Dropping either would take its key out of every bundle
+ * derived from then on, so a stored address a dApp or an address book still
+ * refers to would resolve to nothing.
+ */
 const ALL_NETWORKS = ['mainnet', 'devnet', 'preview', 'preprod', 'qanet', 'stagenet', 'local', 'undeployed'] as const;
 
 export {Roles};

--- a/packages/core/src/wallet/manager.ts
+++ b/packages/core/src/wallet/manager.ts
@@ -6,6 +6,7 @@ import { encryptKeystore, decryptKeystore, keystoreNeedsUpgrade, type EncryptedK
 import { deriveAllAddressesFromSeed, deriveRawKeys, Roles } from './address.js';
 import { deriveWalletKeys, type WalletKeys } from '../sync/operations.js';
 import { removeWalletSyncArtifacts } from '../sync/wallet-sync.js';
+import { canonicalNetworkId } from '../types/network.js';
 
 const CONFIG_KEY = 'config.json';
 
@@ -92,6 +93,55 @@ interface WalletMeta {
  * was written, which is `meta.network` — it was discarded on any switch, so a
  * stored one cannot refer to anywhere else.
  */
+/**
+ * Re-key per-network birthdays onto the ids in use today.
+ *
+ * Colliding keys keep the LOWER height. Both `local` and `undeployed` were
+ * offered at once, so a wallet can hold a birthday under each — created on one
+ * name, switched to the other — and letting insertion order decide would pick
+ * either. Lower is the safe direction: a birthday below the wallet's true
+ * first-existence height only costs scanning, while one above it lets the
+ * pre-seed guard (`reference.height <= birthday`) accept a reference newer than
+ * the wallet's own history, skipping transactions it needs to see.
+ */
+function canonicalBirthdays(birthdays: Record<string, number>): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [id, height] of Object.entries(birthdays)) {
+    const key = canonicalNetworkId(id);
+    const existing = out[key];
+    out[key] = existing === undefined ? height : Math.min(existing, height);
+  }
+  return out;
+}
+
+/**
+ * Resolve every network id a meta record carries to the id in use today.
+ *
+ * `birthdays` is re-keyed whatever the wallet's own network is, NOT only when
+ * that network was the renamed one. A wallet that has since moved elsewhere
+ * still holds the old key, and leaving it there means the next return trip looks
+ * like a first arrival to `setNetwork` and gets stamped with the current tip —
+ * a birthday far above the truth, with the consequence described above.
+ */
+function canonicalMeta(meta: WalletMeta): WalletMeta {
+  const network = canonicalNetworkId(meta.network);
+  const birthdays = meta.birthdays ? canonicalBirthdays(meta.birthdays) : undefined;
+  const birthdaysChanged =
+    birthdays !== undefined &&
+    (Object.keys(birthdays).length !== Object.keys(meta.birthdays!).length ||
+      Object.entries(birthdays).some(([id, height]) => meta.birthdays![id] !== height));
+  if (network === meta.network && !birthdaysChanged) return meta;
+
+  const migrated: WalletMeta = { ...meta, network, ...(birthdays ? { birthdays } : {}) };
+  // The stored address was derived for the OLD id, so its bech32m prefix names a
+  // network this wallet is no longer reported on — shown in an account list, it
+  // invites a receive on the wrong encoding. Dropped rather than re-derived,
+  // which would need the seed: `list()` renders "(locked)", an already-handled
+  // state, and the next unlock backfills the right address.
+  if (network !== meta.network) delete migrated.address;
+  return migrated;
+}
+
 function birthdayFor(meta: WalletMeta, network: string): number | undefined {
   if (meta.birthdays && meta.birthdays[network] !== undefined) return meta.birthdays[network];
   if (meta.birthday !== undefined && meta.network === network) return meta.birthday;
@@ -112,7 +162,8 @@ export class WalletManager {
     // on empty storage would push into DEFAULT_CONFIG itself and every later
     // fresh manager would then see that wallet as already existing.
     if (!data) return { ...DEFAULT_CONFIG, wallets: [...DEFAULT_CONFIG.wallets] };
-    return JSON.parse(decoder.decode(data)) as WalletConfig;
+    const config = JSON.parse(decoder.decode(data)) as WalletConfig;
+    return { ...config, defaultNetwork: canonicalNetworkId(config.defaultNetwork) };
   }
 
   private async saveConfig(config: WalletConfig): Promise<void> {
@@ -123,10 +174,19 @@ export class WalletManager {
     await this.storage.write(metaKey(meta.name), encoder.encode(JSON.stringify(meta)));
   }
 
+  /**
+   * Every read of a wallet's network goes through here, so a renamed network is
+   * canonicalised once rather than at each call site. It matters most on unlock:
+   * the meta record's network becomes the wallet-wide selection, so a stale id
+   * here would reassert itself over a migrated selection on every unlock.
+   *
+   * The stored bytes are left alone — the record is rewritten only when
+   * something else is already saving it.
+   */
   private async loadMeta(name: string): Promise<WalletMeta | null> {
     const data = await this.storage.read(metaKey(name));
     if (!data) return null;
-    return JSON.parse(decoder.decode(data)) as WalletMeta;
+    return canonicalMeta(JSON.parse(decoder.decode(data)) as WalletMeta);
   }
 
   private validateName(name: string): void {
@@ -165,6 +225,9 @@ export class WalletManager {
     // same phrase back here so the stored wallet matches what the user wrote down.
     mnemonic?: string,
   ): Promise<WalletInfo & { mnemonic: string }> {
+    // A caller-supplied id (a --network flag, a picker selection) is about to be
+    // persisted, so a retired name is resolved here rather than written back out.
+    network = canonicalNetworkId(network);
     this.validateName(name);
     const config = await this.loadConfig();
 
@@ -204,6 +267,9 @@ export class WalletManager {
   }
 
   async import(name: string, mnemonic: string, passphrase: string, network = 'devnet'): Promise<WalletInfo> {
+    // A caller-supplied id (a --network flag, a picker selection) is about to be
+    // persisted, so a retired name is resolved here rather than written back out.
+    network = canonicalNetworkId(network);
     this.validateName(name);
 
     if (!validateMnemonic(mnemonic)) {
@@ -236,6 +302,9 @@ export class WalletManager {
   }
 
   async importFromSeed(name: string, hexSeed: string, passphrase: string, network = 'devnet'): Promise<WalletInfo> {
+    // A caller-supplied id (a --network flag, a picker selection) is about to be
+    // persisted, so a retired name is resolved here rather than written back out.
+    network = canonicalNetworkId(network);
     const addresses = this.deriveAddressesFromSeed(hexSeed);
     const address = this.primaryAddress(addresses, network);
 
@@ -533,6 +602,9 @@ export class WalletManager {
    * address to keep the locked account list immediately useful.
    */
   async setNetwork(name: string, network: string, address?: string, birthday?: number): Promise<void> {
+    // A caller-supplied id (a --network flag, a picker selection) is about to be
+    // persisted, so a retired name is resolved here rather than written back out.
+    network = canonicalNetworkId(network);
     const meta = await this.loadMeta(name);
     if (!meta) {
       throw new WalletError('WALLET_ERROR', `Wallet "${name}" not found`);

--- a/packages/core/tests/unit/types/network.test.ts
+++ b/packages/core/tests/unit/types/network.test.ts
@@ -1,9 +1,11 @@
 import {describe, expect, it} from 'vitest';
 import {
+  canonicalNetworkId,
   DEFAULT_NETWORKS,
   describeProver,
   proverConfigsEqual,
   resolveProverConfig,
+  SUPPORTED_NETWORKS,
   validateNetworkConfig,
   type NetworkConfig,
 } from '../../../src/types/network.js';
@@ -42,5 +44,59 @@ describe('prover network configuration', () => {
     expect(proverConfigsEqual({type: 'wasm'}, {type: 'wasm'})).toBe(true);
     expect(proverConfigsEqual({type: 'server', url: 'https://a'}, {type: 'server', url: 'https://b'})).toBe(false);
     expect(proverConfigsEqual({type: 'wasm'}, {type: 'server', url: 'https://a'})).toBe(false);
+  });
+});
+
+// The two lists drifted once already: `undeployed` had a preset no interface
+// could select, and `local` was offered against a preset pointing at a node port
+// the local stack does not listen on. Holding them equal makes either mistake a
+// test failure rather than a network that silently cannot be reached.
+describe('supported networks', () => {
+  it('offers exactly the networks that have a preset', () => {
+    expect([...SUPPORTED_NETWORKS].sort()).toEqual(Object.keys(DEFAULT_NETWORKS).sort());
+  });
+
+  it('gives every offered network a preset whose id matches its key', () => {
+    for (const id of SUPPORTED_NETWORKS) {
+      expect(DEFAULT_NETWORKS[id]?.id, `preset for ${id}`).toBe(id);
+    }
+  });
+
+  it('points the local devnet stack at the port the stack listens on', () => {
+    // 9944 is what the compose stack, docs/TESTING.md, and every localhost
+    // fallback in the repo use. The retired `local` preset said 9933.
+    expect(DEFAULT_NETWORKS.undeployed!.nodeUrl).toBe('ws://localhost:9944');
+    expect(DEFAULT_NETWORKS.undeployed!.indexerUrl).toBe('http://localhost:8088/api/v4/graphql');
+  });
+});
+
+describe('canonicalNetworkId', () => {
+  it('resolves the retired local id to undeployed', () => {
+    expect(canonicalNetworkId('local')).toBe('undeployed');
+  });
+
+  it('leaves every offered network id untouched', () => {
+    for (const id of SUPPORTED_NETWORKS) {
+      expect(canonicalNetworkId(id)).toBe(id);
+    }
+  });
+
+  it('returns a string for keys that exist on Object.prototype', () => {
+    // Network ids are not restricted to a known list, so an arbitrary string
+    // reaches here from `--network`. An object-literal lookup answers these from
+    // the prototype chain, putting a function where a string is declared and
+    // sending it on to setNetworkId(), socket paths and JSON output.
+    for (const key of ['toString', 'constructor', '__proto__', 'hasOwnProperty']) {
+      expect(typeof canonicalNetworkId(key), `canonicalNetworkId(${key})`).toBe('string');
+      expect(canonicalNetworkId(key)).toBe(key);
+    }
+  });
+
+  it('passes through ids it does not know, including the empty string', () => {
+    // Custom and unlisted ids are legitimate — endpoints are overridable and
+    // `stagenet` has addresses but no preset — so this must not gate on a list.
+    expect(canonicalNetworkId('stagenet')).toBe('stagenet');
+    expect(canonicalNetworkId('some-future-net')).toBe('some-future-net');
+    expect(canonicalNetworkId('')).toBe('');
   });
 });

--- a/packages/core/tests/unit/wallet/address-parity.test.ts
+++ b/packages/core/tests/unit/wallet/address-parity.test.ts
@@ -71,13 +71,25 @@ describe('Address Derivation Parity', () => {
     expect(addresses.nightExternal.bech32m.preprod).not.toBe(addresses.metadata.bech32m.preprod);
   });
 
+  // `undeployed` and `stagenet` are covered deliberately. The claim that the
+  // wallet could not derive addresses for `undeployed` is why it spent a long
+  // time unavailable as a network choice, and this loop stopping at qanet is why
+  // nothing contradicted it.
   it('should produce valid bech32m with mn_ prefix for all networks and roles', () => {
     for (const role of ['nightExternal', 'nightInternal', 'dust', 'zswap', 'metadata'] as const) {
-      for (const network of ['mainnet', 'devnet', 'preview', 'preprod', 'qanet'] as const) {
+      for (const network of [
+        'mainnet', 'devnet', 'preview', 'preprod', 'qanet', 'stagenet', 'undeployed',
+      ] as const) {
         const addr = addresses[role].bech32m[network];
         expect(addr).toMatch(/^mn_/);
         expect(addr.length).toBeGreaterThan(20);
       }
     }
+  });
+
+  it('should encode the local devnet stack under its own prefix', () => {
+    expect(addresses.nightExternal.bech32m.undeployed).toMatch(/^mn_addr_undeployed1/);
+    expect(addresses.dust.bech32m.undeployed).toMatch(/^mn_dust_undeployed1/);
+    expect(addresses.zswap.bech32m.undeployed).toMatch(/^mn_shield-addr_undeployed1/);
   });
 });

--- a/packages/core/tests/unit/wallet/manager.test.ts
+++ b/packages/core/tests/unit/wallet/manager.test.ts
@@ -227,3 +227,127 @@ describe('WalletManager keystore KDF upgrade', () => {
       expect(keystoreWrites).not.toContain(KEYSTORE_KEY);
     });
 });
+
+// `local` was a duplicate preset for the same local devnet stack as `undeployed`,
+// on a node port the stack does not listen on. Wallets created while it was
+// offered still carry it, and on unlock a wallet's own network becomes the
+// wallet-wide selection — so a stale id here reasserts itself over a migrated
+// selection every time the wallet is opened.
+describe('WalletManager legacy network ids', () => {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+
+  async function storageWithLegacyWallet(meta: Record<string, unknown> = {}): Promise<MemoryStorage> {
+    const storage = new MemoryStorage();
+    await storage.write(
+      'config.json',
+      encoder.encode(
+        JSON.stringify({ activeWallet: 'bob', wallets: ['bob'], defaultNetwork: 'local', configVersion: 1 }),
+      ),
+    );
+    await storage.write(
+      'wallets/bob.meta',
+      encoder.encode(
+        JSON.stringify({
+          name: 'bob',
+          network: 'local',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          address: 'mn_addr_local1example',
+          createdHere: true,
+          ...meta,
+        }),
+      ),
+    );
+    return storage;
+  }
+
+  it('reports a wallet stored on local as being on undeployed', async () => {
+    const manager = new WalletManager(await storageWithLegacyWallet());
+
+    const [wallet] = await manager.list();
+
+    expect(wallet!.network).toBe('undeployed');
+  });
+
+  it('carries the birthday across the rename', async () => {
+    // Birthdays are keyed by network id and gate the pre-seed shortcut
+    // (`reference.height <= birthday`). Left under the old key, the wallet has
+    // no birthday on the network it now reports, and every sync walks genesis.
+    const storage = await storageWithLegacyWallet({ birthdays: { local: 4200 } });
+    const manager = new WalletManager(storage);
+
+    await manager.setNetwork('bob', 'preprod');
+
+    const stored = JSON.parse(decoder.decode((await storage.read('wallets/bob.meta'))!));
+    expect(stored.birthdays.undeployed).toBe(4200);
+    expect(stored.birthdays.local).toBeUndefined();
+  });
+
+  it('treats a switch to the retired id as staying put', async () => {
+    // Migration is lazy: the record on disk is rewritten only when something
+    // else is already saving it, so the stored bytes keep the old id and the
+    // wallet is still reported on the new one. What must NOT happen is the
+    // switch being taken as a real network change, which discards the address
+    // and the birthday.
+    const storage = await storageWithLegacyWallet({ birthdays: { local: 4200 } });
+    const manager = new WalletManager(storage);
+
+    await manager.setNetwork('bob', 'local');
+
+    const stored = JSON.parse(decoder.decode((await storage.read('wallets/bob.meta'))!));
+    expect(stored.birthdays).toEqual({ local: 4200 });
+    expect((await manager.list())[0]!.network).toBe('undeployed');
+  });
+
+  it('re-keys a birthday held by a wallet that has since moved elsewhere', async () => {
+    // The re-key must not be gated on the wallet's OWN network having been
+    // renamed. This wallet was created on the local stack and has since moved to
+    // preprod, so it still holds the old key while reporting preprod. Left
+    // there, the return trip below looks like a first arrival and gets stamped
+    // with the tip passed in — a birthday far above the truth, which lets the
+    // pre-seed guard accept a reference newer than the wallet's own history.
+    const storage = await storageWithLegacyWallet({ network: 'preprod', birthdays: { local: 100 } });
+    const manager = new WalletManager(storage);
+
+    await manager.setNetwork('bob', 'undeployed', 'addr', 5000);
+
+    const stored = JSON.parse(decoder.decode((await storage.read('wallets/bob.meta'))!));
+    expect(stored.birthdays).toEqual({ undeployed: 100 });
+  });
+
+  it('keeps the lower height when both names carry a birthday', async () => {
+    // Both `local` and `undeployed` were offered at once, so a wallet can hold a
+    // birthday under each. Insertion order deciding it would pick either; lower
+    // is the safe direction, because too low only costs scanning.
+    const storage = await storageWithLegacyWallet({ birthdays: { local: 100, undeployed: 5000 } });
+    const manager = new WalletManager(storage);
+
+    await manager.setNetwork('bob', 'preprod');
+
+    const stored = JSON.parse(decoder.decode((await storage.read('wallets/bob.meta'))!));
+    expect(stored.birthdays.undeployed).toBe(100);
+  });
+
+  it('does not report an address whose prefix names the old network', async () => {
+    // `mn_addr_local1…` shown against a wallet reported on `undeployed` is an
+    // invitation to receive on the wrong encoding. "(locked)" is honest and is
+    // already what the list renders for a wallet with no stored address.
+    const manager = new WalletManager(await storageWithLegacyWallet());
+
+    const [wallet] = await manager.list();
+
+    expect(wallet!.network).toBe('undeployed');
+    expect(wallet!.address).not.toContain('local');
+    expect(wallet!.address).toBe('(locked)');
+  });
+
+  it('never persists the retired id for a newly created wallet', async () => {
+    const storage = new MemoryStorage();
+    const manager = new WalletManager(storage);
+
+    await manager.generate('carol', 'passphrase-long-enough', 'local');
+
+    const stored = JSON.parse(decoder.decode((await storage.read('wallets/carol.meta'))!));
+    expect(stored.network).toBe('undeployed');
+  });
+});

--- a/packages/extension/components/screens/NetworkConfig.tsx
+++ b/packages/extension/components/screens/NetworkConfig.tsx
@@ -31,7 +31,7 @@ export const NETWORK_LABELS: Record<SupportedNetwork, string> = {
   preview: 'Preview',
   preprod: 'Preprod',
   qanet: 'QA net',
-  local: 'Local',
+  undeployed: 'Undeployed',
 };
 
 export const NETWORK_DESCRIPTIONS: Record<SupportedNetwork, MessageKey> = {
@@ -40,7 +40,7 @@ export const NETWORK_DESCRIPTIONS: Record<SupportedNetwork, MessageKey> = {
   preview: 'network_descPreview',
   preprod: 'network_descPreprod',
   qanet: 'network_descQanet',
-  local: 'network_descLocal',
+  undeployed: 'network_descUndeployed',
 };
 
 const isSupported = (id: string): id is SupportedNetwork =>
@@ -114,6 +114,24 @@ export function networkLabel(id: string): string {
   return isSupported(id) ? NETWORK_LABELS[id] : id;
 }
 
+/**
+ * Which network the panel opens on, given the saved settings.
+ *
+ * A saved id the build no longer offers cannot be shown as selected — there is
+ * no radio for it — so the panel falls back. That fallback is `mainnet` for the
+ * side panel, which is why a stored id has to be resolved to a current one
+ * BEFORE it arrives here (see `canonicalNetworkId` in core): reaching this
+ * fallback would present a value-bearing network as the account's own, and
+ * `selectableNetworks` would then offer mainnet even with developer mode off,
+ * because it never strands a wallet on the network it is already using.
+ *
+ * Extracted so the load path can be tested against real stored settings rather
+ * than a copy of this decision.
+ */
+export function loadedNetwork(saved: string, fallback: SupportedNetwork): SupportedNetwork {
+  return isSupported(saved) ? saved : fallback;
+}
+
 export interface NetworkConfigState {
   network: SupportedNetwork;
   current: SupportedNetwork;
@@ -151,7 +169,7 @@ export function useNetworkConfig(fallback: SupportedNetwork = 'mainnet'): Networ
 
   useEffect(() => {
     void sendMessage('settingsGet', undefined).then((settings) => {
-      const named = isSupported(settings.network) ? settings.network : fallback;
+      const named = loadedNetwork(settings.network, fallback);
       const loadedUrls = settings.customEndpoints ?? presetFor(named);
       setCurrent(named);
       setNetwork(named);

--- a/packages/extension/entrypoints/setup/App.tsx
+++ b/packages/extension/entrypoints/setup/App.tsx
@@ -403,8 +403,9 @@ export function PasswordStep({
 
 // Choose a network (design template setup-network), rendered in the full-tab
 // setup Shell like every other step. The named network list is shared with
-// Settings → Network (see NetworkConfig); only SUPPORTED_NETWORKS are offered
-// (mainnet is the default; undeployed isn't address-derivable). The choice
+// Settings → Network (see NetworkConfig); only SUPPORTED_NETWORKS are offered,
+// and mainnet among those only with developer mode on. This step defaults to
+// preprod, the network with a bundled pre-seed reference. The choice
 // becomes the NEW account's network — existing accounts keep theirs. It is
 // also saved as the default selection for the new account flow.
 

--- a/packages/extension/lib/background/settings.ts
+++ b/packages/extension/lib/background/settings.ts
@@ -3,6 +3,7 @@ import { browser } from 'wxt/browser';
 // the barrel drags in the ledger WASM (top-level await), which cannot exist in
 // the service worker's module graph. See lib/offscreen for where WASM lives.
 import {
+  canonicalNetworkId,
   DEFAULT_NETWORKS,
   isProverConfig,
   proverConfigsEqual,
@@ -95,7 +96,10 @@ export async function getSettings(): Promise<ExtensionSettings> {
   const saved = stored[SETTINGS_KEY] as Partial<ExtensionSettings> | undefined;
   const customEndpoints = parseEndpoints(saved?.customEndpoints);
   return {
-    network: saved?.network ?? DEFAULT_SETTINGS.network,
+    // Canonicalised on read: a selection saved under a network id that has since
+    // been renamed would otherwise match no preset and fall through to the
+    // localhost guess below.
+    network: canonicalNetworkId(saved?.network ?? DEFAULT_SETTINGS.network),
     customEndpoints,
     autoLockMinutes: 'autoLockMinutes' in (saved ?? {}) ? parseAutoLock(saved?.autoLockMinutes) : DEFAULT_SETTINGS.autoLockMinutes,
     nameResolverUrl: parseResolverUrl(saved?.nameResolverUrl),
@@ -126,7 +130,9 @@ export async function getNetworkConfig(networkId?: string): Promise<NetworkConfi
   const base = DEFAULT_NETWORKS[network] ?? {
     id: network,
     nodeUrl: 'ws://localhost:9944',
-    indexerUrl: 'http://localhost:8088',
+    // The GraphQL path is part of the endpoint, not decoration: the indexer
+    // client posts queries to it, and the bare origin is not a GraphQL endpoint.
+    indexerUrl: 'http://localhost:8088/api/v4/graphql',
     prover: serverProver(),
   };
   if (!customEndpoints || network !== settingsNetwork) return base;

--- a/packages/extension/lib/i18n/messages/network.ts
+++ b/packages/extension/lib/i18n/messages/network.ts
@@ -7,7 +7,7 @@ export const network = {
   network_descPreview: 'Preview upcoming changes',
   network_descPreprod: 'Pre-production testing',
   network_descQanet: 'Quality assurance network',
-  network_descLocal: 'Node running on this machine',
+  network_descUndeployed: 'Local devnet stack on this machine',
   network_endpointUrls: 'Endpoint URLs',
   network_useDefaults: 'Use defaults',
   network_nodeUrl: 'Node URL',

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1472,8 +1472,8 @@
   "network_authHeaderValue": {
     "message": "Header-Wert"
   },
-  "network_descLocal": {
-    "message": "Node auf diesem Rechner"
+  "network_descUndeployed": {
+    "message": "Lokaler Devnet-Stack auf diesem Rechner"
   },
   "settings_preseedWarmingIncluded": {
     "message": "Enthalten"

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1472,8 +1472,8 @@
   "network_authHeaderValue": {
     "message": "Valor de la cabecera"
   },
-  "network_descLocal": {
-    "message": "Nodo en este equipo"
+  "network_descUndeployed": {
+    "message": "Stack devnet local en este equipo"
   },
   "settings_preseedWarmingIncluded": {
     "message": "Incluido"

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1472,8 +1472,8 @@
   "network_authHeaderValue": {
     "message": "Valeur de l’en-tête"
   },
-  "network_descLocal": {
-    "message": "Nœud sur cette machine"
+  "network_descUndeployed": {
+    "message": "Stack devnet local sur cette machine"
   },
   "settings_preseedWarmingIncluded": {
     "message": "Inclus"

--- a/packages/extension/tests/legacy-network-upgrade.test.tsx
+++ b/packages/extension/tests/legacy-network-upgrade.test.tsx
@@ -1,0 +1,139 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+import { DEFAULT_NETWORKS, resolveProverConfig } from '@shieldedtech/moth-wallet/types/network';
+import { getSettings } from '../lib/background/settings';
+import { onMessage, sendMessage } from '../lib/messaging/protocol';
+import {
+  loadedNetwork,
+  NETWORK_LABELS,
+  NetworkFields,
+  selectableNetworks,
+  type NetworkConfigState,
+} from '../components/screens/NetworkConfig';
+
+// What a profile saved by a build that offered `local` looks like on disk. The
+// panel reads it back through the background, so the whole path is exercised:
+// stored bytes → getSettings → messaging → the panel's load decision → markup.
+const LEGACY_PROFILE = { network: 'local' as const };
+
+/** The exact wiring from handlers.ts — the panel's only source of settings.
+ *  Registered once: the messaging layer allows a single listener per message
+ *  type per JS context, just as the real background does. */
+const serveSettings = () => onMessage('settingsGet', () => getSettings());
+
+/** The side panel constructs the screen with no fallback argument, so mainnet is
+ *  what an unrecognised stored id resolves to. */
+const PANEL_FALLBACK = 'mainnet' as const;
+
+/** Reproduces the panel's load effect over real settings, then renders the
+ *  picker exactly as the screen does. */
+async function openNetworkPanel() {
+  const settings = await sendMessage('settingsGet', undefined);
+  const network = loadedNetwork(settings.network, PANEL_FALLBACK);
+  const urls = settings.customEndpoints ?? {
+    nodeUrl: DEFAULT_NETWORKS[network]!.nodeUrl,
+    indexerUrl: DEFAULT_NETWORKS[network]!.indexerUrl,
+    prover: resolveProverConfig(DEFAULT_NETWORKS[network]!),
+  };
+  const state: NetworkConfigState = {
+    network,
+    current: network,
+    urls,
+    currentUrls: urls,
+    ready: true,
+    changed: false,
+    networkChanged: false,
+    indexerChanged: false,
+    requiresResyncConfirmation: false,
+    usesOverrides: settings.customEndpoints !== null,
+    valid: true,
+    developerMode: settings.developerMode,
+    available: selectableNetworks(settings.developerMode, network),
+    needsValueWarning: false,
+    pick: vi.fn(),
+    edit: vi.fn(() => vi.fn()),
+    editAuthHeader: vi.fn(() => vi.fn()),
+    setProverType: vi.fn(),
+    editProverUrl: vi.fn(),
+    resetEndpoints: vi.fn(),
+    save: vi.fn(),
+  };
+  return { settings, state, html: renderToStaticMarkup(<NetworkFields state={state} />) };
+}
+
+/**
+ * The label on the one network radio the picker shows as selected.
+ *
+ * Scoped to radios carrying a network label: the screen renders a second
+ * radiogroup for the proving method, and that one has a selected radio too.
+ */
+function checkedNetwork(html: string): string {
+  const labelled = html
+    .split('role="radio"')
+    .slice(1)
+    .map((radio) => ({
+      checked: radio.startsWith(' aria-checked="true"'),
+      label: Object.values(NETWORK_LABELS).find((name) => radio.includes(`>${name}</span>`)),
+    }))
+    .filter((radio): radio is { checked: boolean; label: string } => radio.label !== undefined);
+
+  const selected = labelled.filter((radio) => radio.checked);
+  expect(selected.map((radio) => radio.label), 'exactly one network is selected').toHaveLength(1);
+  return selected[0]!.label;
+}
+
+describe('upgrading a profile saved on the retired local network', () => {
+  beforeAll(() => serveSettings());
+  beforeEach(() => fakeBrowser.storage.local.clear());
+
+  it('opens the picker on Undeployed, selected', async () => {
+    await fakeBrowser.storage.local.set({ settings: LEGACY_PROFILE });
+
+    const { settings, state, html } = await openNetworkPanel();
+
+    expect(settings.network).toBe('undeployed');
+    expect(state.network).toBe('undeployed');
+    expect(checkedNetwork(html)).toBe('Undeployed');
+    expect(html).toContain(DEFAULT_NETWORKS.undeployed!.nodeUrl);
+  });
+
+  it('does not offer mainnet to a profile that never asked for it', async () => {
+    // The failure this guards against is not a blank radio. `selectableNetworks`
+    // never strands a wallet on the network it is already using, so a fallback to
+    // mainnet would ALSO unhide mainnet with developer mode off — presenting a
+    // value-bearing network as this account's own, one click from being saved.
+    await fakeBrowser.storage.local.set({ settings: LEGACY_PROFILE });
+
+    const { state, html } = await openNetworkPanel();
+
+    expect(state.developerMode).toBe(false);
+    expect(state.available).not.toContain('mainnet');
+    expect(html).not.toContain('>Mainnet</span>');
+  });
+
+  it('keeps endpoint edits made while the network was called local', async () => {
+    const customEndpoints = {
+      nodeUrl: 'ws://localhost:19944',
+      indexerUrl: 'http://localhost:18088/api/v4/graphql',
+      prover: { type: 'wasm' as const },
+    };
+    await fakeBrowser.storage.local.set({ settings: { ...LEGACY_PROFILE, customEndpoints } });
+
+    const { state, html } = await openNetworkPanel();
+
+    expect(state.urls).toEqual(customEndpoints);
+    expect(html).toContain('ws://localhost:19944');
+  });
+
+  // The mechanism above only works because the id is resolved before it reaches
+  // the panel. An id with no mapping still takes the fallback, which is what
+  // makes the migration load-bearing rather than decorative.
+  it('still falls back for an id that has no current equivalent', async () => {
+    await fakeBrowser.storage.local.set({ settings: { network: 'stagenet' } });
+
+    const { state } = await openNetworkPanel();
+
+    expect(state.network).toBe(PANEL_FALLBACK);
+  });
+});

--- a/packages/extension/tests/network-config.test.tsx
+++ b/packages/extension/tests/network-config.test.tsx
@@ -81,7 +81,7 @@ describe('NetworkFields', () => {
     expect(html.match(/role="radio"/g)).toHaveLength(state.available.length + PROVER_RADIOS);
     expect(html).toContain('aria-checked="true"');
     expect(html).toContain('Preview');
-    expect(html).toContain('Local');
+    expect(html).toContain('Undeployed');
     expect(html).not.toContain('Custom');
     expect(html).toContain('Node URL');
     expect(html).toContain('Indexer URL');

--- a/packages/extension/tests/network-switch.test.ts
+++ b/packages/extension/tests/network-switch.test.ts
@@ -186,8 +186,14 @@ describe('saveNetworkConfig', () => {
   });
 
   it('requires an unlocked wallet and a supported network', async () => {
+    // `stagenet` has bech32m addresses but no preset and is not offered, so it
+    // exercises the guard the way `undeployed` used to before it became a real
+    // network choice.
     await expect(
-      saveNetworkConfig({ network: 'undeployed', endpoints: endpoints('undeployed'), resyncApproved: true }),
+      saveNetworkConfig({ network: 'stagenet', endpoints: endpoints('devnet'), resyncApproved: true }),
+    ).rejects.toThrow('Unsupported network');
+    await expect(
+      saveNetworkConfig({ network: 'local', endpoints: endpoints('undeployed'), resyncApproved: true }),
     ).rejects.toThrow('Unsupported network');
     await fakeBrowser.storage.session.clear();
     await expect(

--- a/packages/extension/tests/settings.test.ts
+++ b/packages/extension/tests/settings.test.ts
@@ -28,6 +28,31 @@ describe('extension settings', () => {
     expect(await getNetworkConfig()).toEqual({ id: 'preview', ...migratedEndpoints });
   });
 
+  // `local` was a second preset for the same local devnet stack as `undeployed`,
+  // pointing at a node port the stack does not listen on. Installs that selected
+  // it still have it saved, and it is no longer a network the panel can offer —
+  // so it has to resolve rather than fall through to a localhost guess.
+  it('resolves a selection saved under the retired local id', async () => {
+    await fakeBrowser.storage.local.set({ settings: { network: 'local' } });
+
+    expect((await getSettings()).network).toBe('undeployed');
+    expect(await getNetworkConfig()).toEqual(DEFAULT_NETWORKS.undeployed);
+  });
+
+  it('keeps endpoint overrides across the rename', async () => {
+    // Overrides belong to the selected network, and `getNetworkConfig` only
+    // applies them when the requested network IS the selected one. If the
+    // migration moved one side and not the other, the edits would be dropped.
+    const customEndpoints = {
+      nodeUrl: 'ws://localhost:19944',
+      indexerUrl: 'http://localhost:18088/api/v4/graphql',
+      prover: { type: 'wasm' as const },
+    };
+    await fakeBrowser.storage.local.set({ settings: { network: 'local', customEndpoints } });
+
+    expect(await getNetworkConfig()).toEqual({ id: 'undeployed', ...customEndpoints });
+  });
+
   it('restores WASM proving as part of a network override', async () => {
     const customEndpoints = {
       nodeUrl: DEFAULT_NETWORKS.devnet!.nodeUrl,

--- a/packages/extension/tests/token-labels.test.ts
+++ b/packages/extension/tests/token-labels.test.ts
@@ -21,7 +21,7 @@ describe('nativeAssetLabelsForNetwork', () => {
   });
 
   it('uses testnet names everywhere else', () => {
-    for (const id of ['preprod', 'preview', 'devnet', 'qanet', 'local']) {
+    for (const id of ['preprod', 'preview', 'devnet', 'qanet', 'undeployed']) {
       expect(nativeAssetLabelsForNetwork(id)).toEqual(TESTNET_NATIVE_ASSET_LABELS);
     }
   });

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -114,6 +114,8 @@ export function App({ networkId: networkIdProp }: AppProps) {
 
   useEffect(() => {
     loadSettings(storage).then(settings => {
+      // loadSettings resolves renamed network ids on both the selection and the
+      // override keys, so nothing here has to know about them.
       const targetNetwork = networkIdProp ?? settings.lastNetwork ?? 'devnet';
       setInitialNetwork(targetNetwork);
       network.connect(targetNetwork, settings.networkOverrides?.[targetNetwork]);

--- a/packages/tui/src/hooks/useNetwork.ts
+++ b/packages/tui/src/hooks/useNetwork.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   JsonRpcNodeClient,
+  canonicalNetworkId,
   DEFAULT_NETWORKS,
   resolveProverConfig,
   serverProver,
@@ -35,10 +36,17 @@ export function useNetwork(initialNetworkId: string = 'devnet') {
     // Stop existing polling
     stopPolling();
 
+    // The id reaches here from persisted TUI settings and from --network, so a
+    // renamed one is resolved before it is used to look up a preset or to key
+    // the per-network overrides.
+    id = canonicalNetworkId(id);
+
     const preset = DEFAULT_NETWORKS[id] ?? {
       id,
       nodeUrl: 'ws://localhost:9944',
-      indexerUrl: 'http://localhost:8088',
+      // The GraphQL path is part of the endpoint, not decoration: the indexer
+      // client posts queries to it, and the bare origin is not a GraphQL endpoint.
+      indexerUrl: 'http://localhost:8088/api/v4/graphql',
       prover: serverProver(),
     };
     const presetProver = resolveProverConfig(preset);

--- a/packages/tui/src/screens/network.tsx
+++ b/packages/tui/src/screens/network.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
-import { DEFAULT_NETWORKS, serverProver } from '@shieldedtech/moth-wallet';
+import { serverProver, SUPPORTED_NETWORKS } from '@shieldedtech/moth-wallet';
 import type { NetworkState } from '../types.js';
 import type { NetworkOverrides } from '../settings.js';
 import { SectionHeader } from '../components/SectionHeader.js';
@@ -14,7 +14,7 @@ interface NetworkProps {
   onBack: () => void;
 }
 
-const NETWORKS = Object.keys(DEFAULT_NETWORKS);
+const NETWORKS: readonly string[] = SUPPORTED_NETWORKS;
 
 type UrlField = 'nodeUrl' | 'indexerUrl' | 'proofServerUrl';
 

--- a/packages/tui/src/screens/onboarding/NetworkSelectScreen.tsx
+++ b/packages/tui/src/screens/onboarding/NetworkSelectScreen.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import { DEFAULT_NETWORKS } from '@shieldedtech/moth-wallet';
+import { SUPPORTED_NETWORKS } from '@shieldedtech/moth-wallet';
 import { BackHint } from '../../components/BackHint.js';
 import { SectionHeader } from '../../components/SectionHeader.js';
 import { Select } from '../../components/Select.js';
 import type { Navigator, Route } from '../../navigation/index.js';
 
-const NETWORKS = Object.keys(DEFAULT_NETWORKS);
+const NETWORKS: readonly string[] = SUPPORTED_NETWORKS;
 const ITEMS = NETWORKS.map((id) => ({ label: id, value: id }));
 
 interface Props {

--- a/packages/tui/src/settings.ts
+++ b/packages/tui/src/settings.ts
@@ -1,3 +1,4 @@
+import { canonicalNetworkId } from '@shieldedtech/moth-wallet';
 import type { ProverConfig, StorageAdapter } from '@shieldedtech/moth-wallet';
 
 const SETTINGS_KEY = 'tui/settings.json';
@@ -25,11 +26,41 @@ const DEFAULTS: TuiSettings = {
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
+/**
+ * Re-key per-network endpoint overrides onto the ids in use today.
+ *
+ * Without this the session loses them on the SECOND launch rather than the
+ * first, which is the harder failure to spot: the first launch still finds the
+ * entry under the old name and persists `lastNetwork` as the new one, so the
+ * next launch looks up a key nothing is filed under and quietly falls back to
+ * the preset endpoints — including dropping a WASM prover choice.
+ *
+ * An entry already stored under a current name wins over one being renamed onto
+ * it: it was saved against the name in use, so it is the more deliberate of the
+ * two. Nothing else can distinguish them.
+ */
+function canonicalOverrides(saved: Record<string, NetworkOverrides> = {}): Record<string, NetworkOverrides> {
+  const out: Record<string, NetworkOverrides> = {};
+  for (const [id, overrides] of Object.entries(saved)) {
+    if (canonicalNetworkId(id) === id) out[id] = overrides;
+  }
+  for (const [id, overrides] of Object.entries(saved)) {
+    const key = canonicalNetworkId(id);
+    if (key !== id && out[key] === undefined) out[key] = overrides;
+  }
+  return out;
+}
+
 export async function loadSettings(storage: StorageAdapter): Promise<TuiSettings> {
   const data = await storage.read(SETTINGS_KEY);
   if (!data) return { ...DEFAULTS };
   try {
-    return { ...DEFAULTS, ...JSON.parse(decoder.decode(data)) };
+    const saved: TuiSettings = { ...DEFAULTS, ...JSON.parse(decoder.decode(data)) };
+    return {
+      ...saved,
+      lastNetwork: canonicalNetworkId(saved.lastNetwork),
+      networkOverrides: canonicalOverrides(saved.networkOverrides),
+    };
   } catch {
     return { ...DEFAULTS };
   }

--- a/packages/tui/tests/unit/settings-legacy-network.test.ts
+++ b/packages/tui/tests/unit/settings-legacy-network.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import type { StorageAdapter } from '@shieldedtech/moth-wallet';
+import { loadSettings, saveSettings, type TuiSettings } from '../../src/settings.js';
+
+const encoder = new TextEncoder();
+
+/** Minimal StorageAdapter over a Map — the settings path only reads and writes
+ *  one key, so there is nothing to gain from a filesystem here. */
+function storageWith(settings: Record<string, unknown>): StorageAdapter {
+  const files = new Map<string, Uint8Array>([
+    ['tui/settings.json', encoder.encode(JSON.stringify(settings))],
+  ]);
+  return {
+    read: async (key: string) => files.get(key) ?? null,
+    write: async (key: string, data: Uint8Array) => void files.set(key, data),
+    delete: async (key: string) => void files.delete(key),
+    list: async () => [...files.keys()],
+    exists: async (key: string) => files.has(key),
+  } as unknown as StorageAdapter;
+}
+
+// A TUI profile written while the local devnet stack was called `local`. The
+// failure this guards against showed up on the SECOND launch: the first one
+// found the overrides under the old key and persisted `lastNetwork` as the new
+// one, so the next lookup missed and the session silently reverted to preset
+// endpoints — a custom node, indexer and prover choice gone with no message.
+describe('TUI settings saved on the retired local network', () => {
+  const OVERRIDES = {
+    nodeUrl: 'ws://localhost:19944',
+    indexerUrl: 'http://localhost:18088/api/v4/graphql',
+    prover: { type: 'wasm' as const },
+  };
+
+  it('resolves the remembered network', async () => {
+    const settings = await loadSettings(storageWith({ lastNetwork: 'local' }));
+
+    expect(settings.lastNetwork).toBe('undeployed');
+  });
+
+  it('carries endpoint overrides onto the new key', async () => {
+    const settings = await loadSettings(
+      storageWith({ lastNetwork: 'local', networkOverrides: { local: OVERRIDES } }),
+    );
+
+    expect(settings.networkOverrides.undeployed).toEqual(OVERRIDES);
+    expect(settings.networkOverrides.local).toBeUndefined();
+  });
+
+  it('survives the round trip that used to lose them', async () => {
+    // Launch one: read the legacy profile, then persist it the way app.tsx does
+    // — `lastNetwork` from the live session, `networkOverrides` carried through.
+    const storage = storageWith({ lastNetwork: 'local', networkOverrides: { local: OVERRIDES } });
+    const first = await loadSettings(storage);
+    await saveSettings(storage, { ...first, lastNetwork: 'undeployed' } satisfies TuiSettings);
+
+    // Launch two: the lookup that used to come back empty.
+    const second = await loadSettings(storage);
+
+    expect(second.lastNetwork).toBe('undeployed');
+    expect(second.networkOverrides[second.lastNetwork]).toEqual(OVERRIDES);
+  });
+
+  it('keeps the entry already filed under the current name', async () => {
+    // Both names were selectable at once, so a profile can hold an entry under
+    // each. The one saved against the name in use is the more deliberate.
+    const settings = await loadSettings(
+      storageWith({
+        lastNetwork: 'local',
+        networkOverrides: { local: OVERRIDES, undeployed: { nodeUrl: 'ws://localhost:29944' } },
+      }),
+    );
+
+    expect(settings.networkOverrides.undeployed).toEqual({ nodeUrl: 'ws://localhost:29944' });
+  });
+});


### PR DESCRIPTION
# Overview

`undeployed` is now offered by every interface, including the extension, which could not select it before. `local` is retired.

The two were duplicate presets for the same thing. `undeployed` is the id the Midnight tooling, `docs/TESTING.md` and this repo's own README instructions all use for the local devnet stack, and it points at the node port that stack listens on — **9944**. `local` pointed at **9933**, which nothing in the documented stack serves, so selecting **Local** in the extension connected to a closed port. It had been that way since the first commit.

`undeployed` was kept out of the picker by a comment claiming the wallet could not derive addresses for it. That was false — `mn_addr_undeployed1…`, `mn_dust_undeployed1…` and `mn_shield-addr_undeployed1…` have always derived. The `address-parity` network loop stopping at `qanet` is why nothing contradicted it.

## Breaking change, with a migration

`local` is gone from `SUPPORTED_NETWORKS` and `DEFAULT_NETWORKS`, and the extension rejects it on save. Read paths resolve it through the new `canonicalNetworkId`, so the extension's stored selection, a wallet's meta record, the TUI's `lastNetwork` and endpoint overrides, `--network local`, and `createMothBrowser({ network: 'local' })` all keep working and land on `undeployed`. Stored records are rewritten lazily, only when something else is already saving them. `local` stays in `ALL_NETWORKS` so addresses already handed out still resolve.

## The part worth reviewing

Not the rename — the records **keyed by** the id. A self-review at high effort found three defects there, all fixed in this branch and each pinned by a test that fails against the earlier version:

- **Per-network birthdays** are re-keyed whatever the wallet's own network is. Gating that on the wallet's own id having been renamed left a wallet that had moved elsewhere holding the old key, so the next return trip looked like a first arrival and got stamped with the current tip. A birthday above the truth lets the pre-seed guard (`reference.height <= birthday`) accept a reference newer than the wallet's own history — missed funds, not a slow sync.
- **Colliding birthdays** resolve to the lower height. Both names were offered at once, so a wallet can hold one under each; insertion order deciding it would pick either. Too low only costs scanning.
- **TUI endpoint overrides** are re-keyed at load. Otherwise they survived the first launch and vanished on the second, once `lastNetwork` had been rewritten but the override key had not — a custom node, indexer and prover choice gone with no message.

Also from that review: a stored address derived under the old id is dropped rather than shown, since its bech32m prefix names a network the wallet is no longer reported on; and `canonicalNetworkId` uses a `Map`, because network ids are not restricted to a known list and an object literal answered `--network toString` from `Object.prototype`, putting a function where a string is declared.

## Why the migration is load-bearing

The extension's panel falls back to mainnet for an id it does not recognise, and `selectableNetworks` never strands a wallet on the network it is already using. So without this, a `local` profile would open the network screen showing **Mainnet** as its own network, with mainnet unhidden despite developer mode being off. Verified by disabling the migration and watching the new test fail on exactly that.

## Also fixed

- The four localhost indexer fallbacks omitted the `/api/v4/graphql` path the indexer client posts queries to.
- The README network table listed `devnet` as localhost, omitted `undeployed`, and gave qanet hostnames (`rpc.qanet.dev.midnight.network`) that do not resolve.
- The `--network` row in `docs/spec/wallet-service/COMMANDS.md` repeated the derivation claim and pointed at a section of `01-architecture.md` that does not exist.

Mainnet is documented as unavailable rather than listed as an option — no row in the network table, not among the `--network` values — because the CLI refuses it and the extension keeps it out of the picker. **No gating behaviour changed:** the CLI block and the extension's developer-mode hatch behave exactly as before.

## Verification

- Full suite: **751 passed, 34 skipped**, exit 0. 15 new tests across `core`, `extension` and `tui`.
- `tsc --noEmit` clean in `core`, `extension`, `cli`, `tui`, `browser`.
- A new test holds `SUPPORTED_NETWORKS` equal to the keys of `DEFAULT_NETWORKS`, so a preset no interface can reach — or an offered network with no preset — fails the suite. That is the drift this PR is cleaning up.
- `address-parity` now covers `undeployed` and `stagenet`; the loop stopping at `qanet` is why the false derivation claim went unchallenged.
- README endpoint claims DNS-checked: the `.dev.` qanet hostnames are NXDOMAIN, the ones now in the table resolve.

## Known gaps

- Sync caches are keyed by network, so a migrated account resyncs once under the new key — correct, since the node URL genuinely changes — and its old entries are left behind rather than cleaned up.
- `host-dispatch.ts:34` drops the `birthday` argument, so the extension never records one on a network switch. Pre-existing, not touched here, wants its own issue.
- The extension's new test reimplements the panel's load effect rather than rendering `useNetworkConfig`; exercising the hook needs a DOM test environment the package does not have.
- No real-Chrome pass on an upgraded profile — the panel behaviour is pinned by tests, but that an actual migrated profile unlocks and syncs against the stack on 9944 is unverified.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [x] Every non-merge, non-bot commit has a matching DCO `Signed-off-by` trailer
- [ ] All check jobs of the CI have succeeded — just pushed, not yet reported
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant)
- [x] Update documentation (if relevant)
- [x] No new todos introduced

## Links

None — no tracking issue for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)