### PR TITLE
fix: never run the v8 ledger on a v9 network in the dapp-connector paths

### DIFF
--- a/packages/core/src/ledger/protocol-version.ts
+++ b/packages/core/src/ledger/protocol-version.ts
@@ -149,6 +149,12 @@ export async function detectLedgerVersion(
   network: {readonly id: string; readonly indexerUrl: string; readonly ledgerVersion?: LedgerVersion},
   options: {readonly probe?: (indexerUrl: string) => Promise<number | undefined>} = {},
 ): Promise<DetectedLedger> {
+  // An explicit configuration is law: no probe, no cache, no race. Detection
+  // exists for configs written before the fork, which carry no version.
+  if (network.ledgerVersion !== undefined) {
+    return { version: network.ledgerVersion, source: 'config' };
+  }
+
   const cached = detected.get(network.id);
   if (cached) return cached;
 

--- a/packages/extension/lib/background/settings.ts
+++ b/packages/extension/lib/background/settings.ts
@@ -132,6 +132,9 @@ export async function getNetworkConfig(networkId?: string): Promise<NetworkConfi
   if (!customEndpoints || network !== settingsNetwork) return base;
   return {
     id: base.id,
+    // The ledger generation belongs to the network, not to its endpoints:
+    // overrides move URLs, never the serialization format.
+    ...(base.ledgerVersion ? { ledgerVersion: base.ledgerVersion } : {}),
     ...(customEndpoints.nodeAuthHeader ? { nodeAuthHeader: customEndpoints.nodeAuthHeader } : {}),
     nodeUrl: customEndpoints.nodeUrl,
     indexerUrl: customEndpoints.indexerUrl,

--- a/packages/extension/lib/offscreen/wallet-host.ts
+++ b/packages/extension/lib/offscreen/wallet-host.ts
@@ -44,7 +44,8 @@ import {
   type SignedMessage,
 } from '@shieldedtech/moth-browser';
 import { deriveAllAddressesFromSeed } from '@shieldedtech/moth-wallet/wallet/address';
-import * as ledger from '@midnight-ntwrk/ledger-v8';
+import type * as ledger from '@midnight-ntwrk/ledger-v8';
+import { ledgerFor } from '@shieldedtech/moth-wallet/ledger/index';
 import type { HistoryEntry } from '@midnight-ntwrk/dapp-connector-api';
 import { serializeBalances } from '../messaging/balances-json';
 import { serializeActivity } from '../messaging/activity-json';
@@ -580,6 +581,9 @@ export function sendTokens(
   return enqueueTransferOperation(() => trackOp(async () => {
     await ensureProver(network);
     const wallet = await syncEnsure(seedHex, walletName, network);
+    // Re-pin: the seam's "current" is process-global, and a concurrent task on
+    // a v8 network can move it while the awaits above run.
+    await initSdk((await detectLedgerVersion(network)).version);
     const finalized = await buildTransferTransaction(
       wallet.facade,
       activeWalletKeys(),
@@ -616,6 +620,9 @@ export function estimateTransferFee(
 ): Promise<{ fee: string }> {
   return enqueueTransferOperation(() => trackOp(async () => {
     const wallet = await syncEnsure(seedHex, walletName, network);
+    // Re-pin: the seam's "current" is process-global, and a concurrent task on
+    // a v8 network can move it while the awaits above run.
+    await initSdk((await detectLedgerVersion(network)).version);
     const fee = await coreEstimateTransferFee(
       wallet.facade,
       activeWalletKeys(),
@@ -639,10 +646,14 @@ export async function registerDust(
   dustAddress?: string,
 ): Promise<{ txHash: string | null; notYet?: DustNotYet }> {
   // Load the ledger this network speaks before any core call reaches the seam.
-  await initSdk((await detectLedgerVersion(network)).version);
+  const { version } = await detectLedgerVersion(network);
+  await initSdk(version);
   return trackOp(async () => {
     await ensureProver(network);
     const wallet = await syncEnsure(seedHex, walletName, network);
+    // Re-pin: the seam's "current" is process-global, and a concurrent task on
+    // a v8 network can move it while the awaits above run.
+    await initSdk(version);
     let txHash: string | null;
     try {
       txHash = await coreDesignateForDust(
@@ -684,10 +695,14 @@ export async function deregisterDust(
   network: NetworkConfig,
 ): Promise<{ txHash: string }> {
   // Load the ledger this network speaks before any core call reaches the seam.
-  await initSdk((await detectLedgerVersion(network)).version);
+  const { version } = await detectLedgerVersion(network);
+  await initSdk(version);
   return trackOp(async () => {
     await ensureProver(network);
     const wallet = await syncEnsure(seedHex, walletName, network);
+    // Re-pin: the seam's "current" is process-global, and a concurrent task on
+    // a v8 network can move it while the awaits above run.
+    await initSdk(version);
     const txHash = await coreDedesignateFromDust(
       wallet.facade,
       seedHex,
@@ -706,10 +721,14 @@ export async function transferBuild(
   requests: TransferRequestDTO[],
 ): Promise<{ txHex: string }> {
   // Load the ledger this network speaks before any core call reaches the seam.
-  await initSdk((await detectLedgerVersion(network)).version);
+  const { version } = await detectLedgerVersion(network);
+  await initSdk(version);
   return trackOp(async () => {
     await ensureProver(network);
     const wallet = await syncEnsure(seedHex, walletName, network);
+    // Re-pin: the seam's "current" is process-global, and a concurrent task on
+    // a v8 network can move it while the awaits above run.
+    await initSdk(version);
     const finalized = await buildTransferTransaction(
       wallet.facade,
       activeWalletKeys(),
@@ -732,10 +751,14 @@ export async function balanceTransaction(
   sealed: boolean,
 ): Promise<{ txHex: string }> {
   // Load the ledger this network speaks before any core call reaches the seam.
-  await initSdk((await detectLedgerVersion(network)).version);
+  const { version } = await detectLedgerVersion(network);
+  await initSdk(version);
   return trackOp(async () => {
     await ensureProver(network);
     const wallet = await syncEnsure(seedHex, walletName, network);
+    // Re-pin: the seam's "current" is process-global, and a concurrent task on
+    // a v8 network can move it while the awaits above run.
+    await initSdk(version);
     const finalized = await coreBalanceTransaction(
       wallet.facade,
       activeWalletKeys(),
@@ -759,9 +782,13 @@ export async function makeIntent(
   payFees: boolean,
 ): Promise<{ txHex: string }> {
   // Load the ledger this network speaks before any core call reaches the seam.
-  await initSdk((await detectLedgerVersion(network)).version);
+  const { version } = await detectLedgerVersion(network);
+  await initSdk(version);
   return trackOp(async () => {
     const wallet = await syncEnsure(seedHex, walletName, network);
+    // Re-pin: the seam's "current" is process-global, and a concurrent task on
+    // a v8 network can move it while the awaits above run.
+    await initSdk(version);
     const intent = await buildSwapIntent(
       wallet.facade,
       activeWalletKeys(),
@@ -782,15 +809,20 @@ export async function transferSubmit(
   txHex: string,
 ): Promise<void> {
   // Load the ledger this network speaks before any core call reaches the seam.
-  await initSdk((await detectLedgerVersion(network)).version);
+  const { version } = await detectLedgerVersion(network);
+  await initSdk(version);
   return trackOp(async () => {
     const wallet = await syncEnsure(seedHex, walletName, network);
-    const transaction = ledger.Transaction.deserialize<ledger.SignatureEnabled, ledger.Proof, ledger.Binding>(
-      'signature',
-      'proof',
-      'binding',
-      fromHex(txHex),
-    );
+    // Re-pin: the seam's "current" is process-global, and a concurrent task on
+    // a v8 network can move it while the awaits above run.
+    await initSdk(version);
+    // Through the seam, never a static module: this network may be v9, and a
+    // v8 deserializer refuses its transaction format outright.
+    const transaction = ledgerFor(version).Transaction.deserialize<
+      ledger.SignatureEnabled,
+      ledger.Proof,
+      ledger.Binding
+    >('signature', 'proof', 'binding', fromHex(txHex));
     await submitFinalizedTransaction(wallet.facade, transaction);
   });
 }


### PR DESCRIPTION
Found live against the team-6 ledger-v9 devnet: every dApp transaction failed at submission with `Unable to deserialize Transaction … expected header tag 'midnight:transaction[v9](signature[v1]…)', got 'midnight:transaction[v12](signature[v2]…)'`. Reproduced outside the browser by feeding a real chain transaction to both ledgers: ledger-v8 throws exactly this, ledger-v9 rc.3 deserializes fine.

Three fixes:

1. **wallet-host `transferSubmit` used a static `import * as ledger from '@midnight-ntwrk/ledger-v8'`** and deserialized the dApp's transaction with it, bypassing the ledger seam entirely - fatal for every dApp on a v9 network. Now routed through `ledgerFor(version)`. The transaction paths also re-pin the seam immediately before each core call, since `current` is process-global and concurrent v8-network activity can move it during the `ensureProver`/`syncEnsure` awaits.
2. **`getNetworkConfig` dropped `ledgerVersion` when merging custom endpoint overrides**, so pointing a v9 network at your own node silently downgraded detection's config fallback to v8. The ledger generation belongs to the network, not its URLs.
3. **`detectLedgerVersion` now treats an explicitly configured `ledgerVersion` as authoritative** (no probe, no cache). Detection remains for pre-fork configs that carry no version; previously a single failed probe (e.g. wrong indexer URL at first boot) cached `v8` for the network id until the offscreen document died.

While debugging we also reproduced #91 in the wild (recreated account resumed the removed account's sync cursors: balance and DUST showed 0 while the chain held both; a fresh account name fixed it) - no code here, just confirmation that fix matters.

Verified: `yarn build` + extension build green; full dApp flow (mint invite coins → RSVP → reveal → door) works in the browser against the team-6 devnet with this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)