### PR TITLE
build: pin the Midnight toolchain as one version train, and gate it in CI

### DIFF
--- a/.changeset/midnight-version-train.md
+++ b/.changeset/midnight-version-train.md
@@ -1,0 +1,50 @@
+---
+'@shieldedtech/moth-wallet': patch
+'@shieldedtech/moth-tui': patch
+'@shieldedtech/moth-cli': patch
+---
+
+Pin the Midnight toolchain and SDK as one version train, and gate it in CI.
+
+Midnight's compiler, runtime and SDK are not independently versioned — they are
+one set that has to move together. Until now this repo's version of that set was
+spread across five unlinked places: each workspace's `dependencies`, the root
+`resolutions`, the committed contract artifact's `contract-info.json`, the
+Compact compiler (which is not an npm dependency at all, just whichever binary
+`compact` happened to have active), and the DApp scaffolding template. Nothing
+connected them and nothing checked them, so skew was only discoverable by
+hitting it at runtime.
+
+Ordinary semver reasoning is actively wrong for part of this set. Several of
+these packages are WASM-backed, and a caret range — which correctly means "any
+API-compatible version" — admits two API-compatible copies of a WASM module.
+Those are two distinct module instances, so a value built by one fails the
+other's `instanceof` check. No range syntax can express "exactly one copy". The
+result is the worst kind of failure: install succeeds, types check, the contract
+*deploys*, and then the first circuit call fails with
+`expected instance of StateValue`.
+
+That is exactly what happened during M1, three times over, all version skew and
+no logic bugs: `compact-js@2.5.3` is unrestorable because it asks for
+`ledger-v9@^0.1.0-alpha.1` while ledger-v9 exists only at `1.0.0-rc.x`;
+`compact-runtime@0.16.0`'s `onchain-runtime-v3@^3.0.0` floated to `3.1.0` while
+`midnight-js-protocol@4.1.1` pins `3.0.0` exactly, loading two WASM modules; and
+compiler `0.34.0` emits artifacts demanding `compact-runtime@0.19.0` when the
+SDK pins `0.16.0` — compiler `0.31.1` is the one that matches.
+
+`midnight-versions.json` is now the single source of truth, carrying the
+compiler and language version alongside the npm pins so the compiler is pinned
+too. Four gates run on every PR: `yarn constraints` (Yarn 4 constraints, via
+`yarn.config.cjs`) rejects a caret range or an `@midnight*` package nobody added
+to the train in any workspace manifest, and `yarn check:versions` covers what
+constraints structurally cannot see — duplicate WASM instances in the resolved
+tree, contract artifacts built by the wrong compiler, root `resolutions` that
+have drifted, and scaffolding templates left on stale versions.
+
+No dependency actually changes version here. `@midnightntwrk/wallet-sdk` moves
+from `^1.2.0` to `1.2.0` in `core` and `tui`, which is what it already resolved
+to, and the four `{{SDK_*_VERSION}}` placeholders in the DApp API template —
+which nothing in this repo ever substituted, so a scaffolded project would have
+failed to install — are replaced with the pinned versions. Upgrade guidance,
+including why the contracts' `pragma language_version >= 0.23` must stay put
+while compiler `0.31.1` is pinned, is in `docs/MIDNIGHT_VERSIONS.md`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      # Fails fast on Midnight version drift. `yarn constraints` catches a
+      # caret range or an undeclared @midnight* package in a workspace
+      # manifest; `check:versions` catches what constraints structurally
+      # cannot see — duplicate WASM instances in the resolved tree, a contract
+      # artifact built by the wrong compiler, resolutions that have drifted
+      # from the train, and scaffolding templates left on stale versions.
+      - name: Check Midnight version train
+        run: |
+          yarn constraints
+          yarn check:versions
+
       # Builds the workspace in dependency order (core/browser first) so the
       # extension/cli type checks and tests resolve the built packages.
       - name: Build packages

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,7 +4,3 @@ approvedGitRepositories:
 enableScripts: true
 
 nodeLinker: node-modules
-
-npmScopes:
-  midnight-ntwrk:
-    npmRegistryServer: "https://registry.npmjs.org"

--- a/docs/MIDNIGHT_VERSIONS.md
+++ b/docs/MIDNIGHT_VERSIONS.md
@@ -1,0 +1,119 @@
+# The Midnight version train
+
+Midnight's compiler, runtime and SDK are not independently versioned components.
+They are one set that moves together. `midnight-versions.json` at the repo root
+declares that set, and four gates keep the repo consistent with it.
+
+Read this before changing any `@midnight-ntwrk/*` or `@midnightntwrk/*` version.
+
+## Why exact pins, and why this is not over-engineering
+
+Ordinary semver reasoning is actively wrong for part of this dependency set.
+
+Several of these packages are WASM-backed. A caret range is *supposed* to mean
+"any API-compatible version" — but two API-compatible copies of a WASM module
+are two distinct module instances, so a value built by one fails the other's
+`instanceof` check. There is no range syntax that expresses "exactly one copy",
+which is why every single-instance package is pinned exactly and verified in the
+resolved tree, not just in the manifests.
+
+The failure mode is the nasty kind: install succeeds, types check, the contract
+*deploys* fine, and then the first circuit call fails with
+`expected instance of StateValue`.
+
+That is not hypothetical — it is how we lost time on M1. Three separate
+failures, all version skew, no logic bugs:
+
+| symptom | cause |
+|---|---|
+| `npm install` fails outright | `compact-js@2.5.3` requires `@midnight-ntwrk/ledger-v9@^0.1.0-alpha.1`; ledger-v9 exists only at `1.0.0-rc.x`, so the range is unsatisfiable. 2.5.3 looks like a patch but is a ledger-v9 prerelease. |
+| deploy succeeds, `call` fails with `expected instance of StateValue` | `compact-runtime@0.16.0` accepts `onchain-runtime-v3@^3.0.0` and floated to `3.1.0`, while `midnight-js-protocol@4.1.1` pins `3.0.0` exactly. Two WASM modules loaded. |
+| artifacts demand a runtime the SDK will not install | compiler `0.34.0` emits `checkRuntimeVersion('0.19.0')`, but `midnight-js-protocol@4.1.1` pins `compact-runtime` to exactly `0.16.0`. Compiler `0.31.1` is the one that emits `0.16.0`. |
+
+The lesson from the third row is the one to remember: **on Midnight you pick the
+compiler that matches your SDK, not the newest one.**
+
+## The compiler is not an npm dependency
+
+This is the part nothing else in the repo could pin. `compact` is a separate
+binary with its own installed toolchains, and its artifacts embed the runtime
+version they demand. So `midnight-versions.json` carries `compiler` and
+`languageVersion` alongside the npm pins, and `yarn compile:contracts` selects
+the toolchain explicitly with `compact +<version>`.
+
+Two consequences worth knowing:
+
+- Compiler `0.31.1` caps the language version at `0.23.0`. The contracts'
+  `pragma language_version >= 0.23` is deliberate — do not "modernize" it to a
+  newer language version while the compiler is pinned here.
+- Upgrading to compiler `0.34.0` means `compact-runtime@0.19.0`, which depends
+  on `@midnightntwrk/onchain-runtime-v4` — a different npm scope, published only
+  as `4.0.0-rc.x` — and therefore `midnight-js` `5.0.0-beta.x`. That is a whole
+  train move, not a compiler bump.
+
+## The four gates
+
+| gate | command | catches |
+|---|---|---|
+| Manifests | `yarn constraints` | a caret range, or an `@midnight*` package no one added to the train, in any workspace |
+| Resolved tree | `yarn check:versions` | duplicate WASM instances an upstream caret smuggled in |
+| Artifacts | `yarn check:versions` | a contract compiled by the wrong compiler or against the wrong runtime |
+| Templates & resolutions | `yarn check:versions` | scaffolding templates and root `resolutions` drifting from the train |
+
+`yarn constraints` sees only workspace manifests; everything outside them is
+`scripts/check-midnight-versions.mjs`. Both run in CI on every PR.
+
+Note that root `resolutions` must be literal in `package.json` — Yarn cannot
+compute them from the train at install time. So they are *verified* against the
+train rather than derived from it. Adding a package to `singleInstance` without
+a matching `resolutions` entry fails the gate.
+
+## Upgrading
+
+Upgrade the train, never a single package. A one-package bump is what produced
+all three failures above.
+
+```sh
+# 1. Edit midnight-versions.json — compiler, languageVersion and npm together.
+#    Check the new SDK's own pins first:
+npm view @midnight-ntwrk/midnight-js-protocol@<new> dependencies
+
+# 2. Propagate to every workspace manifest.
+yarn constraints --fix
+yarn install
+
+# 3. Rebuild contract artifacts with the newly pinned compiler.
+compact update <new-compiler>   # if not already installed
+yarn compile:contracts
+
+# 4. Verify, then exercise it for real — a clean install and type-check do NOT
+#    prove the WASM instances agree.
+yarn check:versions
+yarn test
+```
+
+Step 4's last point is the whole reason this document exists: the duplicate-WASM
+failure is invisible to `yarn install`, `tsc` and `yarn constraints` alike. Only
+an actual circuit call proves it.
+
+### Do not trust version numbers
+
+`compact-js@2.5.3` is a prerelease wearing a patch-release number. No automated
+range can tell you that. Exact pins plus a human reading the
+`midnight-versions.json` diff is the only real defense, so keep train bumps in
+their own commit where they are easy to review.
+
+## Registry
+
+All `@midnight-ntwrk/*` and `@midnightntwrk/*` packages are on public npm. Do not
+add `.npmrc` or `.yarnrc.yml` registry overrides — a previous
+`npmScopes.midnight-ntwrk` entry was removed because it merely restated the
+default registry while implying a policy it did not enforce (it did not cover the
+hyphenless `@midnightntwrk` scope that the wallet SDK ships under).
+
+## Known gap
+
+`packages/cli/templates/dapp/api/package.json` still contains a
+`{{API_PACKAGE_NAME}}` placeholder, and nothing in this repo substitutes template
+placeholders yet. Its *dependency* versions are now concrete and gated, but the
+template is not yet renderable — wiring up a scaffolder is separate work.

--- a/midnight-versions.json
+++ b/midnight-versions.json
@@ -1,0 +1,54 @@
+{
+  "$comment": [
+    "Single source of truth for the Midnight toolchain + SDK version set.",
+    "These packages must move as ONE train: the compiler decides which",
+    "compact-runtime its artifacts demand (via checkRuntimeVersion), the",
+    "runtime decides which onchain-runtime it loads, and midnight-js pins",
+    "both exactly. Bump one in isolation and you get either an install",
+    "failure or a duplicate-WASM `expected instance of StateValue` at call",
+    "time. See docs/MIDNIGHT_VERSIONS.md before changing anything here.",
+    "Enforced by yarn.config.cjs and scripts/check-midnight-versions.mjs."
+  ],
+
+  "compiler": "0.31.1",
+  "languageVersion": "0.23.0",
+
+  "npm": {
+    "@midnight-ntwrk/compact-js": "2.5.1",
+    "@midnight-ntwrk/compact-runtime": "0.16.0",
+    "@midnight-ntwrk/dapp-connector-api": "4.0.1",
+    "@midnight-ntwrk/ledger-v8": "8.1.0",
+    "@midnight-ntwrk/midnight-js": "4.1.1",
+    "@midnight-ntwrk/midnight-js-contracts": "4.1.1",
+    "@midnight-ntwrk/midnight-js-http-client-proof-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-indexer-public-data-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+    "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.1.1",
+    "@midnight-ntwrk/midnight-js-types": "4.1.1",
+    "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
+    "@midnight-ntwrk/platform-js": "2.2.4",
+    "@midnight-ntwrk/zkir-v2": "2.1.0",
+    "@midnightntwrk/wallet-sdk": "1.2.0",
+    "@midnightntwrk/wallet-sdk-abstractions": "2.1.0"
+  },
+
+  "singleInstance": [
+    "@midnight-ntwrk/compact-js",
+    "@midnight-ntwrk/compact-runtime",
+    "@midnight-ntwrk/ledger-v8",
+    "@midnight-ntwrk/onchain-runtime-v3",
+    "@midnight-ntwrk/platform-js",
+    "@midnight-ntwrk/zkir-v2",
+    "@midnightntwrk/wallet-sdk",
+    "@midnightntwrk/wallet-sdk-abstractions"
+  ],
+
+  "artifacts": [
+    "packages/core/contracts/moth-ft/managed/compiler/contract-info.json"
+  ],
+
+  "templates": [
+    "packages/cli/templates/dapp/api/package.json"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,11 +19,19 @@
     "changeset": "changeset",
     "version": "changeset version",
     "version-release": "yarn run version && yarn install",
-    "release": "node scripts/release-packages.mjs"
+    "release": "node scripts/release-packages.mjs",
+    "check:versions": "node scripts/check-midnight-versions.mjs",
+    "compile:contracts": "node scripts/compile-contracts.mjs"
   },
   "resolutions": {
     "@midnight-ntwrk/compact-js": "2.5.1",
+    "@midnight-ntwrk/compact-runtime": "0.16.0",
     "@midnight-ntwrk/ledger-v8": "8.1.0",
+    "@midnight-ntwrk/onchain-runtime-v3": "3.0.0",
+    "@midnight-ntwrk/platform-js": "2.2.4",
+    "@midnight-ntwrk/zkir-v2": "2.1.0",
+    "@midnightntwrk/wallet-sdk": "1.2.0",
+    "@midnightntwrk/wallet-sdk-abstractions": "2.1.0",
     "@vitejs/plugin-react": "^5",
     "adm-zip": ">=0.6.0",
     "brace-expansion": ">=5.0.9",

--- a/packages/cli/templates/dapp/api/package.json
+++ b/packages/cli/templates/dapp/api/package.json
@@ -10,10 +10,10 @@
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@midnight-ntwrk/midnight-js-contracts": "{{SDK_CONTRACTS_VERSION}}",
-    "@midnight-ntwrk/midnight-js-types": "{{SDK_TYPES_VERSION}}",
-    "@midnight-ntwrk/midnight-js-network-id": "{{SDK_NETWORK_ID_VERSION}}",
-    "@midnight-ntwrk/compact-runtime": "{{SDK_COMPACT_RUNTIME_VERSION}}"
+    "@midnight-ntwrk/midnight-js-contracts": "4.1.1",
+    "@midnight-ntwrk/midnight-js-types": "4.1.1",
+    "@midnight-ntwrk/midnight-js-network-id": "4.1.1",
+    "@midnight-ntwrk/compact-runtime": "0.16.0"
   },
   "devDependencies": {
     "typescript": "^6.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
     "@midnight-ntwrk/midnight-js-level-private-state-provider": "4.1.1",
     "@midnight-ntwrk/midnight-js-node-zk-config-provider": "4.1.1",
     "@midnight-ntwrk/zkir-v2": "2.1.0",
-    "@midnightntwrk/wallet-sdk": "^1.2.0",
+    "@midnightntwrk/wallet-sdk": "1.2.0",
     "@noble/ciphers": "^2.2.0",
     "@noble/hashes": "^2.2.0",
     "@scure/bip39": "^2.2.0",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@midnight-ntwrk/ledger-v8": "8.1.0",
-    "@midnightntwrk/wallet-sdk": "^1.2.0",
+    "@midnightntwrk/wallet-sdk": "1.2.0",
     "@shieldedtech/moth-wallet": "^0.12.1",
     "ink": "^7.0.1",
     "ink-spinner": "^5.0.0",

--- a/scripts/check-midnight-versions.mjs
+++ b/scripts/check-midnight-versions.mjs
@@ -1,0 +1,186 @@
+#!/usr/bin/env node
+// Verifies everything about the Midnight version train that `yarn constraints`
+// structurally cannot see.
+//
+// Constraints operate on workspace *manifests*. Three things live outside them:
+//
+//   1. The resolved dependency tree. An upstream package's own caret range can
+//      still pull a second copy of a WASM-backed module, which breaks
+//      `instanceof` at call time (`expected instance of StateValue`) with a
+//      perfectly clean install and type-check.
+//   2. The Compact compiler, which is not an npm dependency at all — it is a
+//      separate binary selected with `compact +<version>`. Its committed
+//      artifacts embed the runtime version they demand via checkRuntimeVersion.
+//   3. Scaffolding templates, which are not workspaces, so nothing installs or
+//      type-checks them until a user runs the generated project.
+//
+// Usage: node scripts/check-midnight-versions.mjs
+import {readFileSync, existsSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {dirname, join, relative} from 'node:path';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+const readJson = (p) => JSON.parse(read(p));
+
+const train = readJson('midnight-versions.json');
+const problems = [];
+const note = (section, msg) => problems.push(`${section}: ${msg}`);
+
+// ── 1. One resolved version per WASM-backed package ────────────────────────
+console.log('Resolved dependency tree (single-instance packages)');
+const lock = read('yarn.lock');
+const resolved = new Map();
+for (const [, ident, version] of lock.matchAll(
+  /^ {2}resolution: "((?:@[^/]+\/)?[^@"]+)@npm:([^"]+)"/gm,
+)) {
+  if (!train.singleInstance.includes(ident)) continue;
+  if (!resolved.has(ident)) resolved.set(ident, new Set());
+  resolved.get(ident).add(version);
+}
+
+for (const pkg of train.singleInstance) {
+  const versions = resolved.get(pkg);
+  if (!versions) {
+    console.log(`  – ${pkg} (not installed)`);
+    continue;
+  }
+  const list = [...versions].sort();
+  if (list.length > 1) {
+    console.log(`  ✗ ${pkg}: ${list.length} versions — ${list.join(', ')}`);
+    note(
+      'tree',
+      `${pkg} resolves to ${list.length} versions (${list.join(', ')}). ` +
+      `Duplicate WASM instances fail \`instanceof\` at call time. Add an ` +
+      `exact "resolutions" entry for it in the root package.json.`,
+    );
+  } else {
+    const want = train.npm[pkg];
+    if (want !== undefined && list[0] !== want) {
+      console.log(`  ✗ ${pkg}: ${list[0]} (train declares ${want})`);
+      note('tree', `${pkg} resolved to ${list[0]} but the train declares ${want}.`);
+    } else {
+      console.log(`  ✓ ${pkg}: ${list[0]}`);
+    }
+  }
+}
+
+// ── 2. Committed contract artifacts match the pinned toolchain ─────────────
+console.log('\nCompiled contract artifacts');
+for (const artifact of train.artifacts) {
+  if (!existsSync(join(ROOT, artifact))) {
+    console.log(`  ✗ ${artifact} (missing)`);
+    note('artifact', `${artifact} does not exist. Run \`yarn compile:contracts\`.`);
+    continue;
+  }
+  const info = readJson(artifact);
+  const expected = {
+    'compiler-version': train.compiler,
+    'language-version': train.languageVersion,
+    'runtime-version': train.npm['@midnight-ntwrk/compact-runtime'],
+  };
+  const bad = Object.entries(expected).filter(([k, v]) => info[k] !== v);
+  if (bad.length === 0) {
+    console.log(
+      `  ✓ ${artifact} (compiler ${info['compiler-version']}, ` +
+      `language ${info['language-version']}, runtime ${info['runtime-version']})`,
+    );
+  } else {
+    console.log(`  ✗ ${artifact}`);
+    for (const [k, v] of bad) {
+      console.log(`      ${k}: found ${info[k] ?? '(absent)'}, expected ${v}`);
+      note(
+        'artifact',
+        `${artifact} ${k} is ${info[k] ?? '(absent)'} but the train declares ${v}. ` +
+        `Recompile with \`yarn compile:contracts\` (which pins compact +${train.compiler}).`,
+      );
+    }
+  }
+}
+
+// ── 3. Scaffolding templates carry real, in-train versions ─────────────────
+// Templates are not workspaces, so `yarn constraints` never sees them and
+// nothing installs them until a user runs the generated project. Note that a
+// placeholder in a *non-dependency* field (e.g. "name") is legitimate — those
+// are per-project. Only dependency versions must be concrete.
+console.log('\nScaffolding templates');
+for (const template of train.templates) {
+  if (!existsSync(join(ROOT, template))) {
+    console.log(`  \u2717 ${template} (missing)`);
+    note('template', `${template} listed in midnight-versions.json does not exist.`);
+    continue;
+  }
+  const manifest = readJson(template);
+  const deps = {...manifest.dependencies, ...manifest.devDependencies};
+
+  const placeholders = Object.entries(deps).filter(([, v]) => /\{\{.+\}\}/.test(v));
+  const drift = Object.entries(deps).filter(
+    ([k, v]) => train.npm[k] !== undefined && v !== train.npm[k] && !/\{\{.+\}\}/.test(v),
+  );
+  const unknown = Object.keys(deps).filter(
+    (k) => k.startsWith('@midnight') && train.npm[k] === undefined,
+  );
+
+  if (placeholders.length === 0 && drift.length === 0 && unknown.length === 0) {
+    console.log(`  \u2713 ${template}`);
+    continue;
+  }
+  console.log(`  \u2717 ${template}`);
+  for (const [k, v] of placeholders) {
+    console.log(`      ${k}: unsubstituted ${v}`);
+    note(
+      'template',
+      `${template} leaves ${k} as ${v}. Nothing in this repo substitutes ` +
+      `dependency placeholders, so a scaffolded project would fail to ` +
+      `install. Replace it with the pinned version from the train.`,
+    );
+  }
+  for (const [k, v] of drift) {
+    console.log(`      ${k}: ${v}, expected ${train.npm[k]}`);
+    note('template', `${template} pins ${k} at ${v}; train declares ${train.npm[k]}.`);
+  }
+  for (const k of unknown) {
+    console.log(`      ${k}: not in the train`);
+    note('template', `${template} depends on ${k}, absent from midnight-versions.json.`);
+  }
+}
+
+// ── 4. Root resolutions cover every single-instance package ───────────────
+// Yarn resolutions have to be literal in package.json, so they cannot be
+// derived from the train at install time. Verify them instead, or they become
+// a second source of truth that silently drifts.
+console.log('\nRoot resolutions');
+const rootResolutions = readJson('package.json').resolutions ?? {};
+for (const pkg of train.singleInstance) {
+  const want = train.npm[pkg];
+  const found = rootResolutions[pkg];
+  if (found === want) {
+    console.log(`  \u2713 ${pkg}: ${found}`);
+  } else if (found === undefined) {
+    console.log(`  \u2717 ${pkg}: no resolution`);
+    note(
+      'resolutions',
+      `${pkg} is single-instance but has no "resolutions" entry in the root ` +
+      `package.json. Add "${pkg}": "${want}".`,
+    );
+  } else {
+    console.log(`  \u2717 ${pkg}: ${found}, expected ${want}`);
+    note(
+      'resolutions',
+      `root package.json resolves ${pkg} to ${found} but the train declares ${want}.`,
+    );
+  }
+}
+
+// ── Verdict ────────────────────────────────────────────────────────────────
+if (problems.length > 0) {
+  console.error(`\n${problems.length} problem(s) found:\n`);
+  for (const p of problems) console.error(`  • ${p}`);
+  console.error(
+    '\nThe Midnight compiler, runtime and SDK move as one set. Change ' +
+    'midnight-versions.json, then run:\n' +
+    '  yarn constraints --fix && yarn install && yarn compile:contracts\n',
+  );
+  process.exit(1);
+}
+console.log('\nMidnight version train is consistent.');

--- a/scripts/compile-contracts.mjs
+++ b/scripts/compile-contracts.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Compiles the Compact contracts with the compiler version pinned in
+// midnight-versions.json, via the `compact +<version>` toolchain selector.
+//
+// The compiler is not an npm dependency, so nothing else in the repo can pin
+// it. Compiling with whatever `compact` happens to have installed is how you
+// get artifacts that call checkRuntimeVersion('0.19.0') against an SDK that
+// pins compact-runtime 0.16.0 — the contract deploys and then fails on call.
+//
+// Usage:
+//   node scripts/compile-contracts.mjs [--skip-zk] [--out <dir>]
+//
+// --out redirects output (for scratch builds); default is the committed
+// managed/ directory beside each contract source.
+import {spawnSync} from 'node:child_process';
+import {readFileSync} from 'node:fs';
+import {fileURLToPath} from 'node:url';
+import {dirname, join} from 'node:path';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const train = JSON.parse(readFileSync(join(ROOT, 'midnight-versions.json'), 'utf8'));
+
+const CONTRACTS = [
+  {
+    source: 'packages/core/contracts/moth-ft/moth-ft.compact',
+    out: 'packages/core/contracts/moth-ft/managed',
+  },
+];
+
+const argv = process.argv.slice(2);
+const skipZk = argv.includes('--skip-zk');
+const outIndex = argv.indexOf('--out');
+const outOverride = outIndex === -1 ? null : argv[outIndex + 1];
+
+if (outIndex !== -1 && !outOverride) {
+  console.error('--out requires a directory argument');
+  process.exit(2);
+}
+
+let failed = false;
+for (const contract of CONTRACTS) {
+  const out = outOverride ?? contract.out;
+  const args = [
+    'compile',
+    `+${train.compiler}`,
+    ...(skipZk ? ['--skip-zk'] : []),
+    contract.source,
+    out,
+  ];
+  console.log(`compact ${args.join(' ')}`);
+  const result = spawnSync('compact', args, {cwd: ROOT, stdio: 'inherit'});
+  if (result.error) {
+    console.error(
+      `\nCould not run \`compact\`: ${result.error.message}\n` +
+      `Install the Compact CLI, then \`compact update ${train.compiler}\`.`,
+    );
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    failed = true;
+    console.error(`\n${contract.source} failed to compile (exit ${result.status}).`);
+    console.error(
+      `If this is a language-version error, note that compiler ` +
+      `${train.compiler} caps the language version at ` +
+      `${train.languageVersion} — the contract's \`pragma language_version\` ` +
+      `must not exceed it.`,
+    );
+  }
+}
+process.exit(failed ? 1 : 0);

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -1,0 +1,51 @@
+// Yarn 4 constraints: keep every workspace pinned to the Midnight version
+// train declared in midnight-versions.json.
+//
+// Why exact pins and not ranges: several of these packages are WASM-backed.
+// A caret range is *supposed* to mean "any API-compatible version", but two
+// API-compatible copies of a WASM module are two distinct module instances,
+// so a value built by one fails the other's `instanceof` check. That surfaces
+// as `expected instance of StateValue` at call time — long after install and
+// type-checking have both passed. Ranges cannot express "exactly one copy",
+// so we forbid them here and verify the resolved tree separately in
+// scripts/check-midnight-versions.mjs.
+//
+//   yarn constraints        check (exits non-zero on drift)
+//   yarn constraints --fix  rewrite manifests to match the train
+
+const TRAIN = require('./midnight-versions.json').npm;
+
+const MIDNIGHT_SCOPES = ['@midnight-ntwrk/', '@midnightntwrk/'];
+const isMidnight = (ident) => MIDNIGHT_SCOPES.some((s) => ident.startsWith(s));
+
+module.exports = {
+  async constraints({Yarn}) {
+    for (const dep of Yarn.dependencies()) {
+      if (!isMidnight(dep.ident)) continue;
+
+      const want = TRAIN[dep.ident];
+
+      // A Midnight package nobody has added to the train. Refuse it rather
+      // than let it float: this is how a stray transitive-looking dep ends up
+      // being the second WASM instance.
+      if (want === undefined) {
+        dep.error(
+          `${dep.ident} is not declared in midnight-versions.json.\n` +
+          `Add it to "npm" (and to "singleInstance" if it is WASM-backed) ` +
+          `so it moves with the rest of the train, then re-run yarn constraints.`,
+        );
+        continue;
+      }
+
+      if (dep.range !== want) {
+        dep.update(want);
+        dep.error(
+          `${dep.ident} must be pinned to exactly ${want} ` +
+          `(from midnight-versions.json); found "${dep.range}". ` +
+          `Run \`yarn constraints --fix\`. Do not bump this in isolation — ` +
+          `the Midnight compiler, runtime and SDK move as one set.`,
+        );
+      }
+    }
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,14 +1184,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/onchain-runtime-v3@npm:3.0.0, @midnight-ntwrk/onchain-runtime-v3@npm:^3.0.0":
+"@midnight-ntwrk/onchain-runtime-v3@npm:3.0.0":
   version: 3.0.0
   resolution: "@midnight-ntwrk/onchain-runtime-v3@npm:3.0.0"
   checksum: 10c0/74e42e97eba6f2d1c03b32a9dc75dcc87be83850275d60dcbf17c673cfebf63927fc37160365874089ae2356e65a215e75d1cd049c6e31e7320117471a90ec33
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/platform-js@npm:2.2.4, @midnight-ntwrk/platform-js@npm:^2.2.4":
+"@midnight-ntwrk/platform-js@npm:2.2.4":
   version: 2.2.4
   resolution: "@midnight-ntwrk/platform-js@npm:2.2.4"
   dependencies:
@@ -1213,14 +1213,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnight-ntwrk/zkir-v2@npm:2.1.0, @midnight-ntwrk/zkir-v2@npm:^2.1.0":
+"@midnight-ntwrk/zkir-v2@npm:2.1.0":
   version: 2.1.0
   resolution: "@midnight-ntwrk/zkir-v2@npm:2.1.0"
   checksum: 10c0/cf139a9dc6834d5e4036af6c65a40d384a02e66c4ef14d1e948fc690be62ce1bcf79d468efb2df719ff573c1825251c9c65630f287fbc76d2026482a13b907ef
   languageName: node
   linkType: hard
 
-"@midnightntwrk/wallet-sdk-abstractions@npm:^2.1.0":
+"@midnightntwrk/wallet-sdk-abstractions@npm:2.1.0":
   version: 2.1.0
   resolution: "@midnightntwrk/wallet-sdk-abstractions@npm:2.1.0"
   dependencies:
@@ -1409,7 +1409,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@midnightntwrk/wallet-sdk@npm:^1.2.0":
+"@midnightntwrk/wallet-sdk@npm:1.2.0":
   version: 1.2.0
   resolution: "@midnightntwrk/wallet-sdk@npm:1.2.0"
   dependencies:
@@ -2952,7 +2952,7 @@ __metadata:
   resolution: "@shieldedtech/moth-tui@workspace:packages/tui"
   dependencies:
     "@midnight-ntwrk/ledger-v8": "npm:8.1.0"
-    "@midnightntwrk/wallet-sdk": "npm:^1.2.0"
+    "@midnightntwrk/wallet-sdk": "npm:1.2.0"
     "@shieldedtech/moth-wallet": "npm:^0.12.1"
     "@types/react": "npm:^19.0.0"
     ink: "npm:^7.0.1"
@@ -2977,7 +2977,7 @@ __metadata:
     "@midnight-ntwrk/midnight-js-level-private-state-provider": "npm:4.1.1"
     "@midnight-ntwrk/midnight-js-node-zk-config-provider": "npm:4.1.1"
     "@midnight-ntwrk/zkir-v2": "npm:2.1.0"
-    "@midnightntwrk/wallet-sdk": "npm:^1.2.0"
+    "@midnightntwrk/wallet-sdk": "npm:1.2.0"
     "@noble/ciphers": "npm:^2.2.0"
     "@noble/hashes": "npm:^2.2.0"
     "@scure/bip39": "npm:^2.2.0"


### PR DESCRIPTION
# Overview

Midnight's compiler, runtime and SDK are not independently versioned components —
they are one set that moves together. Until now this repo's version of that set
lived in **five unlinked places**, with nothing connecting or checking them:

1. each workspace's `dependencies`
2. the root `resolutions`
3. the committed contract artifact's `contract-info.json`
4. the **Compact compiler** — not an npm dependency at all, just whichever binary `compact` happened to have active
5. the DApp scaffolding template

So version skew was only discoverable by hitting it at runtime.

### Why exact pins, and why semver is the wrong tool here

Several of these packages are WASM-backed. A caret range is *supposed* to mean
"any API-compatible version" — but two API-compatible copies of a WASM module are
two distinct module instances, so a value built by one fails the other's
`instanceof` check. There is no range syntax that expresses "exactly one copy".

The failure mode is the nasty kind: **install succeeds, types check, the contract
deploys, and the first circuit call fails** with `expected instance of StateValue`.

That is not hypothetical — it is all three M1 failures, none of which were logic bugs:

| symptom | cause |
|---|---|
| `npm install` fails outright | `compact-js@2.5.3` requires `ledger-v9@^0.1.0-alpha.1`; ledger-v9 exists only at `1.0.0-rc.x`, so the range is unsatisfiable. 2.5.3 looks like a patch but is a ledger-v9 prerelease. |
| deploy OK, `call` fails `expected instance of StateValue` | `compact-runtime@0.16.0` accepts `onchain-runtime-v3@^3.0.0` and floated to `3.1.0`, while `midnight-js-protocol@4.1.1` pins `3.0.0` exactly. Two WASM modules loaded. |
| artifacts demand a runtime the SDK won't install | compiler `0.34.0` emits `checkRuntimeVersion('0.19.0')`, but `midnight-js-protocol@4.1.1` pins `compact-runtime` to exactly `0.16.0`. Compiler `0.31.1` is the one that emits `0.16.0`. |

The lesson from the third row: **on Midnight you pick the compiler that matches
your SDK, not the newest one.**

## What this changes

`midnight-versions.json` is the single source of truth, carrying `compiler` and
`languageVersion` alongside the npm pins — so the compiler is pinned too, which
nothing else in the repo could express.

Four gates run on every PR:

| gate | command | catches |
|---|---|---|
| Manifests | `yarn constraints` | a caret range, or an `@midnight*` package nobody added to the train, in any workspace |
| Resolved tree | `yarn check:versions` | duplicate WASM instances an upstream caret smuggled in |
| Artifacts | `yarn check:versions` | a contract compiled by the wrong compiler or against the wrong runtime |
| Templates + resolutions | `yarn check:versions` | scaffolding templates and root `resolutions` drifting from the train |

`yarn constraints` sees only workspace manifests; everything outside them is
`scripts/check-midnight-versions.mjs`. Root `resolutions` must be literal in
`package.json` (Yarn cannot compute them at install time), so they are *verified*
against the train rather than derived from it — otherwise they quietly become a
second source of truth.

`yarn compile:contracts` selects the toolchain explicitly with
`compact +<version>` read from the train.

**No dependency actually changes version.** `@midnightntwrk/wallet-sdk` moves from
`^1.2.0` to `1.2.0` in `core` and `tui` — what it already resolved to — and the
`yarn.lock` diff is 7 lines each way, entirely `@midnight*` descriptor keys.

Two additional float hazards are pinned preventatively: `platform-js` (`compact-js`
wants `^2.2.4` while `midnight-js-protocol` pins `2.2.4` exactly — identical shape
to the `onchain-runtime-v3` bug, and `2.2.4` is currently the newest 2.x, so it is
one publish away from splitting) and `wallet-sdk-abstractions` (`^2.1.0`).

The DApp API template's four `{{SDK_*_VERSION}}` placeholders — which **nothing in
this repo ever substituted**, so a scaffolded project could not install — are now
the pinned versions and gated.

Rationale, the M1 failure table, and the upgrade procedure are in
`docs/MIDNIGHT_VERSIONS.md`.

## Verification

All four gates pass, and **each was negative-tested** — a gate that cannot fail is
worthless:

- compiler drift (train → `0.34.0`) → artifact gate fails
- resolution drift (`onchain-runtime-v3` → `3.1.0`) → resolutions gate fails
- template placeholder restored → template gate fails
- synthetic duplicate `onchain-runtime-v3@3.1.0` injected into the lockfile → tree gate fails
- the two real `^1.2.0` carets → `yarn constraints` flagged both workspaces; `--fix` corrected them

Full CI sequence locally: `yarn install --immutable`, `yarn build` (6/6),
extension typecheck, `yarn test:release-policy`, `yarn turbo run test`
(12/12 tasks, 52 passed, 30 devnet tests self-skipped).

Contracts were deliberately **not** recompiled: the pinned compiler was confirmed
to reproduce the committed artifact's versions exactly (`0.31.1` / `0.23.0` /
`0.16.0`) via a scratch build, so there was no reason to churn the committed PLONK keys.

## ⚠️ Interaction with `feat/ledger-v9-support`

That branch is the real train move, and it will **conflict with these gates by
design** — worth settling the mechanism before either lands. It introduces:

- `@midnightntwrk/ledger-v9@1.0.0-rc.3` — not in the train, so `yarn constraints` rejects it
- `@midnight-ntwrk/zkir-v2@2.2.0-rc.3` — train declares `2.1.0`, so constraints rejects it
- `wallet-sdk-v9: npm:@midnightntwrk/wallet-sdk@2.0.0-beta.2` — an **aliased second copy** of wallet-sdk alongside `^1.2.0`

The last one is the interesting case. A deliberate side-by-side v8/v9 migration is
a legitimate reason to have two instances, which is precisely what the
single-instance gate is built to reject. Also note my root
`resolutions["@midnightntwrk/wallet-sdk"] = "1.2.0"` may interact with that alias
in ways I have not tested.

So whoever lands ledger-v9 will need either to move the whole train in one commit,
or for us to add an explicit, documented exception mechanism for intentional
dual-instance migrations. I did not build that here — it is a real design decision,
not something to guess at. Happy to add it in this PR if reviewers prefer.

## Known gap

`packages/cli/templates/dapp/api/package.json` still contains
`{{API_PACKAGE_NAME}}`, and nothing in this repo substitutes template placeholders
at all — there is no template-rendering code. This PR fixes the *version* half
(now concrete and gated); the template still is not renderable. Wiring up a
scaffolder is separate work, flagged under "Known gap" in the new doc.

## Submission Checklist

- [x] Useful pull request description
- [ ] Tests are provided (if possible) — **no unit tests for the new scripts.** The change *is* CI enforcement, and every gate was negative-tested manually (above), but the scripts themselves have no automated coverage. Say the word and I will add it.
- [x] Key commits have useful messages
- [x] Every non-merge, non-bot commit has a matching DCO `Signed-off-by` trailer
- [ ] All check jobs of the CI have succeeded — pending first run
- [x] Self-reviewed the diff
- [ ] Reviewer requested — not assigned; unsure who owns tooling here
- [ ] Update README.md file (if relevant) — n/a
- [x] Update documentation (if relevant) — adds `docs/MIDNIGHT_VERSIONS.md`
- [x] No new todos introduced

## Links

No ticket. Context is the M1 milestone toolchain triage.
