### PR TITLE
docs(extension): say how long the revealed seed is, and that the phra…

### DIFF
--- a/packages/extension/lib/i18n/messages/accounts.ts
+++ b/packages/extension/lib/i18n/messages/accounts.ts
@@ -24,8 +24,16 @@ export const accounts = {
     'Reveals what this account was created from. Accounts restored from a seed show that seed, because they have no phrase.',
   accounts_revealNoPhraseReason:
     'This account was restored from a hex seed, so it has no recovery phrase — a phrase cannot be worked out from a seed. Its seed is the backup.',
+  // States the length because the length is the trap: a phrase expands to 64
+  // bytes, while `moth wallet import --seed-hex` and the node toolkit deal in
+  // 32. Pasting 128 characters where 64 are expected errors out harmlessly;
+  // truncating to 64 does not — it restores a different, empty wallet and
+  // reports nothing, which is what setup_importSeedNoChecksum warns about on the
+  // way in. And it names the phrase as the backup: 128 characters cannot be
+  // hand-transcribed, and a seed kept as the record of a phrase-backed account
+  // can never regenerate that phrase.
   accounts_revealAsSeedNote:
-    'Reveals the hex seed your 24 words expand to. Some tools take a seed instead of a phrase. It has no built-in check, so copy it exactly.',
+    'Reveals the 128-character (64-byte) seed your 24 words expand to, for tools that take a seed instead of a phrase. Most Midnight tooling expects a 64-character (32-byte) seed — these are not interchangeable, and truncating this one restores a different, empty wallet. Your 24 words remain the backup for this account.',
   accounts_revealTitle: 'Secret phrase for $1',
   accounts_revealHint: "Enter this account's password to reveal its secret phrase.",
   accounts_revealPasswordPlaceholder: 'Account password',

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1590,7 +1590,7 @@
     "message": "Zeigt, woraus dieses Konto erstellt wurde. Aus einem Seed wiederhergestellte Konten zeigen diesen Seed, da sie keine Phrase haben."
   },
   "accounts_revealAsSeedNote": {
-    "message": "Zeigt den Hex-Seed, zu dem deine 24 Wörter expandieren. Manche Werkzeuge nehmen einen Seed statt einer Phrase. Er hat keine eingebaute Prüfung — kopiere ihn genau."
+    "message": "Zeigt den 128 Zeichen langen (64 Byte) Seed, zu dem deine 24 Wörter expandieren — für Werkzeuge, die einen Seed statt einer Phrase annehmen. Die meisten Midnight-Werkzeuge erwarten einen 64 Zeichen langen (32 Byte) Seed; die beiden sind nicht austauschbar, und ein Kürzen dieses Seeds stellt eine andere, leere Wallet wieder her. Deine 24 Wörter bleiben das Backup für dieses Konto."
   },
   "accounts_revealNoPhraseReason": {
     "message": "Dieses Konto wurde aus einem Hex-Seed wiederhergestellt und hat daher keine Wiederherstellungsphrase — eine Phrase lässt sich aus einem Seed nicht ermitteln. Der Seed ist das Backup."

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1590,7 +1590,7 @@
     "message": "Muestra a partir de qué se creó esta cuenta. Las cuentas restauradas desde un seed muestran ese seed, porque no tienen frase."
   },
   "accounts_revealAsSeedNote": {
-    "message": "Muestra el seed hexadecimal al que se expanden tus 24 palabras. Algunas herramientas aceptan un seed en lugar de una frase. No tiene comprobación integrada: cópialo con exactitud."
+    "message": "Muestra el seed de 128 caracteres (64 bytes) al que se expanden tus 24 palabras, para herramientas que aceptan un seed en lugar de una frase. La mayoría de las herramientas de Midnight esperan un seed de 64 caracteres (32 bytes); no son intercambiables, y truncar este seed restaura una cartera distinta y vacía. Tus 24 palabras siguen siendo la copia de seguridad de esta cuenta."
   },
   "accounts_revealNoPhraseReason": {
     "message": "Esta cuenta se restauró desde un seed hexadecimal, así que no tiene frase de recuperación — una frase no puede deducirse de un seed. Su seed es la copia de seguridad."

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1590,7 +1590,7 @@
     "message": "Révèle ce à partir de quoi ce compte a été créé. Les comptes restaurés depuis un seed affichent ce seed, car ils n’ont pas de phrase."
   },
   "accounts_revealAsSeedNote": {
-    "message": "Révèle le seed hexadécimal auquel vos 24 mots correspondent. Certains outils acceptent un seed plutôt qu’une phrase. Il n’a aucune vérification intégrée : copiez-le exactement."
+    "message": "Révèle le seed de 128 caractères (64 octets) auquel vos 24 mots correspondent, pour les outils qui acceptent un seed plutôt qu'une phrase. La plupart des outils Midnight attendent un seed de 64 caractères (32 octets) ; les deux ne sont pas interchangeables, et tronquer celui-ci restaure un autre portefeuille, vide. Vos 24 mots restent la sauvegarde de ce compte."
   },
   "accounts_revealNoPhraseReason": {
     "message": "Ce compte a été restauré depuis un seed hexadécimal : il n’a donc pas de phrase de récupération, et une phrase ne peut pas être déduite d’un seed. Son seed est la sauvegarde."


### PR DESCRIPTION
…se is still the backup

The reveal note said a seed can be used where some tools want one, without saying how long it is. That is the part that bites: a phrase expands to 64 bytes (128 hex), while `moth wallet import --seed-hex` and the node toolkit deal in 32 (64 hex). Pasting 128 where 64 is expected errors out harmlessly; truncating to 64 does not -- it restores a different, empty wallet and reports nothing, which is exactly what setup_importSeedNoChecksum warns about on the way in.

It also now names the phrase as the backup for a phrase-backed account. 128 characters cannot be hand-transcribed, and a seed kept as the record of such an account can never regenerate its phrase -- the same asymmetry accounts_revealNoPhraseReason already states for seed-restored accounts, pointed the other way. Translated in all three locales, since the parity guard would have accepted stale text.