### PR TITLE
fix(ci): close the scan gate's critical findings

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -38,5 +38,9 @@ jobs:
         run: yarn install --immutable
 
       # Fails if packages changed without a changeset, prompting the author to add one.
+      # BASE_REF goes through env: rather than ${{ }} in run: — github context data
+      # is untrusted input and expanding it inline is a script-injection sink.
       - name: Verify a changeset exists
-        run: yarn changeset status --since=origin/${{ github.base_ref }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: yarn changeset status --since="origin/$BASE_REF"

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,13 @@
+# gitleaks fingerprints for false positives: path:rule:line.
+# A committed secret fails the Scan workflow regardless of fail_severity, so
+# deliberate test fixtures have to be listed here explicitly.
+#
+# Fingerprints are line-anchored on purpose. If one of these lines moves the
+# finding comes back and gets looked at again, rather than silently staying
+# suppressed.
+
+# A fake secret in a test asserting that parse errors do not echo input back.
+packages/core/tests/unit/contract/args-parser.test.ts:generic-api-key:26
+
+# A 64-hex token type id used as a display fixture, not a credential.
+packages/tui/tests/unit/state-view-rows.test.ts:generic-api-key:23


### PR DESCRIPTION
Route github.base_ref through env: in check-changeset rather than expanding it inline in run:, which opengrep and zizmor both flag as a template-injection sink.

Add .gitleaksignore for two deliberate test fixtures: a fake secret in a test asserting parse errors do not echo input back, and a token type id used as a display fixture. A committed secret fails the build regardless of fail_severity, so these need explicit fingerprints.

@chrisferry this is a blocking issue that arose on main because  of a more stringent gate in #105 