### PR TITLE
feat: opt-in warm wallet syncs, and stop paying for teardown on every switch

### DIFF
--- a/.changeset/warm-wallet-switching.md
+++ b/.changeset/warm-wallet-switching.md
@@ -1,0 +1,42 @@
+---
+'@shieldedtech/moth-wallet': patch
+'@shieldedtech/moth-tui': patch
+---
+
+Make wallet switching fast: an opt-in pool of warm syncs, and stop paying for the
+outgoing wallet's teardown on the way to the incoming one.
+
+Switching wallets was slow even between wallets on the same network, because
+nothing about a sync is shared per-network. The cache entries
+(`sync/<network>/<wallet>/<part>.dat`), the WASM sub-wallet state and the indexer
+subscription are all per-wallet, so every switch rebuilt the whole thing:
+serialize four caches, stop the SDK, deserialize three sub-wallets, re-init the
+facade, reconnect, then wait up to 5s for a first state emission — and it did all
+of that strictly after awaiting the outgoing teardown, which is itself bounded at
+5s against a node whose client never settles.
+
+- **`WarmSyncPool` (opt-in, off by default).** Parks the outgoing facade instead
+  of stopping it, so switching back to a wallet is a re-subscribe rather than a
+  rebuild. Enabled in the TUI with `warmWallets` in `~/.moth/tui/settings.json`,
+  or `MOTH_WARM_WALLETS` per run; capped at 5. Each warm wallet keeps its full
+  sync state resident and its indexer subscription open — roughly the cost of a
+  second wallet syncing — which is why it is opt-in rather than a tuned default.
+  Warm facades hold live keys, so they are evicted before anything frees key
+  material (lock, quit) or clears stored state (remove, clear sync cache), and a
+  reused facade re-asserts the SDK's global network id the cold path would have
+  set.
+- **The outgoing teardown is no longer awaited when the incoming sync is for a
+  different wallet or network.** Those write disjoint cache entries, so the wait
+  bought nothing. A restart of the same wallet still awaits, since there the two
+  do overlap.
+- **`NodeSyncStateStore.put` writes atomically** (temp file + rename). Sync state
+  entries are large and were written in place, so a concurrent reader could decode
+  a truncated one — which the restore path treats as "sync from genesis". Now that
+  a switch can leave two syncs briefly alive, that went from exotic to ordinary.
+- **Fixed spurious sync restarts.** `getActiveWalletKeys`, `isActiveWalletNew` and
+  `activeWalletBirthdayOn` depended on the whole `activeWallet` object, which
+  `refresh()` rebuilds on every call, so creating, importing or removing any
+  wallet tore down and rebuilt the sync of the active one. They only read the
+  name, so that is what they depend on now.
+- **Locking a wallet takes its syncs down before zeroing its keys**, warm and
+  foreground alike — the ordering quit already used, extended to the lock path.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,7 +57,7 @@ export {
 
 // Sync
 export {
-  startWalletSync, formatNight, NIGHT_TOKEN_ID, clearSyncCache, clearDustSyncCache, resolveSyncStore,
+  startWalletSync, applyNetworkId, formatNight, NIGHT_TOKEN_ID, clearSyncCache, clearDustSyncCache, resolveSyncStore,
   EMPTY_COINS, EMPTY_SUB_PROGRESS, type WalletSyncOptions,
   type WalletBalances, type SyncedWallet, type DustGeneration, type SyncProgress,
   type SubWalletSyncProgress, type SubWalletProgress, type WalletCoinDetails,
@@ -77,6 +77,7 @@ export {
   InMemorySyncStateStore, syncStateKey, emptyRefStateKey, emptyRefMnemonicKey, emptyRefHeightKey,
   type SyncStateStore, type WalletPart,
 } from './sync/sync-store.js';
+export { WarmSyncPool, warmPoolKey } from './sync/warm-pool.js';
 export {
   deriveActivity, deriveActivityEntry, sortActivity,
   type ActivityEntry, type ActivityDelta, type ActivityKind, type ActivityStatus,

--- a/packages/core/src/sync/node-sync-store.ts
+++ b/packages/core/src/sync/node-sync-store.ts
@@ -4,7 +4,7 @@
 // the package's "./*" subpath exports and must never be re-exported from the
 // barrel, which has to stay browser-bundleable.
 
-import {existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync} from 'node:fs';
+import {existsSync, mkdirSync, readFileSync, writeFileSync, renameSync, unlinkSync} from 'node:fs';
 import {join, dirname} from 'node:path';
 import {homedir} from 'node:os';
 import type {SyncStateStore} from './sync-store.js';
@@ -30,10 +30,34 @@ export class NodeSyncStateStore implements SyncStateStore {
     }
   }
 
+  /**
+   * Write via a temporary file and rename, so a reader never sees a partial one.
+   *
+   * A plain writeFileSync leaves the entry truncated for as long as the write
+   * takes, and these are large. Any concurrent reader — a second moth process, or
+   * an outgoing sync saving its cache while an incoming one restores from a
+   * neighbouring entry — could decode a half-written state, and the restore path
+   * treats a bad decode as "sync from genesis". A slow, correct-looking resync is
+   * the worst way for this to fail, so make the swap atomic instead.
+   *
+   * The temporary lives in the destination directory: rename is only atomic
+   * within a filesystem, and a temp dir may be on another one.
+   */
   async put(key: string, value: string): Promise<void> {
     const file = this.fileFor(key);
     mkdirSync(dirname(file), {recursive: true, mode: 0o700});
-    writeFileSync(file, value, {encoding: 'utf-8', mode: 0o600});
+    const temp = `${file}.${process.pid}.${Date.now()}.tmp`;
+    try {
+      writeFileSync(temp, value, {encoding: 'utf-8', mode: 0o600});
+      renameSync(temp, file);
+    } catch (err) {
+      try {
+        unlinkSync(temp);
+      } catch {
+        /* nothing to clean up */
+      }
+      throw err;
+    }
   }
 
   async delete(key: string): Promise<void> {

--- a/packages/core/src/sync/wallet-sync.ts
+++ b/packages/core/src/sync/wallet-sync.ts
@@ -409,6 +409,21 @@ function subPct(sub: {applied: number; total: number}, done: boolean): string {
   return sub.total > 0 ? `${Math.round(Math.min(1, sub.applied / sub.total) * 100)}%` : '100%';
 }
 
+/**
+ * Re-assert the SDK's global network id.
+ *
+ * `startWalletSync` sets it, and every write path sets it again at its own
+ * boundary (see operations.ts and contract/*), because it is process-global and
+ * whatever ran last owns it. A caller that reuses an already-started sync —
+ * WarmSyncPool handing a facade back after the session visited another network —
+ * skips `startWalletSync` entirely, so it has to make the same assertion the
+ * cold path would have made, or the reused wallet encodes addresses for the
+ * network it is no longer on.
+ */
+export function applyNetworkId(networkId: string): void {
+  setNetworkId(networkId);
+}
+
 export async function startWalletSync(
   keys: WalletKeys,
   network: NetworkConfig,

--- a/packages/core/src/sync/warm-pool.ts
+++ b/packages/core/src/sync/warm-pool.ts
@@ -1,0 +1,181 @@
+// A pool of live WalletFacades, parked rather than stopped, so switching back
+// to a wallet costs a re-subscribe instead of a full teardown and rebuild.
+//
+// Everything under sync/ is keyed per (wallet, network) — the cache entries
+// (see syncStateKey), the WASM sub-wallet state, the indexer subscription — so
+// two wallets on the SAME network share nothing, and every switch pays for a
+// complete rebuild: serialize four caches, stop the SDK (bounded at
+// STOP_TIMEOUT_MS against a node whose client never settles), deserialize three
+// sub-wallets, re-init the facade, reconnect, then wait up to 5s for a first
+// state emission. Parking the outgoing facade skips all of it on the way back.
+//
+// OFF by default (capacity 0), and deliberately. A parked facade holds its
+// wallet's full WASM state resident AND keeps its indexer subscription open, so
+// each warm entry costs roughly the memory and network of a second wallet that
+// is still syncing. Callers opt in with a capacity they are willing to pay for;
+// at 0 this class is a pass-through that stops what it is handed, which is what
+// the code did before it existed.
+//
+// SAFETY — a parked facade holds LIVE secret keys in WASM and keeps syncing
+// with them:
+//   - Anything that frees key material (lockOne, lockAll, quitting) MUST evict
+//     the matching entries first, or the next dust batch throws `Dust secret key
+//     was cleared` from a facade nothing is watching — the same failure the
+//     quit path already guards against for the foreground sync.
+//   - Anything that clears a wallet's stored sync state MUST evict too. A parked
+//     facade rewrites those entries on its next save, so a clear that skips the
+//     pool silently does nothing.
+
+import type {SyncedWallet} from './wallet-sync.js';
+
+/** How long a caller will wait for parked facades to stop before proceeding. */
+const DEFAULT_DRAIN_TIMEOUT_MS = 5_000;
+
+interface PoolEntry {
+  wallet: SyncedWallet;
+  walletName: string;
+  networkId: string;
+}
+
+/**
+ * Identity of a warm entry.
+ *
+ * The endpoints belong in the key, not just the wallet and network: a facade is
+ * built against specific indexer/node/prover endpoints, so reusing one after the
+ * user edits a network override would keep talking to the old ones — a switch
+ * that silently ignores the setting it was made to apply. Keying on them turns
+ * that into an ordinary cache miss.
+ */
+export function warmPoolKey(
+  walletName: string,
+  network: {id: string; nodeUrl: string; indexerUrl: string},
+  proverKey = '',
+): string {
+  return JSON.stringify([walletName, network.id, network.nodeUrl, network.indexerUrl, proverKey]);
+}
+
+export class WarmSyncPool {
+  private capacityValue: number;
+  /** Insertion-ordered, least-recently parked first — `park` re-inserts to refresh recency. */
+  private readonly entries = new Map<string, PoolEntry>();
+  /** In-flight stops, so a drain can wait for teardowns it did not start. */
+  private readonly draining = new Set<Promise<void>>();
+
+  constructor(capacity = 0) {
+    this.capacityValue = Math.max(0, capacity);
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  get capacity(): number {
+    return this.capacityValue;
+  }
+
+  /** Change how many facades stay warm. Lowering it stops the excess immediately. */
+  setCapacity(capacity: number): void {
+    this.capacityValue = Math.max(0, capacity);
+    this.trim();
+  }
+
+  /**
+   * Take ownership of a warm facade, if one is parked under this key.
+   *
+   * Removes it from the pool: the caller owns it from here, and is responsible
+   * for parking or stopping it again. Two owners of one facade would each
+   * subscribe and each stop it, so the pool never hands out a reference it keeps.
+   */
+  take(key: string): SyncedWallet | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+    this.entries.delete(key);
+    return entry.wallet;
+  }
+
+  /**
+   * Hand a facade back to the pool, still running.
+   *
+   * At capacity 0 this stops it instead — the caller's code path is the same
+   * whether the pool is enabled or not.
+   */
+  park(key: string, wallet: SyncedWallet, walletName: string, networkId: string): void {
+    if (this.capacityValue <= 0) {
+      this.stopDetached(wallet);
+      return;
+    }
+    const existing = this.entries.get(key);
+    if (existing && existing.wallet !== wallet) this.stopDetached(existing.wallet);
+    // Delete before set so the re-inserted entry lands at the end of the
+    // iteration order: Map preserves insertion order, which is the whole LRU.
+    this.entries.delete(key);
+    this.entries.set(key, {wallet, walletName, networkId});
+    this.trim();
+  }
+
+  /** Stop and drop everything parked for a wallet — every network unless one is named. */
+  async evictWallet(walletName: string, networkId?: string, timeoutMs = DEFAULT_DRAIN_TIMEOUT_MS): Promise<void> {
+    for (const [key, entry] of [...this.entries]) {
+      if (entry.walletName !== walletName) continue;
+      if (networkId !== undefined && entry.networkId !== networkId) continue;
+      this.entries.delete(key);
+      this.stopDetached(entry.wallet);
+    }
+    await this.drain(timeoutMs);
+  }
+
+  /** Stop and drop every warm facade, then wait (bounded) for the teardowns. */
+  async evictAll(timeoutMs = DEFAULT_DRAIN_TIMEOUT_MS): Promise<void> {
+    for (const [key, entry] of [...this.entries]) {
+      this.entries.delete(key);
+      this.stopDetached(entry.wallet);
+    }
+    await this.drain(timeoutMs);
+  }
+
+  /**
+   * Wait for in-flight teardowns, bounded.
+   *
+   * Bounded because callers drain on the way to freeing keys or exiting, and
+   * `stop()` is only bounded in its SDK half — its cache save is not. The same
+   * trade the foreground stop already makes: a key freed under a still-running
+   * sync is noisy, a session that will not close is worse.
+   */
+  async drain(timeoutMs = DEFAULT_DRAIN_TIMEOUT_MS): Promise<void> {
+    if (this.draining.size === 0) return;
+    const pending = Promise.all([...this.draining]).then(() => undefined);
+    if (timeoutMs <= 0) {
+      await pending;
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      pending,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+    clearTimeout(timer);
+  }
+
+  private trim(): void {
+    while (this.entries.size > this.capacityValue) {
+      const oldest = this.entries.keys().next();
+      if (oldest.done) return;
+      const entry = this.entries.get(oldest.value)!;
+      this.entries.delete(oldest.value);
+      this.stopDetached(entry.wallet);
+    }
+  }
+
+  private stopDetached(wallet: SyncedWallet): void {
+    const promise = wallet
+      .stop()
+      .catch(() => {})
+      .finally(() => {
+        this.draining.delete(promise);
+      });
+    this.draining.add(promise);
+  }
+}

--- a/packages/core/tests/unit/sync/node-sync-store.test.ts
+++ b/packages/core/tests/unit/sync/node-sync-store.test.ts
@@ -1,0 +1,67 @@
+// The Node store's writes have to be atomic. Sync state entries are large, and a
+// reader that catches one mid-write decodes garbage — which the restore path
+// treats as "sync from genesis", the slowest possible way to fail. A switch that
+// no longer awaits the outgoing teardown makes concurrent access ordinary rather
+// than exotic, so the swap is a rename.
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { NodeSyncStateStore } from '../../../src/sync/node-sync-store.js';
+
+let base: string;
+
+beforeEach(() => { base = mkdtempSync(join(tmpdir(), 'moth-store-')); });
+afterEach(() => { rmSync(base, { recursive: true, force: true }); });
+
+describe('NodeSyncStateStore', () => {
+  it('round-trips a value through the legacy path layout', async () => {
+    const store = new NodeSyncStateStore(base);
+    await store.put('sync/devnet/alice/shielded.dat', 'state-v1');
+    expect(await store.get('sync/devnet/alice/shielded.dat')).toBe('state-v1');
+    expect(readFileSync(join(base, 'sync', 'devnet', 'alice', 'shielded.dat'), 'utf-8')).toBe('state-v1');
+  });
+
+  it('returns null for an entry that was never written', async () => {
+    expect(await new NodeSyncStateStore(base).get('sync/devnet/ghost/dust.dat')).toBeNull();
+  });
+
+  // The reader either sees the old value or the new one — never a prefix of the
+  // new one, which is what a truncating in-place write exposes.
+  it('replaces an existing entry without an intermediate short read', async () => {
+    const store = new NodeSyncStateStore(base);
+    const key = 'sync/devnet/alice/dust.dat';
+    await store.put(key, 'x'.repeat(50_000));
+
+    const reads: (string | null)[] = [];
+    await Promise.all([
+      store.put(key, 'y'.repeat(120_000)),
+      (async () => { reads.push(await store.get(key)); })(),
+      (async () => { reads.push(await store.get(key)); })(),
+    ]);
+    reads.push(await store.get(key));
+
+    for (const value of reads) {
+      expect(value === null || value === 'x'.repeat(50_000) || value === 'y'.repeat(120_000)).toBe(true);
+    }
+    expect(await store.get(key)).toBe('y'.repeat(120_000));
+  });
+
+  it('leaves no temporary files behind', async () => {
+    const store = new NodeSyncStateStore(base);
+    await store.put('sync/devnet/alice/history.dat', 'entries');
+    await store.put('sync/devnet/alice/history.dat', 'more entries');
+
+    const files = readdirSync(join(base, 'sync', 'devnet', 'alice'));
+    expect(files).toEqual(['history.dat']);
+  });
+
+  it('deletes an entry, and ignores deleting one that is not there', async () => {
+    const store = new NodeSyncStateStore(base);
+    await store.put('sync/devnet/alice/shielded.dat', 'state');
+    await store.delete('sync/devnet/alice/shielded.dat');
+    expect(await store.get('sync/devnet/alice/shielded.dat')).toBeNull();
+    await expect(store.delete('sync/devnet/alice/shielded.dat')).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/tests/unit/sync/warm-pool.test.ts
+++ b/packages/core/tests/unit/sync/warm-pool.test.ts
@@ -1,0 +1,214 @@
+// The warm pool keeps live facades parked so a wallet switch is a re-subscribe
+// rather than a rebuild. These tests pin the parts that are dangerous to get
+// wrong: ownership (never two owners of one facade), the LRU bound, the
+// pass-through behaviour at capacity 0, and the evictions that everything
+// freeing key material or clearing stored state depends on.
+
+import { describe, expect, it, vi } from 'vitest';
+import { WarmSyncPool, warmPoolKey } from '../../../src/sync/warm-pool.js';
+import type { SyncedWallet } from '../../../src/sync/wallet-sync.js';
+
+const NETWORK = { id: 'devnet', nodeUrl: 'ws://node', indexerUrl: 'http://indexer' };
+
+function fakeWallet(): SyncedWallet & { stopped: () => number } {
+  let stops = 0;
+  return {
+    facade: {} as SyncedWallet['facade'],
+    balances: {} as SyncedWallet['balances'],
+    stop: async () => { stops++; },
+    refresh: async () => ({}) as SyncedWallet['balances'],
+    subscribe: () => () => {},
+    stopped: () => stops,
+  } as SyncedWallet & { stopped: () => number };
+}
+
+describe('warmPoolKey', () => {
+  it('separates wallets on the same network', () => {
+    expect(warmPoolKey('alice', NETWORK)).not.toBe(warmPoolKey('bob', NETWORK));
+  });
+
+  it('separates the same wallet across networks', () => {
+    expect(warmPoolKey('alice', NETWORK)).not.toBe(
+      warmPoolKey('alice', { ...NETWORK, id: 'preview' }),
+    );
+  });
+
+  // A facade is built against specific endpoints. Reusing one after an override
+  // changes would keep talking to the endpoints the user just replaced.
+  it('separates entries built against different endpoints', () => {
+    expect(warmPoolKey('alice', NETWORK)).not.toBe(
+      warmPoolKey('alice', { ...NETWORK, indexerUrl: 'http://other' }),
+    );
+    expect(warmPoolKey('alice', NETWORK, 'server:http://a')).not.toBe(
+      warmPoolKey('alice', NETWORK, 'wasm'),
+    );
+  });
+});
+
+describe('WarmSyncPool', () => {
+  it('is a pass-through at capacity 0: parking stops rather than keeps', async () => {
+    const pool = new WarmSyncPool(0);
+    const w = fakeWallet();
+    const key = warmPoolKey('alice', NETWORK);
+
+    pool.park(key, w, 'alice', 'devnet');
+    await pool.drain();
+
+    expect(pool.size).toBe(0);
+    expect(w.stopped()).toBe(1);
+    expect(pool.take(key)).toBeUndefined();
+  });
+
+  it('returns a parked facade without stopping it', async () => {
+    const pool = new WarmSyncPool(1);
+    const w = fakeWallet();
+    const key = warmPoolKey('alice', NETWORK);
+
+    pool.park(key, w, 'alice', 'devnet');
+    expect(pool.size).toBe(1);
+
+    expect(pool.take(key)).toBe(w);
+    expect(w.stopped()).toBe(0);
+  });
+
+  // Two owners would each subscribe and each stop it. take() must hand over.
+  it('hands over ownership — a taken facade is no longer pooled', () => {
+    const pool = new WarmSyncPool(2);
+    const w = fakeWallet();
+    const key = warmPoolKey('alice', NETWORK);
+
+    pool.park(key, w, 'alice', 'devnet');
+    expect(pool.take(key)).toBe(w);
+    expect(pool.take(key)).toBeUndefined();
+    expect(pool.size).toBe(0);
+  });
+
+  it('evicts least-recently-parked first past capacity', async () => {
+    const pool = new WarmSyncPool(2);
+    const a = fakeWallet(), b = fakeWallet(), c = fakeWallet();
+    const keyA = warmPoolKey('a', NETWORK), keyB = warmPoolKey('b', NETWORK), keyC = warmPoolKey('c', NETWORK);
+
+    pool.park(keyA, a, 'a', 'devnet');
+    pool.park(keyB, b, 'b', 'devnet');
+    pool.park(keyC, c, 'c', 'devnet');
+    await pool.drain();
+
+    expect(pool.size).toBe(2);
+    expect(a.stopped()).toBe(1);
+    expect(pool.take(keyA)).toBeUndefined();
+    expect(pool.take(keyB)).toBe(b);
+    expect(pool.take(keyC)).toBe(c);
+  });
+
+  it('re-parking refreshes recency', async () => {
+    const pool = new WarmSyncPool(2);
+    const a = fakeWallet(), b = fakeWallet(), c = fakeWallet();
+    const keyA = warmPoolKey('a', NETWORK), keyB = warmPoolKey('b', NETWORK), keyC = warmPoolKey('c', NETWORK);
+
+    pool.park(keyA, a, 'a', 'devnet');
+    pool.park(keyB, b, 'b', 'devnet');
+    // Take A back out and return it: it is now the most recent, so B goes first.
+    pool.take(keyA);
+    pool.park(keyA, a, 'a', 'devnet');
+    pool.park(keyC, c, 'c', 'devnet');
+    await pool.drain();
+
+    expect(b.stopped()).toBe(1);
+    expect(a.stopped()).toBe(0);
+    expect(pool.take(keyA)).toBe(a);
+  });
+
+  it('lowering capacity stops the excess immediately', async () => {
+    const pool = new WarmSyncPool(3);
+    const a = fakeWallet(), b = fakeWallet();
+    pool.park(warmPoolKey('a', NETWORK), a, 'a', 'devnet');
+    pool.park(warmPoolKey('b', NETWORK), b, 'b', 'devnet');
+
+    pool.setCapacity(0);
+    await pool.drain();
+
+    expect(pool.size).toBe(0);
+    expect(a.stopped()).toBe(1);
+    expect(b.stopped()).toBe(1);
+  });
+
+  // lockOne(name) zeroes that wallet's keys in WASM. Every facade holding them
+  // has to be down first, on every network it is parked for.
+  it('evictWallet stops that wallet everywhere by default', async () => {
+    const pool = new WarmSyncPool(4);
+    const devnet = fakeWallet(), preview = fakeWallet(), other = fakeWallet();
+    pool.park(warmPoolKey('alice', NETWORK), devnet, 'alice', 'devnet');
+    pool.park(warmPoolKey('alice', { ...NETWORK, id: 'preview' }), preview, 'alice', 'preview');
+    pool.park(warmPoolKey('bob', NETWORK), other, 'bob', 'devnet');
+
+    await pool.evictWallet('alice');
+
+    expect(devnet.stopped()).toBe(1);
+    expect(preview.stopped()).toBe(1);
+    expect(other.stopped()).toBe(0);
+    expect(pool.size).toBe(1);
+  });
+
+  it('evictWallet can be scoped to one network', async () => {
+    const pool = new WarmSyncPool(4);
+    const devnet = fakeWallet(), preview = fakeWallet();
+    pool.park(warmPoolKey('alice', NETWORK), devnet, 'alice', 'devnet');
+    pool.park(warmPoolKey('alice', { ...NETWORK, id: 'preview' }), preview, 'alice', 'preview');
+
+    await pool.evictWallet('alice', 'devnet');
+
+    expect(devnet.stopped()).toBe(1);
+    expect(preview.stopped()).toBe(0);
+    expect(pool.size).toBe(1);
+  });
+
+  it('evictAll stops everything and waits for it', async () => {
+    const pool = new WarmSyncPool(3);
+    const a = fakeWallet(), b = fakeWallet();
+    pool.park(warmPoolKey('a', NETWORK), a, 'a', 'devnet');
+    pool.park(warmPoolKey('b', NETWORK), b, 'b', 'devnet');
+
+    await pool.evictAll();
+
+    expect(pool.size).toBe(0);
+    expect(a.stopped()).toBe(1);
+    expect(b.stopped()).toBe(1);
+  });
+
+  // Quitting must not hang on a facade whose stop never settles.
+  it('drain gives up at the deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const pool = new WarmSyncPool(1);
+      const hung: SyncedWallet = {
+        ...fakeWallet(),
+        stop: () => new Promise<void>(() => {}),
+      };
+      pool.park(warmPoolKey('a', NETWORK), hung, 'a', 'devnet');
+
+      const evicted = pool.evictAll(1_000);
+      const settled = vi.fn();
+      void evicted.then(settled);
+
+      await vi.advanceTimersByTimeAsync(1_100);
+      await evicted;
+      expect(settled).toHaveBeenCalled();
+      expect(pool.size).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A stop that throws must not leave the drain hanging or the entry behind.
+  it('survives a facade whose stop rejects', async () => {
+    const pool = new WarmSyncPool(1);
+    const broken: SyncedWallet = {
+      ...fakeWallet(),
+      stop: async () => { throw new Error('teardown failed'); },
+    };
+    pool.park(warmPoolKey('a', NETWORK), broken, 'a', 'devnet');
+
+    await expect(pool.evictAll()).resolves.toBeUndefined();
+    expect(pool.size).toBe(0);
+  });
+});

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -37,6 +37,23 @@ screen is used for wallet and dApp transactions. Local WASM proving is
 recommended for simple transactions, such as token transfers; complex
 transactions, such as contract calls, require a configured proof server.
 
+### Fast wallet switching (opt-in)
+
+Switching wallets normally rebuilds the sync from scratch — even between wallets on the same
+network, since sync state, WASM wallet state and the indexer subscription are all per-wallet.
+Setting `warmWallets` keeps that many previously-used wallets syncing in the background, so
+switching back to one is instant.
+
+```jsonc
+// ~/.moth/tui/settings.json
+{ "warmWallets": 1 }
+```
+
+Off by default (`0`), capped at `5`, and overridable per run with `MOTH_WARM_WALLETS=1`. Each warm
+wallet holds its full sync state in memory and keeps an open indexer subscription — roughly the
+cost of a second wallet syncing — so raise it only as far as you want to pay for. Warm wallets are
+dropped when the wallet is locked or removed, its sync cache is cleared, or the TUI quits.
+
 ### Keybindings
 
 | Key | Action |

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -11,6 +11,7 @@ import {
   dedesignateFromDustWithKeys,
   listNightUtxos,
   clearSyncCache,
+  WarmSyncPool,
   NIGHT_TOKEN_ID,
   DustRegistrationNotYetError,
   type SendRequest,
@@ -38,7 +39,7 @@ import { useNetwork } from './hooks/useNetwork.js';
 import { useBalance } from './hooks/useBalance.js';
 import { useLogs } from './hooks/useLogs.js';
 import { useChainStatus } from './hooks/useChainStatus.js';
-import { loadSettings, saveSettings, type TuiSettings } from './settings.js';
+import { loadSettings, saveSettings, resolveWarmWallets, type TuiSettings } from './settings.js';
 
 export interface AppProps {
   walletName?: string;
@@ -71,7 +72,12 @@ export function App({ networkId: networkIdProp }: AppProps) {
   const networkConfig = useMemo(() => network.getConfig(), [network.getConfig]);
   const chain = useChainStatus(networkConfig);
   const activeWalletKeys = wallet.getActiveWalletKeys();
-  const balance = useBalance(activeWalletKeys, networkConfig, logs.info, wallet.activeWallet?.name, wallet.isActiveWalletNew(), wallet.activeWalletBirthdayOn);
+  // Starts disabled and is given its capacity once settings load (below). Held
+  // here rather than inside useBalance because the paths that free key material
+  // or clear stored state — locking, removing, clearing a sync cache, quitting —
+  // all live in this component and must evict from it. See WarmSyncPool.
+  const warmPool = useMemo(() => new WarmSyncPool(0), []);
+  const balance = useBalance(activeWalletKeys, networkConfig, logs.info, wallet.activeWallet?.name, wallet.isActiveWalletNew(), wallet.activeWalletBirthdayOn, warmPool);
   const [lastWalletName, setLastWalletName] = useState<string | null>(null);
 
   // Daemon: keep a ref to the latest WalletBalances snapshot so daemon
@@ -121,8 +127,11 @@ export function App({ networkId: networkIdProp }: AppProps) {
       setInitialNetwork(targetNetwork);
       network.connect(targetNetwork, settings.networkOverrides?.[targetNetwork]);
       setLastWalletName(settings.lastWallet ?? null);
+      const warm = resolveWarmWallets(settings);
+      warmPool.setCapacity(warm);
       setSettingsLoaded(true);
       logs.info(`Session started (network: ${targetNetwork}, wallet: ${settings.lastWallet ?? 'none'})`);
+      if (warm > 0) logs.info(`Keeping up to ${warm} previously-used wallet${warm === 1 ? '' : 's'} warm for instant switching`);
     }).catch(err => {
       // Storage failure (permissions, corrupt file): surface it and still start
       // with defaults so the app never hangs waiting on settingsLoaded.
@@ -132,6 +141,8 @@ export function App({ networkId: networkIdProp }: AppProps) {
       setInitialNetwork(targetNetwork);
       network.connect(targetNetwork);
       setLastWalletName(null);
+      // The env override still applies with no settings file to read.
+      warmPool.setCapacity(resolveWarmWallets({ warmWallets: 0 }));
       setSettingsLoaded(true);
     });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -163,14 +174,16 @@ export function App({ networkId: networkIdProp }: AppProps) {
   const quit = useCallback(() => {
     void (async () => {
       try {
-        await balance.stop();
+        // Warm facades are still syncing with live keys, so they have to come
+        // down with the foreground one — before lockAll() zeroes anything.
+        await Promise.all([balance.stop(), warmPool.evictAll(3_000)]);
       } catch {
         /* stopping is best-effort; exiting is not optional */
       }
       wallet.lockAll();
       exit();
     })();
-  }, [balance, wallet, exit]);
+  }, [balance, wallet, warmPool, exit]);
 
   useEffect(() => {
     // Unmount that did not come through `quit` — Ctrl-C, a crash, the process
@@ -180,9 +193,10 @@ export function App({ networkId: networkIdProp }: AppProps) {
     // quit path awaits properly.
     return () => {
       void balance.stop().catch(() => {});
+      void warmPool.evictAll().catch(() => {});
       wallet.lockAll();
     };
-  }, [wallet.lockAll]);
+  }, [wallet.lockAll]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Onboarding handler — fired by the wizard's final step. Uses a ref so
   // route params can hold a stable callback while we still see latest state.
@@ -466,7 +480,15 @@ export function App({ networkId: networkIdProp }: AppProps) {
                 }
               })();
             }}
-            onLock={(name) => {
+            onLock={async (name) => {
+              // Take the syncs down FIRST: lockOne zeroes this wallet's keys in
+              // WASM, and anything still syncing with them throws `Dust secret
+              // key was cleared` mid-batch — from a warm facade nobody is
+              // watching, or from the foreground one. Same ordering as quit.
+              await Promise.all([
+                warmPool.evictWallet(name),
+                wallet.activeWallet?.name === name ? balance.stop() : Promise.resolve(),
+              ]);
               wallet.lockOne(name);
               logs.info(`Wallet locked: ${name}`);
             }}
@@ -480,13 +502,19 @@ export function App({ networkId: networkIdProp }: AppProps) {
               }
             }}
             onRemove={async (name) => {
+              await warmPool.evictWallet(name);
               await wallet.removeWallet(name);
               logs.info(`Wallet removed: ${name}`);
             }}
             onClearCache={(name) => {
-              void clearSyncCache(name, network.id).then(() => {
-                logs.info(`Sync cache cleared for ${name} on ${network.id}`);
-              });
+              // A warm facade for this wallet would rewrite the entries on its
+              // next save, so the clear has to take it down first or it silently
+              // does nothing.
+              void warmPool.evictWallet(name, network.id)
+                .then(() => clearSyncCache(name, network.id))
+                .then(() => {
+                  logs.info(`Sync cache cleared for ${name} on ${network.id}`);
+                });
             }}
             onCreateNew={() => {
               nav.push('onboarding-network', { onComplete: onboardingCompleteStable, partial: {} });

--- a/packages/tui/src/hooks/useBalance.ts
+++ b/packages/tui/src/hooks/useBalance.ts
@@ -7,6 +7,9 @@ import {
   resolveProverConfig,
   EMPTY_COINS,
   EMPTY_SUB_PROGRESS,
+  warmPoolKey,
+  applyNetworkId,
+  type WarmSyncPool,
   type SyncedWallet,
   type NetworkConfig,
   type DustGeneration,
@@ -74,24 +77,79 @@ export function useBalance(
    * however good a reference is in the store — silently, as a slow sync.
    */
   getBirthday?: (networkId: string) => Promise<number | undefined>,
+  /**
+   * Optional pool of live facades. When present, a switch parks the outgoing
+   * sync instead of stopping it, and a switch back reuses it — see WarmSyncPool
+   * for the cost and the eviction obligations that come with it.
+   */
+  warmPool?: WarmSyncPool | null,
 ) {
   const prover = network ? resolveProverConfig(network) : null;
   const proverKey = prover?.type === 'server' ? `server:${prover.url}` : (prover?.type ?? '');
   const [state, setState] = useState<BalanceState>(EMPTY_STATE);
   const syncRef = useRef<SyncedWallet | null>(null);
   const unsubRef = useRef<(() => void) | null>(null);
+  /** Identity of whatever syncRef holds, so it can be parked under the key it was built with. */
+  const syncKeyRef = useRef<{ key: string; walletName: string; networkId: string } | null>(null);
   const onLogRef = useRef(onLog);
   onLogRef.current = onLog;
+  const poolRef = useRef(warmPool);
+  poolRef.current = warmPool;
+
+  /**
+   * Release the running sync: park it if a pool is taking it, stop it otherwise.
+   *
+   * The stop is NOT awaited when the incoming sync is for a different
+   * (wallet, network) — those write disjoint cache entries, so nothing the
+   * outgoing teardown does can be seen by the incoming restore, and awaiting it
+   * only puts the SDK's bounded-at-5s teardown on the critical path of a switch.
+   * A restart of the SAME wallet does overlap, and is awaited.
+   *
+   * `park: false` is for the case where there is nothing to come back to. Losing
+   * the keys is one of those: the hook re-runs with `walletKeys === null` the
+   * moment a wallet is locked, and parking there would hand the pool a facade
+   * whose keys have just been zeroed — precisely what every eviction call site
+   * exists to prevent.
+   */
+  const release = useCallback(async (
+    incoming: { walletName: string; networkId: string } | null,
+    { park = true }: { park?: boolean } = {},
+  ) => {
+    if (unsubRef.current) { unsubRef.current(); unsubRef.current = null; }
+    const outgoing = syncRef.current;
+    const outgoingKey = syncKeyRef.current;
+    syncRef.current = null;
+    syncKeyRef.current = null;
+    if (!outgoing) return;
+
+    const pool = park ? poolRef.current : null;
+    if (pool && outgoingKey) {
+      pool.park(outgoingKey.key, outgoing, outgoingKey.walletName, outgoingKey.networkId);
+      return;
+    }
+    const overlaps =
+      incoming !== null &&
+      outgoingKey !== null &&
+      incoming.walletName === outgoingKey.walletName &&
+      incoming.networkId === outgoingKey.networkId;
+    if (overlaps) {
+      await outgoing.stop().catch(() => {});
+    } else {
+      void outgoing.stop().catch(() => {});
+    }
+  }, []);
 
   const startSync = useCallback(async () => {
     if (!walletKeys || !network) {
       onLogRef.current?.(`[sync] not starting — ${!walletKeys ? 'no wallet keys (wallet locked?)' : 'no network'}`);
+      await release(null, { park: false });
       setState(EMPTY_STATE);
       return;
     }
 
-    if (unsubRef.current) { unsubRef.current(); unsubRef.current = null; }
-    if (syncRef.current) { await syncRef.current.stop(); syncRef.current = null; }
+    const name = walletName ?? 'default';
+    const key = warmPoolKey(name, network, proverKey);
+    await release({ walletName: name, networkId: network.id });
 
     // Reset to empty (not `...prev`) so a wallet/network switch never shows the
     // PREVIOUS wallet's balances/coins/progress while the new wallet syncs.
@@ -100,13 +158,26 @@ export function useBalance(
     setState({ ...EMPTY_STATE, loading: true, syncStatus: 'Starting sync...' });
 
     try {
-      onLogRef.current?.(`[sync] startWalletSync begin — wallet=${walletName ?? '?'} network=${network.id} indexer=${network.indexerUrl}`);
-      const synced = await startWalletSync(walletKeys, network, (msg) => {
-        setState(prev => ({ ...prev, syncStatus: msg }));
-      }, walletName, isNewWallet, await getBirthday?.(network.id));
-      onLogRef.current?.('[sync] startWalletSync resolved — facade ready, subscribing');
+      // A warm facade is already synced and still streaming: take it and
+      // subscribe. This is the entire point of the pool — no cache restore, no
+      // facade init, no reconnect, no wait for a first emission.
+      const warm = poolRef.current?.take(key);
+      // The cold path sets the SDK's global network id inside startWalletSync;
+      // reusing a facade skips it, and the session may have visited another
+      // network in between. See applyNetworkId.
+      if (warm) applyNetworkId(network.id);
+      const synced = warm ?? await (async () => {
+        onLogRef.current?.(`[sync] startWalletSync begin — wallet=${name} network=${network.id} indexer=${network.indexerUrl}`);
+        const started = await startWalletSync(walletKeys, network, (msg) => {
+          setState(prev => ({ ...prev, syncStatus: msg }));
+        }, walletName, isNewWallet, await getBirthday?.(network.id));
+        onLogRef.current?.('[sync] startWalletSync resolved — facade ready, subscribing');
+        return started;
+      })();
+      if (warm) onLogRef.current?.(`[sync] reusing warm facade — wallet=${name} network=${network.id}`);
 
       syncRef.current = synced;
+      syncKeyRef.current = { key, walletName: name, networkId: network.id };
 
       let firstEmit = true;
       const unsub = synced.subscribe((balances) => {
@@ -123,7 +194,18 @@ export function useBalance(
       onLogRef.current?.(`Sync failed: ${msg}`);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [walletKeys, network?.id, network?.nodeUrl, network?.indexerUrl, proverKey, walletName, isNewWallet, getBirthday]);
+  }, [walletKeys, network?.id, network?.nodeUrl, network?.indexerUrl, proverKey, walletName, isNewWallet, getBirthday, release]);
+
+  // Final teardown, on unmount only. The [startSync] effect below cannot do this:
+  // its cleanup also runs between two syncs, and stopping there would destroy
+  // the facade the next startSync means to park or reuse. Transitions are
+  // `release`'s job; this is the last one out.
+  useEffect(() => () => {
+    const synced = syncRef.current;
+    syncRef.current = null;
+    syncKeyRef.current = null;
+    if (synced) void synced.stop().catch(() => {});
+  }, []);
 
   useEffect(() => {
     startSync();
@@ -144,8 +226,9 @@ export function useBalance(
 
     return () => {
       clearInterval(poller);
+      // Unsubscribe only — the running sync is left in place for `release` (or,
+      // on unmount, for the effect above) to park, reuse, or stop.
       if (unsubRef.current) { unsubRef.current(); unsubRef.current = null; }
-      if (syncRef.current) { syncRef.current.stop().catch(() => {}); syncRef.current = null; }
     };
   }, [startSync]);
 
@@ -169,11 +252,16 @@ export function useBalance(
    * Bounded, because quitting must not hang on a sync that will not settle: after
    * the deadline it gives up and lets the caller proceed. A key freed under a
    * still-running sync is noisy; a TUI that will not close is worse.
+   *
+   * Stops rather than parks, whatever the pool holds: this is the path to freeing
+   * key material, and a parked facade would go on syncing with keys about to be
+   * zeroed. Callers must drain the pool itself alongside this (see WarmSyncPool).
    */
   const stop = useCallback(async (timeoutMs = 3_000): Promise<void> => {
     if (unsubRef.current) { unsubRef.current(); unsubRef.current = null; }
     const synced = syncRef.current;
     syncRef.current = null;
+    syncKeyRef.current = null;
     if (!synced) return;
     await Promise.race([
       synced.stop().catch(() => {}),

--- a/packages/tui/src/hooks/useWallet.ts
+++ b/packages/tui/src/hooks/useWallet.ts
@@ -12,6 +12,7 @@ export function useWallet(storage: StorageAdapter) {
   const [wallets, setWallets] = useState<WalletInfo[]>([]);
   const [activeWallet, setActiveWallet] = useState<WalletState | null>(null);
   const [loading, setLoading] = useState(true);
+  const activeName = activeWallet?.name ?? null;
 
   // Session-only cache: name → unlocked wallet. Keys zeroed on lockAll().
   const sessionCache = useRef<Map<string, UnlockedEntry>>(new Map());
@@ -134,15 +135,22 @@ export function useWallet(storage: StorageAdapter) {
 
   // Daemon write verbs read the typed key bundle. The raw seedHex
   // never escapes walletManager.unlock — see D-KM-3.
+  //
+  // Keyed on the NAME, not the activeWallet object: `refresh()` builds a fresh
+  // object every call, so depending on the object gave this callback — and every
+  // consumer keyed on its identity — a new identity after any refresh. In
+  // useBalance that is the whole sync: an unrelated refresh (a wallet created,
+  // imported, removed) tore down and rebuilt the sync of a wallet that had not
+  // changed. These callbacks only ever read the name, so that is what they
+  // depend on.
   const getActiveWalletKeys = useCallback((): WalletKeys | null => {
-    if (!activeWallet) return null;
-    const entry = sessionCache.current.get(activeWallet.name);
-    return entry?.wallet.walletKeys ?? null;
-  }, [activeWallet]);
+    if (!activeName) return null;
+    return sessionCache.current.get(activeName)?.wallet.walletKeys ?? null;
+  }, [activeName]);
 
   const isActiveWalletNew = useCallback((): boolean => {
-    return activeWallet ? newWallets.current.has(activeWallet.name) : false;
-  }, [activeWallet]);
+    return activeName ? newWallets.current.has(activeName) : false;
+  }, [activeName]);
 
   /**
    * The active wallet's birthday for a SPECIFIC network.
@@ -154,10 +162,10 @@ export function useWallet(storage: StorageAdapter) {
    */
   const activeWalletBirthdayOn = useCallback(
     async (networkId: string): Promise<number | undefined> => {
-      if (!activeWallet) return undefined;
-      return manager.birthdayOn(activeWallet.name, networkId);
+      if (!activeName) return undefined;
+      return manager.birthdayOn(activeName, networkId);
     },
-    [activeWallet, manager],
+    [activeName, manager],
   );
 
   return {

--- a/packages/tui/src/screens/keys.tsx
+++ b/packages/tui/src/screens/keys.tsx
@@ -10,7 +10,8 @@ interface KeysProps {
   isUnlocked: (name: string) => boolean;
   getAddresses: (name: string) => { unshielded: string; shielded: string; dust: string } | null;
   onUnlock: (name: string, passphrase: string) => Promise<void>;
-  onLock: (name: string) => void;
+  /** Takes down any live sync for the wallet before its keys are freed, so it awaits. */
+  onLock: (name: string) => Promise<void>;
   onSwitch: (name: string) => Promise<void>;
   onRemove: (name: string) => Promise<void>;
   onClearCache: (name: string) => void;
@@ -96,8 +97,8 @@ export function Keys({
     }
     if (input === 'l') {
       if (isUnlocked(w.name)) {
-        onLock(w.name);
-        setMessage(`Locked ${w.name}`);
+        setMessage(`Locking ${w.name}...`);
+        void onLock(w.name).then(() => setMessage(`Locked ${w.name}`));
       }
       return;
     }

--- a/packages/tui/src/settings.ts
+++ b/packages/tui/src/settings.ts
@@ -15,13 +15,43 @@ export interface TuiSettings {
   lastNetwork: string;
   lastWallet: string | null;
   networkOverrides: Record<string, NetworkOverrides>;
+  /**
+   * How many previously-used wallets keep a live sync in memory, so switching
+   * back to one is instant instead of a full facade rebuild.
+   *
+   * 0 (the default) disables it. Each warm wallet holds its full WASM sync state
+   * resident and keeps its indexer subscription open, so the cost is roughly a
+   * second wallet syncing per entry — which is why this is opt-in rather than a
+   * tuned default. 1 covers the common "toggling between two accounts" case.
+   *
+   * Overridable per-run with MOTH_WARM_WALLETS.
+   */
+  warmWallets: number;
 }
 
 const DEFAULTS: TuiSettings = {
   lastNetwork: 'devnet',
   lastWallet: null,
   networkOverrides: {},
+  warmWallets: 0,
 };
+
+/** Hard ceiling on warm entries — a typo in the settings file should not exhaust memory. */
+const MAX_WARM_WALLETS = 5;
+
+/**
+ * Resolve the warm-wallet capacity: env override, then settings, then off.
+ *
+ * Anything unparseable resolves to 0. This trades a silently-ignored setting for
+ * a silently-unbounded one, which is the right way round for a memory knob.
+ */
+export function resolveWarmWallets(settings: Pick<TuiSettings, 'warmWallets'>, env = process.env): number {
+  const raw = env.MOTH_WARM_WALLETS;
+  const fromEnv = raw !== undefined && raw !== '' ? Number(raw) : Number.NaN;
+  const value = Number.isFinite(fromEnv) ? fromEnv : Number(settings.warmWallets);
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(Math.floor(value), MAX_WARM_WALLETS);
+}
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();

--- a/packages/tui/tests/unit/warm-wallets-setting.test.ts
+++ b/packages/tui/tests/unit/warm-wallets-setting.test.ts
@@ -1,0 +1,37 @@
+// The warm-wallet capacity is a memory knob, so the resolution rules matter:
+// off unless asked for, env beats the settings file, and anything nonsensical
+// resolves to off rather than to something unbounded.
+
+import { describe, expect, it } from 'vitest';
+import { resolveWarmWallets } from '../../src/settings.js';
+
+describe('resolveWarmWallets', () => {
+  it('is off by default', () => {
+    expect(resolveWarmWallets({ warmWallets: 0 }, {})).toBe(0);
+  });
+
+  it('reads the settings value', () => {
+    expect(resolveWarmWallets({ warmWallets: 2 }, {})).toBe(2);
+  });
+
+  it('lets the environment override the settings file', () => {
+    expect(resolveWarmWallets({ warmWallets: 3 }, { MOTH_WARM_WALLETS: '1' })).toBe(1);
+    expect(resolveWarmWallets({ warmWallets: 3 }, { MOTH_WARM_WALLETS: '0' })).toBe(0);
+  });
+
+  it('ignores an empty or unparseable env value', () => {
+    expect(resolveWarmWallets({ warmWallets: 2 }, { MOTH_WARM_WALLETS: '' })).toBe(2);
+    expect(resolveWarmWallets({ warmWallets: 2 }, { MOTH_WARM_WALLETS: 'yes' })).toBe(2);
+  });
+
+  it('resolves nonsense to off rather than to unbounded', () => {
+    expect(resolveWarmWallets({ warmWallets: -1 }, {})).toBe(0);
+    expect(resolveWarmWallets({ warmWallets: Number.NaN }, {})).toBe(0);
+    expect(resolveWarmWallets({ warmWallets: undefined as unknown as number }, {})).toBe(0);
+  });
+
+  it('caps the value and takes whole wallets only', () => {
+    expect(resolveWarmWallets({ warmWallets: 99 }, {})).toBe(5);
+    expect(resolveWarmWallets({ warmWallets: 2.7 }, {})).toBe(2);
+  });
+});


### PR DESCRIPTION
Switching wallets rebuilt the entire sync even between wallets on the same
network: cache entries, WASM sub-wallet state and the indexer subscription are
all per-wallet, so nothing was shared and every switch paid for a full facade
teardown and rebuild — strictly after awaiting the outgoing stop.

## Changes

- **`WarmSyncPool` (opt-in, off by default).** Parks the outgoing facade instead
  of stopping it, so switching back is a re-subscribe rather than a rebuild.
  Enabled with `warmWallets` in `~/.moth/tui/settings.json` or
  `MOTH_WARM_WALLETS`, capped at 5. Each warm wallet keeps its sync state
  resident and its indexer subscription open, which is why it is opt-in.
  Warm facades hold live keys, so they are evicted before anything frees key
  material (lock, quit) or clears stored state (remove, clear cache), and a
  reused facade re-asserts the SDK's global network id the cold path would set.
- **The outgoing teardown is no longer awaited** when the incoming sync is for a
  different wallet or network — those write disjoint cache entries. Same-wallet
  restarts still await.
- **`NodeSyncStateStore.put` writes atomically** (temp + rename). Entries are
  large and were written in place; a truncated read is treated as
  "sync from genesis", and concurrent access is now ordinary rather than exotic.
- **Fixed spurious sync restarts.** `getActiveWalletKeys`, `isActiveWalletNew`
  and `activeWalletBirthdayOn` depended on the whole `activeWallet` object that
  `refresh()` rebuilds every call, so creating, importing or removing any wallet
  restarted the active wallet's sync. They key on the name now.
- **Locking takes a wallet's syncs down before zeroing its keys**, warm and
  foreground alike — the ordering quit already used.

## Verification

- Full suite: 940 passed, 34 skipped (25 new tests covering pool
  ownership/LRU/eviction/bounded drain, atomic-write concurrency, and setting
  resolution)
- `tsc --noEmit` clean on core, tui and extension; biome clean; `yarn build` green