### PR TITLE
fix(extension): clear an account's sync state when it is removed

### DIFF
--- a/.changeset/extension-remove-clears-sync-state.md
+++ b/.changeset/extension-remove-clears-sync-state.md
@@ -1,0 +1,48 @@
+---
+"@shieldedtech/moth-wallet": patch
+"@shieldedtech/moth-browser": patch
+"@shieldedtech/moth-extension": patch
+---
+
+Clear an account's sync state when it is removed in the extension.
+
+Removing an account left its sync state behind, so re-adding the same seed
+resumed the removed account's sync instead of starting fresh — the one recovery
+a user reaches for when an account is stuck did nothing, silently. The only
+visible difference was a `Restoring … from cache` line where `Pre-seeding …`
+belonged. A name re-used with a *different* seed is the worse case: the wallet
+would apply one seed's cached sub-wallet state while holding another's keys.
+
+Two causes, both fixed here.
+
+`WalletManager.remove()` cleaned the sync store that core resolves by default,
+which on node is the fs-backed `~/.moth/sync` store — right for the CLI, TUI and
+daemon — but in the browser is a volatile in-memory one. It never touched the
+IndexedDB the extension actually writes. The manager now takes the store its
+surface uses, and `createMothBrowser` hands it the IndexedDB one.
+
+The sync engine also writes its final state when it stops, and the extension's
+lock path starts that teardown without awaiting it. A removal racing that flush
+deleted the state and had it written straight back, which is why a removed
+account's dust cursor reappeared to the event. The offscreen host now stops the
+engine before removing, and clears the two per-account keys core does not know
+about: the local submission notes and the dust-repair stamp.
+
+`remove()` additionally clears every network an account has been on rather than
+only its current one. Switching networks deliberately keeps the previous
+network's cache for a cheap return trip, and that cache outlived removal.
+
+Removal is now also safe to interrupt. It writes the account list before
+deleting anything that list points at, and the extension removes the account
+before locking — locking starts a teardown it does not await, and teardown
+closes the document doing the work, so the removal was racing its own shutdown.
+Interrupted the old way, an account stayed listed with its keystore already
+deleted: no passphrase could open it, and when it was the only account the
+wallet had no way back in, because the "no accounts yet" screen needs an empty
+list.
+
+For profiles already in that state, a config entry whose keystore is missing is
+now treated as the absent account it is — skipped by `list()`, and no longer
+blocking a new account from taking that name. Note this changes what `list()`
+reports on every surface, `moth wallet list` included: an entry with no keystore
+is omitted rather than shown as an account that every operation would fail on.

--- a/docs/spec/wallet-service/COMMANDS.md
+++ b/docs/spec/wallet-service/COMMANDS.md
@@ -102,7 +102,7 @@ As of `feat/tui-daemon`'s `removeWalletSyncArtifacts` integration:
 | `~/.moth/wallets/<name>.keystore` | ✓ | Keys are unrecoverable from this point. |
 | `~/.moth/wallets/<name>.meta` | ✓ | |
 | `~/.moth/config.json` entry | ✓ | If this was the active wallet, active flips to another wallet (or `null`). |
-| `~/.moth/sync/<network>/<name>/` (recursive) | ✓ | All three `.dat` files + the directory itself. |
+| `~/.moth/sync/<network>/<name>/` (recursive) | ✓ | All three `.dat` files + the directory itself. For **every** network the wallet has been on (`meta.network` plus every key in `meta.birthdays`), not just the current one — `wallet set-network` deliberately keeps the previous network's cache for a cheap return trip, so removal has to collect them all. |
 | `~/.moth/sync/<network>/<name>.sock` | ✓ | Best-effort; ignored if already cleaned by the daemon's shutdown. |
 | `~/.moth/level-db/<network>/<encPub>/` | ✗ | Cannot be derived without the keystore (chicken-and-egg). Lingers as orphaned bytes — safe because the directory is keyed by encryption pubkey, so a re-create with the same name won't collide. |
 | `~/.moth/empty-ref/<network>/` | ✗ | Shared across all wallets on that network; surviving is correct. |
@@ -113,6 +113,8 @@ As of `feat/tui-daemon`'s `removeWalletSyncArtifacts` integration:
 - **Regenerating with the same name is now safe.** The old sync cache is removed, so the new wallet will sync from scratch (or from the empty-ref pre-seed). Pre-fix, this was a real source of confusing test failures during 2026-06-22 integration bring-up.
 - **A crashed daemon may leave a `.sock` file behind.** Run `wallet remove` (which best-effort cleans it) or just remove the file manually before re-launching the daemon.
 - **`level-db/` will accumulate orphans over many wallet generations.** Not a security issue, just disk usage. A separate `moth maintenance prune-level-db` command would address this if it becomes a real footprint problem.
+- **Removal is ordered so an interruption cannot strand the account.** The config entry goes first; the keystore, meta and sync artifacts are deleted after it, cache cleanup last and best-effort. The reverse order leaves an account listed with no keystore — unopenable by any passphrase, and with a single account, a wallet with no way back in, since onboarding only appears for an empty list. A config entry whose keystore is missing is therefore ignored: `list()` omits it and it does not reserve the name.
+- **The extension does the equivalent, and needs more than core to do it.** Its state lives in IndexedDB, not `~/.moth`, so `WalletManager` is constructed with that store (`createMothBrowser`) — without one, core resolved a volatile in-memory store in the browser and removal cleaned nothing durable, which made a re-added account resume the removed one's sync instead of pre-seeding (#90). The offscreen host also stops the sync engine before removing (a running engine flushes its state on stop, and would write it back after the delete) and clears the two keys core knows nothing about: the local submission notes and the dust-repair stamp.
 - **Audit log persists past wallet removal.** Operationally desirable (you can still answer "what did wallet X do before it was removed?") but worth noting if that's a privacy concern in a particular deployment.
 
 ### In-process operations

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -103,6 +103,7 @@ import {
 import { IndexerClient } from '@shieldedtech/moth-wallet/network/indexer-client';
 import { WalletManager } from '@shieldedtech/moth-wallet/wallet/manager';
 import { IndexedDbStorageAdapter } from './adapters/idb-storage.js';
+import { IdbSyncStateStore } from './adapters/idb-sync-store.js';
 
 export interface MothBrowserConfig {
   /** Indexer GraphQL URL. Overrides the network default. */
@@ -149,7 +150,10 @@ export function createMothBrowser(config: MothBrowserConfig = {}) {
   };
 
   const storage = new IndexedDbStorageAdapter();
-  const wallets = new WalletManager(storage);
+  // The sync store is handed over so wallets.remove() can clean the sync state
+  // where the browser actually keeps it. Left out, core resolves a volatile
+  // in-memory store and removal wipes nothing durable (#90).
+  const wallets = new WalletManager(storage, new IdbSyncStateStore(storage));
   const indexer = new IndexerClient(resolvedConfig.indexerUrl);
 
   return {

--- a/packages/core/src/wallet/manager.ts
+++ b/packages/core/src/wallet/manager.ts
@@ -6,6 +6,7 @@ import { encryptKeystore, decryptKeystore, keystoreNeedsUpgrade, type EncryptedK
 import { deriveAllAddressesFromSeed, deriveRawKeys, Roles } from './address.js';
 import { deriveWalletKeys, type WalletKeys } from '../sync/operations.js';
 import { removeWalletSyncArtifacts } from '../sync/wallet-sync.js';
+import type { SyncStateStore } from '../sync/sync-store.js';
 
 const CONFIG_KEY = 'config.json';
 
@@ -100,9 +101,19 @@ function birthdayFor(meta: WalletMeta, network: string): number | undefined {
 
 export class WalletManager {
   private readonly storage: StorageAdapter;
+  private readonly syncStore?: SyncStateStore;
 
-  constructor(storage: StorageAdapter) {
+  /**
+   * `syncStore` is the store this surface keeps its serialized sync state in,
+   * and is only used by `remove()` to clean it up. Optional because on node the
+   * default resolution (the fs-backed `~/.moth/sync` store) is already the
+   * right one — but in the browser it resolves to a volatile in-memory store,
+   * so a surface backed by IndexedDB MUST pass its own or removal silently
+   * cleans nothing. See `remove()`.
+   */
+  constructor(storage: StorageAdapter, syncStore?: SyncStateStore) {
     this.storage = storage;
+    this.syncStore = syncStore;
   }
 
   private async loadConfig(): Promise<WalletConfig> {
@@ -127,6 +138,36 @@ export class WalletManager {
     const data = await this.storage.read(metaKey(name));
     if (!data) return null;
     return JSON.parse(decoder.decode(data)) as WalletMeta;
+  }
+
+  /**
+   * Config entries whose keystore is actually present.
+   *
+   * The config is an index of accounts; the keystore is the account. An entry
+   * without one cannot be unlocked, renamed or exported — every operation on it
+   * fails — yet it still occupies the name and still counts towards "does this
+   * profile have any accounts?". A single such entry is a wallet with no way
+   * back in: the panel offers Unlock for a keystore that no passphrase can
+   * match, and never the "no accounts yet" screen, which needs an EMPTY list.
+   *
+   * Removal now writes the index before deleting what it points at, so this
+   * state is no longer produced. It reads through here rather than being
+   * repaired in place because profiles that already reached it are stranded, and
+   * a read that skips the entry lets them recover on their own: the account list
+   * goes empty, onboarding returns, and creating an account under the same name
+   * succeeds instead of colliding with a ghost.
+   */
+  private async presentWallets(config: WalletConfig): Promise<string[]> {
+    const present: string[] = [];
+    for (const name of config.wallets) {
+      if (await this.storage.exists(walletKey(name))) present.push(name);
+    }
+    return present;
+  }
+
+  /** Whether `name` is taken by an account that actually exists. */
+  private async nameTaken(config: WalletConfig, name: string): Promise<boolean> {
+    return config.wallets.includes(name) && (await this.storage.exists(walletKey(name)));
   }
 
   private validateName(name: string): void {
@@ -168,7 +209,7 @@ export class WalletManager {
     this.validateName(name);
     const config = await this.loadConfig();
 
-    if (config.wallets.includes(name)) {
+    if (await this.nameTaken(config, name)) {
       throw new WalletError('WALLET_ERROR', `Wallet "${name}" already exists`);
     }
 
@@ -194,7 +235,7 @@ export class WalletManager {
     };
     await this.saveMeta(meta);
 
-    config.wallets.push(name);
+    if (!config.wallets.includes(name)) config.wallets.push(name);
     if (!config.activeWallet) config.activeWallet = name;
     await this.saveConfig(config);
 
@@ -211,7 +252,7 @@ export class WalletManager {
     }
 
     const config = await this.loadConfig();
-    if (config.wallets.includes(name)) {
+    if (await this.nameTaken(config, name)) {
       throw new WalletError('WALLET_ERROR', `Wallet "${name}" already exists`);
     }
 
@@ -226,7 +267,7 @@ export class WalletManager {
     const meta: WalletMeta = { name, network, createdAt: new Date().toISOString(), address, createdHere: false };
     await this.saveMeta(meta);
 
-    config.wallets.push(name);
+    if (!config.wallets.includes(name)) config.wallets.push(name);
     if (!config.activeWallet) config.activeWallet = name;
     await this.saveConfig(config);
 
@@ -243,7 +284,7 @@ export class WalletManager {
 
     this.validateName(name);
     const config = await this.loadConfig();
-    if (config.wallets.includes(name)) {
+    if (await this.nameTaken(config, name)) {
       throw new WalletError('WALLET_ERROR', `Wallet "${name}" already exists`);
     }
 
@@ -251,7 +292,7 @@ export class WalletManager {
     const meta: WalletMeta = { name, network, createdAt: new Date().toISOString(), address, createdHere: false };
     await this.saveMeta(meta);
 
-    config.wallets.push(name);
+    if (!config.wallets.includes(name)) config.wallets.push(name);
     if (!config.activeWallet) config.activeWallet = name;
     await this.saveConfig(config);
 
@@ -432,38 +473,66 @@ export class WalletManager {
       throw new WalletError('WALLET_ERROR', `Wallet "${name}" not found`);
     }
 
-    // Read meta BEFORE deleting it so we know which network's sync
-    // artifacts to clean. A wallet records exactly one network at
-    // generation; subsequent unlocks always run on that same id.
-    let networkId: string | null = null;
+    // Read meta BEFORE deleting it so we know which networks' sync artifacts to
+    // clean. `meta.network` is where the wallet is now; `birthdays` records every
+    // network it has arrived on, and setNetwork deliberately leaves the previous
+    // network's cache in place for a cheap return trip — so a removal that only
+    // cleaned the current one would leave the earlier ones behind.
+    const networkIds = new Set<string>();
     try {
       const metaBuf = await this.storage.read(metaKey(name));
       if (metaBuf) {
         const meta = JSON.parse(new TextDecoder().decode(metaBuf)) as WalletMeta;
-        networkId = meta.network ?? null;
+        if (meta.network) networkIds.add(meta.network);
+        for (const id of Object.keys(meta.birthdays ?? {})) networkIds.add(id);
       }
     } catch {
       /* meta unreadable — proceed; cache cleanup is best-effort anyway */
     }
 
-    await this.storage.delete(walletKey(name));
-    await this.storage.delete(metaKey(name));
-
-    // Clean per-wallet sync artifacts (~/.moth/sync/<network>/<name>/
-    // and the matching .sock). Without this, regenerating a wallet
-    // under the same name would silently inherit stale sync state
-    // belonging to the prior seed — a real footgun observed during
-    // 2026-06-22 debugging. See docs/spec/wallet-service/COMMANDS.md
-    // §"Wallet lifecycle" for the full list of what remove touches.
-    if (networkId) {
-      await removeWalletSyncArtifacts(name, networkId);
-    }
-
+    // Update the index FIRST, before deleting anything it points at.
+    //
+    // The two failure modes are not symmetric. An entry left in the config whose
+    // keystore is already gone is an account the wallet lists but no passphrase
+    // can open — and when it is the only account, that is a wallet you cannot
+    // get back into, since the "no accounts yet" path never runs. An orphaned
+    // keystore with no entry is invisible, costs a few encrypted bytes, and is
+    // overwritten by the next wallet created under that name. So the index goes
+    // first and everything below it is cleanup.
     config.wallets = config.wallets.filter(w => w !== name);
     if (config.activeWallet === name) {
       config.activeWallet = config.wallets[0] ?? null;
     }
     await this.saveConfig(config);
+
+    await this.storage.delete(walletKey(name));
+    await this.storage.delete(metaKey(name));
+
+    // Clean per-wallet sync artifacts: the serialized sub-wallet state in the
+    // sync store, plus (on node) ~/.moth/sync/<network>/<name>/ and the matching
+    // .sock. Without this, regenerating a wallet under the same name would
+    // silently inherit stale sync state belonging to the prior seed — a real
+    // footgun observed during 2026-06-22 debugging. See
+    // docs/spec/wallet-service/COMMANDS.md §"Wallet lifecycle" for the full list
+    // of what remove touches.
+    //
+    // `this.syncStore` matters here: with no store the resolution falls back to
+    // the fs-backed one on node — correct for the CLI/TUI/daemon — but to a
+    // volatile in-memory store in the browser, where it cleaned nothing at all
+    // and a re-added account resumed the removed one's sync (#90).
+    //
+    // Best-effort by construction: this is the slowest part of the removal and
+    // the one reaching outside this manager, so a store that rejects must not
+    // take the removal down with it. The account is already gone from the index
+    // by this point; a cache left behind is a stale-state risk on re-create,
+    // which is bad, but a half-removed account is worse.
+    for (const networkId of networkIds) {
+      try {
+        await removeWalletSyncArtifacts(name, networkId, this.syncStore);
+      } catch {
+        /* cache cleanup is best-effort — never fail a removal over it */
+      }
+    }
   }
 
   /**
@@ -480,7 +549,7 @@ export class WalletManager {
       dust: emptyAddr, zswap: emptyAddr, metadata: emptyAddr,
     };
 
-    for (const name of config.wallets) {
+    for (const name of await this.presentWallets(config)) {
       const meta = await this.loadMeta(name);
       wallets.push({
         name,

--- a/packages/core/tests/unit/wallet/manager.test.ts
+++ b/packages/core/tests/unit/wallet/manager.test.ts
@@ -27,6 +27,10 @@ describe('WalletManager.setLabel', () => {
         }),
       ),
     );
+    // The keystore is what makes an account an account: list() skips a config
+    // entry without one, since nothing can be done with it and a profile left
+    // holding only such entries could not reach onboarding.
+    await storage.write('wallets/alice.keystore', encoder.encode('{"ciphertext":"…"}'));
     return storage;
   }
 

--- a/packages/core/tests/unit/wallet/network-birthdays.test.ts
+++ b/packages/core/tests/unit/wallet/network-birthdays.test.ts
@@ -22,6 +22,9 @@ async function seedLegacyMeta(storage: MemoryStorage, meta: Record<string, unkno
     `wallets/${meta.name}.meta`,
     new TextEncoder().encode(JSON.stringify(meta)),
   );
+  // An account is its keystore; list() skips a config entry without one, so a
+  // meta-only fixture would not appear at all.
+  await storage.write(`wallets/${meta.name}.keystore`, new TextEncoder().encode('{"ciphertext":"…"}'));
   await storage.write(
     'config.json',
     new TextEncoder().encode(

--- a/packages/core/tests/unit/wallet/remove-sync-state.test.ts
+++ b/packages/core/tests/unit/wallet/remove-sync-state.test.ts
@@ -1,0 +1,333 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { StorageAdapter } from '../../../src/storage/adapter.js';
+import { WalletManager } from '../../../src/wallet/manager.js';
+import {
+  InMemorySyncStateStore,
+  emptyRefHeightKey,
+  emptyRefStateKey,
+  syncStateKey,
+} from '../../../src/sync/sync-store.js';
+import { shouldAttemptPreSeed } from '../../../src/sync/preseed-parts.js';
+
+// Removing an account must leave nothing of it behind, because re-adding the
+// same seed is the one recovery a user reaches for when a sync is stuck. State
+// that survives makes the re-added account resume the removed one's sync
+// instead of starting fresh — silently, since the only visible difference is a
+// "Restoring … from cache" line where a "Pre-seeding" one belongs (#90).
+//
+// The manager is given the store its surface actually uses. That argument is
+// the whole fix on the extension side: with none, core resolves the fs-backed
+// store on node (right for the CLI/TUI/daemon) but a volatile in-memory one in
+// the browser, so removal there cleaned nothing durable at all.
+
+class MemoryStorage implements StorageAdapter {
+  private readonly values = new Map<string, Uint8Array>();
+  /** Every mutating call, in order — for asserting what happens before what. */
+  readonly ops: string[] = [];
+
+  async read(key: string): Promise<Uint8Array | null> {
+    return this.values.get(key) ?? null;
+  }
+
+  async write(key: string, data: Uint8Array): Promise<void> {
+    this.ops.push(`write ${key}`);
+    this.values.set(key, data);
+  }
+
+  async delete(key: string): Promise<void> {
+    this.ops.push(`delete ${key}`);
+    this.values.delete(key);
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    return [...this.values.keys()].filter((key) => key.startsWith(prefix));
+  }
+
+  async exists(key: string): Promise<boolean> {
+    return this.values.has(key);
+  }
+}
+
+const encoder = new TextEncoder();
+
+const PARTS = ['shielded', 'unshielded', 'dust', 'history'] as const;
+
+async function cachedParts(store: InMemorySyncStateStore, network: string, wallet: string) {
+  return {
+    shielded: await store.get(syncStateKey(network, wallet, 'shielded')),
+    unshielded: await store.get(syncStateKey(network, wallet, 'unshielded')),
+    dust: await store.get(syncStateKey(network, wallet, 'dust')),
+    history: await store.get(syncStateKey(network, wallet, 'history')),
+  };
+}
+
+describe('WalletManager.remove clears sync state', () => {
+  let storage: MemoryStorage;
+  let store: InMemorySyncStateStore;
+  let home: string;
+  let realHome: string | undefined;
+
+  beforeEach(async () => {
+    // remove() also does the node-only half of the cleanup — rm -rf on
+    // ~/.moth/sync/<network>/<wallet> and its .sock — regardless of the store
+    // it was handed. Under vitest that is the DEVELOPER's ~/.moth, so point HOME
+    // at a temp dir for the duration: a wallet name here colliding with a real
+    // one would otherwise delete real sync state.
+    realHome = process.env.HOME;
+    home = mkdtempSync(join(tmpdir(), 'moth-remove-test-'));
+    process.env.HOME = home;
+
+    storage = new MemoryStorage();
+    store = new InMemorySyncStateStore();
+
+    await storage.write(
+      'config.json',
+      encoder.encode(
+        JSON.stringify({
+          activeWallet: 'alice',
+          wallets: ['alice', 'bob'],
+          defaultNetwork: 'devnet',
+          configVersion: 1,
+        }),
+      ),
+    );
+    // alice was created on devnet and has since been moved to preview, so she
+    // has a cache on both — setNetwork deliberately keeps the old one for a
+    // cheap return trip.
+    await storage.write(
+      'wallets/alice.meta',
+      encoder.encode(
+        JSON.stringify({
+          name: 'alice',
+          network: 'preview',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          createdHere: true,
+          birthdays: { devnet: 1_985_914, preview: 2_087_202 },
+        }),
+      ),
+    );
+    await storage.write('wallets/alice.keystore', encoder.encode('{"ciphertext":"…"}'));
+    await storage.write(
+      'wallets/bob.meta',
+      encoder.encode(JSON.stringify({ name: 'bob', network: 'preview', createdAt: '2026-01-01T00:00:00.000Z' })),
+    );
+    // A real second account, keystore included — list() skips entries without
+    // one, so a keystore-less fixture would not be an account at all.
+    await storage.write('wallets/bob.keystore', encoder.encode('{"ciphertext":"…"}'));
+
+    for (const part of PARTS) {
+      await store.put(syncStateKey('preview', 'alice', part), `alice-preview-${part}`);
+      await store.put(syncStateKey('devnet', 'alice', part), `alice-devnet-${part}`);
+      await store.put(syncStateKey('preview', 'bob', part), `bob-preview-${part}`);
+      await store.put(emptyRefStateKey('preview', part), `ref-preview-${part}`);
+    }
+    await store.put(emptyRefHeightKey('preview'), '2203416');
+  });
+
+  afterEach(() => {
+    if (realHome === undefined) delete process.env.HOME;
+    else process.env.HOME = realHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('deletes the removed account state from the store it was given', async () => {
+    await new WalletManager(storage, store).remove('alice');
+
+    expect(await cachedParts(store, 'preview', 'alice')).toEqual({
+      shielded: null,
+      unshielded: null,
+      dust: null,
+      history: null,
+    });
+  });
+
+  it('leaves a re-added account with nothing to restore, so it pre-seeds', async () => {
+    const manager = new WalletManager(storage, store);
+    await manager.remove('alice');
+
+    // The production predicate startWalletSync branches on: every seedable part
+    // absent means the re-added account takes the pre-seed path. Before the fix
+    // all three were still cached in the browser and it restored instead.
+    expect(shouldAttemptPreSeed(await cachedParts(store, 'preview', 'alice'))).toBe(true);
+  });
+
+  it('clears every network the account has been on, not just the current one', async () => {
+    await new WalletManager(storage, store).remove('alice');
+
+    // A cache left on a network the account was moved away from is the worse
+    // half of this bug: re-adding the name with a DIFFERENT seed and switching
+    // back would apply one seed's cached state while holding another's keys.
+    expect(await cachedParts(store, 'devnet', 'alice')).toEqual({
+      shielded: null,
+      unshielded: null,
+      dust: null,
+      history: null,
+    });
+  });
+
+  it('touches neither another account nor the shared pre-seed reference', async () => {
+    await new WalletManager(storage, store).remove('alice');
+
+    expect(await cachedParts(store, 'preview', 'bob')).toEqual({
+      shielded: 'bob-preview-shielded',
+      unshielded: 'bob-preview-unshielded',
+      dust: 'bob-preview-dust',
+      history: 'bob-preview-history',
+    });
+    // The reference is chain state, shared by every account and expensive to
+    // rebuild — a removal must never take it with them.
+    expect(await store.get(emptyRefStateKey('preview', 'dust'))).toBe('ref-preview-dust');
+    expect(await store.get(emptyRefHeightKey('preview'))).toBe('2203416');
+  });
+
+  it('still removes the keystore, the meta record and the config entry', async () => {
+    const manager = new WalletManager(storage, store);
+    await manager.remove('alice');
+
+    expect(await storage.exists('wallets/alice.keystore')).toBe(false);
+    expect(await storage.exists('wallets/alice.meta')).toBe(false);
+    expect((await manager.list()).map((w) => w.name)).toEqual(['bob']);
+  });
+
+  it('rejects an unknown account without clearing anything', async () => {
+    await expect(new WalletManager(storage, store).remove('carol')).rejects.toThrow('not found');
+
+    expect(await store.get(syncStateKey('preview', 'alice', 'dust'))).toBe('alice-preview-dust');
+  });
+});
+
+
+// Removal is several steps against several stores, and it can be interrupted
+// part-way — in the extension the offscreen document hosting it can be closed
+// mid-call. What survives an interruption is therefore a design question, not an
+// implementation detail: an account still listed in the config whose keystore is
+// already deleted is one no passphrase can open, and if it was the only account
+// the wallet has no way back in at all, because the "no accounts yet" screen
+// only shows for an EMPTY list.
+
+describe('WalletManager.remove leaves a consistent account list', () => {
+  const encoderLocal = new TextEncoder();
+
+  async function oneAccount(): Promise<MemoryStorage> {
+    const storage = new MemoryStorage();
+    await storage.write(
+      'config.json',
+      encoderLocal.encode(
+        JSON.stringify({ activeWallet: 'alice', wallets: ['alice'], defaultNetwork: 'devnet', configVersion: 1 }),
+      ),
+    );
+    await storage.write(
+      'wallets/alice.meta',
+      encoderLocal.encode(JSON.stringify({ name: 'alice', network: 'devnet', createdAt: '2026-01-01T00:00:00.000Z' })),
+    );
+    await storage.write('wallets/alice.keystore', encoderLocal.encode('{"ciphertext":"…"}'));
+    return storage;
+  }
+
+  it('writes the config before deleting the keystore it points at', async () => {
+    const storage = await oneAccount();
+    storage.ops.length = 0;
+
+    await new WalletManager(storage, new InMemorySyncStateStore()).remove('alice');
+
+    const configWrite = storage.ops.indexOf('write config.json');
+    const keystoreDelete = storage.ops.indexOf('delete wallets/alice.keystore');
+    expect(configWrite).toBeGreaterThanOrEqual(0);
+    expect(keystoreDelete).toBeGreaterThanOrEqual(0);
+    // Interrupted between the two, the account is gone from the list and its
+    // keystore is orphaned — invisible, and overwritten by the next wallet of
+    // that name. The reverse order strands the account instead.
+    expect(configWrite).toBeLessThan(keystoreDelete);
+  });
+
+  it('removes the last account cleanly, leaving an empty list and no active wallet', async () => {
+    const storage = await oneAccount();
+    const manager = new WalletManager(storage, new InMemorySyncStateStore());
+
+    await manager.remove('alice');
+
+    expect(await manager.list()).toEqual([]);
+    const config = JSON.parse(new TextDecoder().decode((await storage.read('config.json'))!));
+    expect(config.wallets).toEqual([]);
+    expect(config.activeWallet).toBeNull();
+  });
+
+  it('still removes the account when clearing its sync state fails', async () => {
+    const storage = await oneAccount();
+    // A store that rejects: IndexedDB mid-teardown, a closed connection, a
+    // browser that has revoked storage. Cache cleanup is the slowest, most
+    // outward-reaching part of a removal and must never strand the account.
+    const hostileStore: InMemorySyncStateStore = {
+      get: async () => null,
+      put: async () => {},
+      delete: async () => {
+        throw new Error('IndexedDB connection is closing');
+      },
+    } as unknown as InMemorySyncStateStore;
+
+    await expect(new WalletManager(storage, hostileStore).remove('alice')).resolves.toBeUndefined();
+
+    const config = JSON.parse(new TextDecoder().decode((await storage.read('config.json'))!));
+    expect(config.wallets).toEqual([]);
+    expect(await storage.exists('wallets/alice.keystore')).toBe(false);
+  });
+});
+
+
+// A profile that already reached the stranded state — an entry in the config
+// with no keystore — has to be able to recover without developer tools. These
+// pin the read paths that make that possible.
+
+describe('WalletManager tolerates a config entry with no keystore', () => {
+  const enc = new TextEncoder();
+
+  async function ghostEntry(): Promise<MemoryStorage> {
+    const storage = new MemoryStorage();
+    await storage.write(
+      'config.json',
+      enc.encode(
+        JSON.stringify({ activeWallet: 'alice', wallets: ['alice'], defaultNetwork: 'devnet', configVersion: 1 }),
+      ),
+    );
+    // Meta may or may not survive; the keystore is what makes an account real.
+    await storage.write(
+      'wallets/alice.meta',
+      enc.encode(JSON.stringify({ name: 'alice', network: 'devnet', createdAt: '2026-01-01T00:00:00.000Z' })),
+    );
+    return storage;
+  }
+
+  it('hides it from list(), so onboarding returns instead of an unopenable Unlock', async () => {
+    expect(await new WalletManager(await ghostEntry()).list()).toEqual([]);
+  });
+
+  it('lets the same name be created again rather than colliding with the ghost', async () => {
+    const manager = new WalletManager(await ghostEntry());
+
+    const created = await manager.generate('alice', 'correct horse battery staple', 'devnet');
+
+    expect(created.name).toBe('alice');
+    expect((await manager.list()).map((w) => w.name)).toEqual(['alice']);
+  }, 30_000);
+
+  it('lists a name once after reclaiming it, not twice', async () => {
+    const storage = await ghostEntry();
+    const manager = new WalletManager(storage);
+
+    await manager.generate('alice', 'correct horse battery staple', 'devnet');
+
+    const config = JSON.parse(new TextDecoder().decode((await storage.read('config.json'))!));
+    expect(config.wallets).toEqual(['alice']);
+  }, 30_000);
+
+  it('still refuses a name whose keystore is really there', async () => {
+    const storage = await ghostEntry();
+    const manager = new WalletManager(storage);
+    await manager.generate('alice', 'correct horse battery staple', 'devnet');
+
+    await expect(manager.generate('alice', 'another passphrase entirely', 'devnet')).rejects.toThrow('already exists');
+  }, 60_000);
+});

--- a/packages/extension/lib/background/handlers.ts
+++ b/packages/extension/lib/background/handlers.ts
@@ -107,6 +107,35 @@ export async function lockNow(): Promise<void> {
 }
 
 /**
+ * Remove an account, then lock if it was the one unlocked.
+ *
+ * The order matters and used to be the other way round. `lockNow()` starts a
+ * teardown it deliberately does not await, and teardown CLOSES the offscreen
+ * document — so the removal that followed it was racing a shutdown of the very
+ * process doing the work. An interrupted removal left the account listed with
+ * its keystore already deleted, and with one account that is a wallet nobody can
+ * open again: the panel shows Unlock rather than the "no accounts yet" screen,
+ * and no passphrase can match a keystore that is gone.
+ *
+ * So: remove first, holding the document open with an op guard for the same
+ * reason a send holds it, and lock afterwards. The session still holds key
+ * material while the removal runs, for the seconds it takes; it is cleared
+ * immediately after, and core's remove() no longer depends on finishing to
+ * leave a consistent account list either.
+ */
+export async function removeWallet(name: string): Promise<void> {
+  const { network } = await getSettings();
+  const session = await getSession();
+  beginOp();
+  try {
+    await offscreen.walletRemove(name, network);
+  } finally {
+    endOp();
+  }
+  if (session?.walletName === name) await lockNow();
+}
+
+/**
  * Auto-lock tick, invoked by the alarm. Locks the wallet once the configured
  * inactivity window has elapsed. Skips demo mode and defers whenever a
  * transaction op or pending approval is in flight — locking drops the seed and
@@ -345,12 +374,7 @@ export function registerHandlers(): void {
     });
   });
 
-  onMessage('walletRemove', async ({ data }) => {
-    const { network } = await getSettings();
-    const session = await getSession();
-    if (session?.walletName === data.name) await lockNow();
-    await offscreen.walletRemove(data.name, network);
-  });
+  onMessage('walletRemove', ({ data }) => removeWallet(data.name));
 
   onMessage('walletSetActive', async ({ data }) => {
     const { network } = await getSettings();

--- a/packages/extension/lib/offscreen/wallet-host.ts
+++ b/packages/extension/lib/offscreen/wallet-host.ts
@@ -162,8 +162,48 @@ export async function walletImport(name: string, mnemonic: string, passphrase: s
   return getMoth(network).wallets.import(name, mnemonic, passphrase, network);
 }
 
+/**
+ * Remove an account and everything this profile keys to it.
+ *
+ * core's `remove()` deletes the keystore, the meta record and the serialized
+ * sync state — the last of those only because `createMothBrowser` now hands the
+ * manager this profile's IndexedDB sync store; without it core resolved a
+ * volatile in-memory store and the removal cleaned nothing durable. Two things
+ * it cannot do from in there, and both are why a re-added account used to
+ * resume the removed one's sync instead of starting fresh (#90):
+ *
+ *  - Stop the engine first. A running sync writes its final state when it
+ *    stops, so a removal racing that flush deletes the state and has it written
+ *    straight back — the removed account's dust cursor reappearing to the
+ *    event. `lockNow()` fires teardown without awaiting it, so that flush is
+ *    genuinely in flight by the time this runs.
+ *  - Delete the per-account keys core knows nothing about: the local submission
+ *    notes and the dust-repair stamp.
+ */
 export async function walletRemove(name: string, network: string): Promise<void> {
-  await getMoth(network).wallets.remove(name);
+  const moth = getMoth(network);
+  // `network` is the ACTIVE network, which is not necessarily the one this
+  // account is recorded against — the accounts list shows every account in the
+  // profile. Read the account's own network before the removal takes the record
+  // with it, so the per-account keys below are the ones it actually wrote.
+  const recorded = (await moth.wallets.list().catch(() => [])).find((w) => w.name === name)?.network;
+
+  // Stop this account's engine, or — when `current` is already null because a
+  // teardown cleared it before its slow stop — wait for that flush to land.
+  // Another account's sync is left running: it cannot write this account's keys.
+  if (!current || current.key === `${network}/${name}`) await syncStop();
+
+  await moth.wallets.remove(name);
+
+  // Extension-only per-account state, in the same store as the sync state.
+  // core covers the sync state on every network the account has been on; these
+  // two keys are ours, so clear them on both the recorded network and the one
+  // the removal was issued from.
+  const store = new IdbSyncStateStore();
+  for (const networkId of new Set([network, ...(recorded ? [recorded] : [])])) {
+    await store.delete(submissionsKey(networkId, name)).catch(() => {});
+    await store.delete(dustHealKey(networkId, name)).catch(() => {});
+  }
 }
 
 export async function walletSetActive(name: string, network: string): Promise<void> {

--- a/packages/extension/tests/wallet-host-remove.test.ts
+++ b/packages/extension/tests/wallet-host-remove.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { syncStateKey } from '@shieldedtech/moth-wallet/sync/sync-store';
+import { submissionsKey } from '../lib/offscreen/submissions';
+import { dustHealKey } from '../lib/offscreen/dust-heal';
+
+// Removing an account must leave nothing of it behind in this profile: the
+// account a user re-adds to escape a stuck sync has to start fresh, and a
+// re-added NAME may hold a different seed entirely (#90).
+//
+// Two failures met here, neither visible in the UI:
+//  - core cleaned a sync store the browser never writes to, so IndexedDB kept
+//    the removed account's state (covered in core: remove-sync-state.test.ts —
+//    this suite covers the store actually being handed over, and the rest).
+//  - the engine flushes its final state when it stops, and lockNow() fires that
+//    teardown without awaiting it. A removal that deletes first has the state
+//    written straight back, which is why the removed account's dust cursor came
+//    back to the event.
+
+// One fake IndexedDB-backed sync store shared by every `new IdbSyncStateStore()`
+// in the module under test, mirroring how they all address one database.
+const entries = new Map<string, string>();
+
+const { remove, list, stop, subscribe } = vi.hoisted(() => ({
+  remove: vi.fn(),
+  list: vi.fn(),
+  stop: vi.fn(),
+  subscribe: vi.fn(),
+}));
+
+vi.mock('@shieldedtech/moth-browser', () => ({
+  createMothBrowser: () => ({ wallets: { remove, list } }),
+  startWalletSync: () => Promise.resolve({ stop, subscribe, balances: {}, refresh: vi.fn() }),
+  IdbSyncStateStore: class {
+    async get(key: string) {
+      return entries.get(key) ?? null;
+    }
+    async put(key: string, value: string) {
+      entries.set(key, value);
+    }
+    async delete(key: string) {
+      entries.delete(key);
+    }
+  },
+  deriveWalletKeys: () => ({ shieldedSecretKeys: {}, dustSecretKey: {}, nightExternalKey: new Uint8Array() }),
+  // Untouched by these paths; present so the module's imports resolve.
+  buildTransferTransaction: vi.fn(),
+  estimateTransferFee: vi.fn(),
+  balanceTransaction: vi.fn(),
+  buildSwapIntent: vi.fn(),
+  designateForDust: vi.fn(),
+  dedesignateFromDust: vi.fn(),
+  submitFinalizedTransaction: vi.fn(),
+  deriveShieldedPublicKeys: vi.fn(),
+  clearSyncCache: vi.fn(),
+  clearDustSyncCache: vi.fn(),
+  signMessage: vi.fn(),
+  deriveActivity: vi.fn(),
+  createProvingProvider: vi.fn(),
+  ensureProverReady: vi.fn(),
+  resolveProverConfig: vi.fn(),
+  EMPTY_COINS: {},
+}));
+
+// The bundled reference is fetched from the package; there is no fetch here.
+vi.mock('../lib/offscreen/bundled-preseed', () => ({
+  installBundledReference: vi.fn(async () => false),
+  hasBundledReference: vi.fn(() => false),
+}));
+
+type Host = typeof import('../lib/offscreen/wallet-host');
+
+const NETWORK = {
+  id: 'devnet',
+  nodeUrl: 'ws://localhost:9944',
+  indexerUrl: 'http://localhost:8088/api/v4/graphql',
+  prover: { type: 'server', url: 'http://localhost:6300' },
+} as unknown as Parameters<Host['syncEnsure']>[2];
+
+const PARTS = ['shielded', 'unshielded', 'dust', 'history'] as const;
+
+function seedState(wallet: string, network = 'devnet'): void {
+  for (const part of PARTS) entries.set(syncStateKey(network, wallet, part), `${wallet}-${part}`);
+  entries.set(submissionsKey(network, wallet), '[{"hash":"0xabc"}]');
+  entries.set(dustHealKey(network, wallet), '1782127919459');
+}
+
+describe('offscreen walletRemove', () => {
+  let host: Host;
+
+  beforeEach(async () => {
+    // The host keeps the running engine in module state, so each case gets its
+    // own copy — otherwise "no sync was ever started" inherits the previous
+    // case's engine.
+    vi.resetModules();
+    host = await import('../lib/offscreen/wallet-host');
+    entries.clear();
+    remove.mockReset().mockResolvedValue(undefined);
+    list.mockReset().mockResolvedValue([{ name: 'alice', birthday: 2_087_202 }]);
+    stop.mockReset().mockResolvedValue(undefined);
+    subscribe.mockReset().mockReturnValue(() => {});
+  });
+
+  it('stops the account sync before core deletes its state', async () => {
+    await host.syncEnsure('ab'.repeat(32), 'alice', NETWORK);
+    seedState('alice');
+
+    await host.walletRemove('alice', 'devnet');
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    // The whole point: the engine's final write lands before the delete, not
+    // after it. Reversed, the removed account's state is restored on re-add.
+    expect(stop.mock.invocationCallOrder[0]!).toBeLessThan(remove.mock.invocationCallOrder[0]!);
+    expect(remove).toHaveBeenCalledWith('alice');
+  });
+
+  it('deletes the per-account keys core knows nothing about', async () => {
+    seedState('alice');
+
+    await host.walletRemove('alice', 'devnet');
+
+    // Submission notes would show the removed account's pending rows under the
+    // re-added one; the dust stamp would deny it a repair it never had.
+    expect(entries.has(submissionsKey('devnet', 'alice'))).toBe(false);
+    expect(entries.has(dustHealKey('devnet', 'alice'))).toBe(false);
+  });
+
+  it('clears those keys on the account\'s own network, not just the active one', async () => {
+    // The accounts list shows every account in the profile, so an account
+    // recorded on preview can be removed while devnet is the active network.
+    list.mockResolvedValue([{ name: 'alice', network: 'preview', birthday: 2_087_202 }]);
+    seedState('alice', 'preview');
+
+    await host.walletRemove('alice', 'devnet');
+
+    expect(entries.has(submissionsKey('preview', 'alice'))).toBe(false);
+    expect(entries.has(dustHealKey('preview', 'alice'))).toBe(false);
+  });
+
+  it('leaves another account alone, including its running sync', async () => {
+    await host.syncEnsure('ab'.repeat(32), 'alice', NETWORK);
+    seedState('alice');
+    seedState('bob');
+
+    await host.walletRemove('bob', 'devnet');
+
+    // Removing bob must not stop the account that is actually syncing.
+    expect(stop).not.toHaveBeenCalled();
+    expect(entries.get(submissionsKey('devnet', 'alice'))).toBe('[{"hash":"0xabc"}]');
+    expect(entries.get(dustHealKey('devnet', 'alice'))).toBe('1782127919459');
+  });
+
+  it('still removes an account whose sync was never started', async () => {
+    seedState('alice');
+
+    await expect(host.walletRemove('alice', 'devnet')).resolves.toBeUndefined();
+
+    expect(remove).toHaveBeenCalledWith('alice');
+    expect(stop).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/tests/wallet-remove-handler.test.ts
+++ b/packages/extension/tests/wallet-remove-handler.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+
+// Deleting an account must not be able to close the process doing the deleting.
+//
+// lockNow() starts a teardown it does not await, and teardown closes the
+// offscreen document — so locking BEFORE the removal raced a shutdown of the
+// very thing performing it. Interrupted, the account stayed in the config with
+// its keystore already gone: the panel then shows Unlock (the "no accounts yet"
+// screen needs an EMPTY list) for a keystore no passphrase can match, which with
+// a single account is a wallet with no way back in.
+
+const walletRemoveHost = vi.fn<(name: string, network: string) => Promise<void>>();
+vi.mock('../lib/background/offscreen-client', () => ({
+  offscreen: {
+    walletRemove: (...args: unknown[]) => walletRemoveHost(...(args as [string, string])),
+  },
+}));
+
+const beginOp = vi.fn();
+const endOp = vi.fn();
+const teardown = vi.fn(async () => {});
+const clearSnapshot = vi.fn(async () => {});
+vi.mock('../lib/background/sync-service', () => ({
+  beginOp: () => beginOp(),
+  endOp: () => endOp(),
+  teardown: (...a: unknown[]) => teardown(...(a as [])),
+  clearSnapshot: () => clearSnapshot(),
+  stopSync: vi.fn(async () => {}),
+  startSync: vi.fn(async () => {}),
+  getSnapshot: vi.fn(),
+  hasOpenPorts: vi.fn(() => true),
+  getSetupTabIds: vi.fn(() => []),
+}));
+
+import { removeWallet } from '../lib/background/handlers';
+import { getSession, saveSession, type Session } from '../lib/background/session';
+import { updateSettings } from '../lib/background/settings';
+
+const SESSION = {
+  walletName: 'alice',
+  seedHex: 'ab'.repeat(32),
+  address: 'mn_unshielded_devnet',
+  addresses: { nightExternal: { hex: '', bech32m: { devnet: 'mn_unshielded_devnet' } } },
+  shieldedCoinPublicKey: 'c0'.repeat(16),
+  shieldedEncryptionPublicKey: 'e0'.repeat(16),
+  network: 'devnet',
+  unlockedAt: 1,
+} as unknown as Session;
+
+describe('walletRemove handler', () => {
+  beforeEach(async () => {
+    fakeBrowser.reset();
+    walletRemoveHost.mockReset().mockResolvedValue(undefined);
+    beginOp.mockReset();
+    endOp.mockReset();
+    teardown.mockReset().mockResolvedValue(undefined);
+    clearSnapshot.mockReset().mockResolvedValue(undefined);
+    await updateSettings({ network: 'devnet', customEndpoints: null });
+    await saveSession(SESSION);
+  });
+
+  it('removes the account before tearing the offscreen document down', async () => {
+    await removeWallet('alice');
+
+    expect(walletRemoveHost).toHaveBeenCalledWith('alice', 'devnet');
+    expect(teardown).toHaveBeenCalledTimes(1);
+    expect(walletRemoveHost.mock.invocationCallOrder[0]!).toBeLessThan(teardown.mock.invocationCallOrder[0]!);
+  });
+
+  it('holds the document open for the duration with an op guard', async () => {
+    // The idle teardown timer does not care that a removal is in flight; the op
+    // guard is what every other multi-second offscreen call uses to say so.
+    let openWhileRemoving = false;
+    walletRemoveHost.mockImplementation(async () => {
+      openWhileRemoving = beginOp.mock.calls.length === 1 && endOp.mock.calls.length === 0;
+    });
+
+    await removeWallet('alice');
+
+    expect(openWhileRemoving).toBe(true);
+    expect(endOp).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the op guard and still locks when the removal throws', async () => {
+    walletRemoveHost.mockRejectedValue(new Error('offscreen closed'));
+
+    await expect(removeWallet('alice')).rejects.toThrow('offscreen closed');
+
+    expect(endOp).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves another account\'s session alone', async () => {
+    await removeWallet('bob');
+
+    expect(walletRemoveHost).toHaveBeenCalledWith('bob', 'devnet');
+    // Removing an account that is not the unlocked one must not lock the wallet.
+    expect(teardown).not.toHaveBeenCalled();
+    expect(await getSession()).toEqual(expect.objectContaining({ walletName: 'alice' }));
+  });
+});


### PR DESCRIPTION
Removing an account in the extension left its sync state behind, so re-adding
the same seed resumed the removed account's sync instead of starting fresh --
and a name re-used with a DIFFERENT seed would apply one seed's cached state
while holding another's keys.

Two causes. core's remove() cleaned the sync store it resolves by default,
which in the browser is a volatile in-memory one, not the IndexedDB store the
extension actually writes; WalletManager now takes the store its surface uses
and createMothBrowser passes it. And the sync engine flushes its state when it
stops, which lockNow() sets going without awaiting -- so the flush landed after
the delete and restored the cursor to the event. The offscreen host now stops
the engine before removing, and clears the per-account keys core does not know
about (submission notes, dust-repair stamp).

remove() also clears every network the account has been on rather than only the
current one: set-network deliberately keeps the previous network's cache, which
outlived removal.

Closes #90

# Overview

<!-- Describe your changes briefly here, with some context as to why this is needed. -->

## Submission Checklist

<!-- Please check all the boxes that apply to your pull request. -->

- [ ] Useful pull request description
- [ ] Tests are provided (if possible)
- [ ] Key commits have useful messages
- [ ] Every non-merge, non-bot commit has a matching DCO `Signed-off-by` trailer
- [ ] All check jobs of the CI have succeeded
- [ ] Self-reviewed the diff
- [ ] Reviewer requested
- [ ] Update README.md file (if relevant)
- [ ] Update documentation (if relevant)
- [ ] No new todos introduced

## Links

<!--
- Link any relevant Confluence or additional Jira tickets if need be
- If your PR closes some of the existing issues, please add links to them here.
  Mentioned issues will be automatically closed.
  Usage: "Closes #<issue number>", or "Closes (paste link of issue)"
-->
