### PR TITLE
extension: give a hung sync a way out, not just a failed one

### DIFF
--- a/.changeset/wallet-loading-slow-sync-escape.md
+++ b/.changeset/wallet-loading-slow-sync-escape.md
@@ -1,0 +1,18 @@
+---
+'@shieldedtech/moth-extension': patch
+---
+
+Give a hung sync a way out, not just a failed one.
+
+The loading screen shown after create/restore/unlock only offered "Change
+network" once a sync had thrown — a message prefixed `Sync failed:`. A sync
+that hangs without ever throwing (the wrong network selected, an unreachable
+endpoint, or a subsystem whose progress reads 100% but never flips `isSynced`)
+left the panel showing "Getting things ready" forever, with no error and no
+way to reach Settings -> Network: the router shows only this screen until a
+balance snapshot arrives, so there was no route out.
+
+`WalletLoading` now takes a `slow` prop; once a wait has held for 20s without
+a balance snapshot, it shows the same "network unreachable" hint and "Change
+network" action the failure path already had. A new `useSlowSync` hook in
+`lib/ui/client.ts` times it and resets whenever the wait ends.

--- a/packages/extension/components/screens/WalletLoading.tsx
+++ b/packages/extension/components/screens/WalletLoading.tsx
@@ -21,10 +21,24 @@ function loadingDetail(syncMessage: string): string {
  * rebuilds its shielded, unshielded, and DUST state. */
 export function WalletLoading({
   syncMessage,
+  slow = false,
   onOpenNetwork,
 }: {
   syncMessage: string;
-  /** Present so a failure is not a dead end — the panel has no other chrome here. */
+  /**
+   * True once this interstitial has been up long enough that "still
+   * starting up" no longer explains it — see useSlowSync in lib/ui/client.ts,
+   * which is what actually times this. A sync that never connects (wrong
+   * network selected, an unreachable endpoint, or a subsystem that reports
+   * progress but never finishes) does not throw, so `failure` below never
+   * fires — without this, that case has no error and no route out: the
+   * panel's router shows only WalletLoading until a balance snapshot
+   * arrives, so a genuinely stuck sync traps the user with a spinner and no
+   * way to reach Settings → Network to fix it.
+   */
+  slow?: boolean;
+  /** Present so a failure (or a slow sync, see `slow`) is not a dead end —
+   *  the panel has no other chrome here. */
   onOpenNetwork?: () => void;
 }) {
   // A failure is not a slow step. Without this it falls through loadingDetail's
@@ -68,6 +82,17 @@ export function WalletLoading({
           <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary [animation-delay:-200ms]" />
           <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-primary" />
         </div>
+
+        {slow && (
+          <>
+            <p className="mb-0 mt-4 text-[12.5px] text-muted-foreground">{t('welcome_loadingFailedHint')}</p>
+            {onOpenNetwork ? (
+              <Button variant="secondary" size="lg" className="mt-4" onClick={onOpenNetwork}>
+                {t('welcome_loadingFailedAction')}
+              </Button>
+            ) : null}
+          </>
+        )}
       </div>
     </PanelScreen>
   );

--- a/packages/extension/entrypoints/sidepanel/App.tsx
+++ b/packages/extension/entrypoints/sidepanel/App.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { Toaster } from 'sonner';
-import { useSession, useWallets, usePanelEvents, useSelectedProverType } from '../../lib/ui/client';
+import { useSession, useWallets, usePanelEvents, useSelectedProverType, useSlowSync } from '../../lib/ui/client';
 import { accountLabel } from '../../lib/ui/format';
 import type { Screen } from '../../components/screens/navigation';
 import { GetStarted, openSetupTab } from '../../components/screens/GetStarted';
@@ -27,6 +27,7 @@ export function App() {
   const { wallets, refresh: refreshWallets } = useWallets();
   const events = usePanelEvents();
   const prover = useSelectedProverType(session.status?.network);
+  const slowSync = useSlowSync(!events.balances);
   const [screen, setScreen] = useState<Screen>('home');
   // Set when the user asks to switch accounts: the target's storage name. The
   // current session stays alive and syncing until this unlock succeeds, so
@@ -140,6 +141,7 @@ export function App() {
     return (
       <WalletLoading
         syncMessage={events.syncMessage}
+        slow={slowSync}
         onOpenNetwork={() => setScreen('network-config')}
       />
     );

--- a/packages/extension/lib/ui/client.ts
+++ b/packages/extension/lib/ui/client.ts
@@ -105,6 +105,30 @@ export function useDeveloperMode(): boolean {
   return developerMode;
 }
 
+/**
+ * True once `waiting` has held for `delayMs` without interruption — timing
+ * for WalletLoading's escape hatch (Settings → Network) when a sync hangs
+ * without ever throwing (wrong network selected, an unreachable endpoint, or
+ * a subsystem whose progress reads 100% but never flips `isSynced`). Resets
+ * whenever `waiting` goes false, so completing a sync — or the caller
+ * remounting for a fresh unlock/create/restore — clears it rather than
+ * leaving a stale "this is taking a while" armed for next time.
+ */
+export function useSlowSync(waiting: boolean, delayMs = 20_000): boolean {
+  const [slow, setSlow] = useState(false);
+
+  useEffect(() => {
+    if (!waiting) {
+      setSlow(false);
+      return;
+    }
+    const id = setTimeout(() => setSlow(true), delayMs);
+    return () => clearTimeout(id);
+  }, [waiting, delayMs]);
+
+  return slow;
+}
+
 export function useSelectedProverType(network: string | undefined) {
   const [proverType, setProverType] = useState<ProverType | null>(null);
   const latestRequest = useRef(0);

--- a/packages/extension/tests/wallet-loading.test.tsx
+++ b/packages/extension/tests/wallet-loading.test.tsx
@@ -11,4 +11,46 @@ describe('WalletLoading', () => {
     expect(html).toContain('Preparing your wallet');
     expect(html).not.toContain('Restoring dust state from cache');
   });
+
+  it('shows only the spinner while a sync is merely in progress', () => {
+    const html = renderToStaticMarkup(
+      <WalletLoading syncMessage="Syncing with network..." onOpenNetwork={() => {}} />,
+    );
+    expect(html).not.toContain('Change network');
+    expect(html).not.toContain('unreachable');
+  });
+
+  // A hung sync (wrong network selected, an unreachable endpoint, or a
+  // subsystem whose progress reads 100% but never flips `isSynced`) never
+  // throws, so it can't reach the `failure` branch below — without an escape
+  // hatch here the panel's router shows only WalletLoading forever, with no
+  // error and no way to reach Settings -> Network.
+  it('offers a way to Settings -> Network once the sync has been slow, even without a failure', () => {
+    const html = renderToStaticMarkup(
+      <WalletLoading syncMessage="Syncing with network..." slow onOpenNetwork={() => {}} />,
+    );
+    expect(html).toContain('unreachable');
+    expect(html).toContain('Change network');
+  });
+
+  it('omits the button when the caller has nowhere to send it, but still explains the delay', () => {
+    const html = renderToStaticMarkup(<WalletLoading syncMessage="Syncing with network..." slow />);
+    expect(html).toContain('unreachable');
+    expect(html).not.toContain('Change network');
+  });
+
+  it('prefers the hard failure over the slow-sync hint when both are true', () => {
+    const html = renderToStaticMarkup(
+      <WalletLoading
+        syncMessage="Sync failed: Could not reach the indexer"
+        slow
+        onOpenNetwork={() => {}}
+      />,
+    );
+    expect(html).toContain('Could not open your wallet');
+    expect(html).toContain('Could not reach the indexer');
+    // Only one "Change network" action, not the failure's and the slow
+    // branch's stacked together.
+    expect(html.match(/Change network/g)?.length ?? 0).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

`WalletLoading` (the full-panel interstitial shown after create/restore/unlock,
until the first balance snapshot arrives) only offered a "Change network"
escape hatch when sync had thrown — a message prefixed `Sync failed: ...`. A
sync that hangs *without* throwing has no such message, so it fell through to
the plain "Getting things ready" spinner with no error and, since the panel's
router shows only this screen until a balance snapshot lands, no way to reach
Settings → Network to fix the underlying cause.

Concretely reproduced while integrating this wallet against a local devnet:
selecting the wrong preset (or one pointing at an endpoint that answers but
whose ledger detection silently resolves wrong) left the panel stuck
indefinitely with no feedback, in both Chrome and Brave.

- New `useSlowSync(waiting, delayMs=20s)` hook (`lib/ui/client.ts`): flips
  `true` once `waiting` has held for `delayMs` without interruption, resets
  whenever it goes false (sync completes, or the caller remounts for a fresh
  unlock/create/restore).
- `WalletLoading` takes a new `slow` prop; once true (and there's no hard
  failure), it shows the same "network unreachable" hint and "Change network"
  action the failure branch already had.
- Wired in the side panel: `useSlowSync(!events.balances)`.

## Test plan

- [x] `yarn vitest run` in `packages/extension` — 431/431 passing, including
      4 new cases in `tests/wallet-loading.test.tsx` (in-progress sync shows
      no escape hatch; slow-without-failure shows it; button omitted when the
      caller has nowhere to send it; hard failure still takes precedence over
      the slow-sync hint).
- [x] `yarn run compile` (`tsc --noEmit`) in `packages/extension` — clean.
- [x] `yarn build` at the repo root — all packages build.
- [ ] Manual: load the built extension unpacked, select a network whose sync
      won't complete, confirm the "Change network" action appears after ~20s
      and returns you to the Network screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)