### PR TITLE
extension: show what a dApp transaction takes from the wallet before approval

### DIFF
--- a/.changeset/balance-approval-shows-spend.md
+++ b/.changeset/balance-approval-shows-spend.md
@@ -1,0 +1,24 @@
+---
+'@shieldedtech/moth-extension': minor
+'@shieldedtech/moth-wallet': minor
+---
+
+Show what a dApp transaction takes from the wallet before the user approves it.
+
+When a connected dApp calls `balanceSealedTransaction` or
+`balanceUnsealedTransaction`, the wallet is asked to cover whatever the dApp's
+transaction is short of — and the approval screen said only "Network fee: paid
+in DUST". The user was approving a spend without being told the amount or the
+token. The screen now lists, per token, what the wallet has to supply ("You
+pay") and any surplus it collects back ("You get back"), plus the number of
+contract calls when there are any. If the transaction cannot be decoded, it
+says so in a visible warning rather than showing nothing.
+
+The amounts come from the transaction itself, before anything is balanced,
+booked or spent: core gains `summarizeTransaction` /
+`summarizeConnectorTransaction` (`sync/tx-summary.ts`), which sums the ledger's
+`Transaction.imbalances(segment)` over the guaranteed section and every intent.
+A negative imbalance is what the wallet must put in; a positive one is change.
+The sign convention is pinned by a test against the real ledger. Fees are not
+included — they are only known once the wallet has balanced and proven its own
+segment, and are always paid in DUST.

--- a/.changeset/clear-cache-and-resync.md
+++ b/.changeset/clear-cache-and-resync.md
@@ -1,0 +1,23 @@
+---
+'@shieldedtech/moth-extension': minor
+'@shieldedtech/moth-wallet': patch
+---
+
+Settings → Network gains "Clear cache and resync".
+
+A local network that goes down and comes back as a new chain from genesis
+leaves the wallet holding state for a chain that no longer exists: the
+account's serialized sync state, its pending submissions, and the network's
+pre-seed reference that every fresh sync is seeded from. The engine cannot
+tell, and the only ways out were switching indexer URLs or removing the
+account. The new action, behind a confirmation, stops sync, drops all of that
+for the active account on its network, clears the cached balance snapshot so
+the loading screen shows, and starts syncing again from the start of the
+chain. Nothing is spent.
+
+Core gains `clearEmptyRefCache(networkId, store)` (`sync/preseed.ts`), which
+removes the reference's state parts, height, cursor witnesses and mnemonic and
+forgets the in-process memo — without the last, a worker that had already
+verified the reference would keep handing the stale one out. `clearSyncCache`
+now also evicts the ECDSA unshielded cache identity, which it previously left
+behind for wallets of that kind.

--- a/.changeset/dust-ledger-wedge-detection.md
+++ b/.changeset/dust-ledger-wedge-detection.md
@@ -1,0 +1,45 @@
+---
+'@shieldedtech/moth-wallet': minor
+'@shieldedtech/moth-extension': minor
+'@shieldedtech/moth-cli': minor
+---
+
+Detect and steer users away from the devnet dust-ledger wedge (docs/bugs-found #15-style defect).
+
+Some devnets (midnight-node 2.0.0-rc.4 / midnight-ledger 9.1.0.0-rc.3) can
+enter a state where a DUST registration leaves the node's dust ledger unable
+to reconcile with any wallet's, permanently — every subsequent dust spend,
+from every wallet, fails with the same `InvalidDustSpendProof` /
+`Custom error: 170` signature that a normal transient race also produces.
+Only a chain reset clears it; retrying does not. This is not a Moth defect —
+see `docs/upstream-issues/dust-ledger-wedge-invalid-dust-spend-proof.md` for
+the evidence and the draft issue against `midnightntwrk/midnight-node` /
+`midnight-ledger` — but Moth users hit it on shared and local devnets, so
+Moth now detects and steers around it rather than retrying forever.
+
+**Detection** (`@shieldedtech/moth-wallet`, `sync/dust-ledger-health.ts`): a
+run of consecutive, independently built submissions rejected with the same
+ambiguous signature — with a wallet/node ledger-version mismatch ruled out
+first, and the chain confirmed still producing new blocks meanwhile — is
+surfaced as `DustLedgerWedgedError` instead of a generic failure. Wired into
+every fee-paying submission path: the extension's offscreen host, `moth
+transfer` / `moth dust register`, and the daemon's `transferTokens` /
+`dustRegister` / `dustDeregister` RPCs (used by both the headless CLI daemon
+and the TUI).
+
+**Registration UX** (`@shieldedtech/moth-extension`): the "Register for
+DUST" flow now warns before registering a NIGHT coin that has sat
+unregistered for more than a minute — the only pattern with zero known
+failures across four documented occurrences is registering within seconds of
+funding — and a wallet that has never registered is nudged to do so as soon
+as new NIGHT is observed, rather than waiting for the user to find the Dust
+screen on their own.
+
+**Repro harness**: `packages/cli/tests/integration/daemon/dust-wedge-repro.test.ts`
+isolates the fund-to-register delay as the one variable prior occurrences
+didn't control for, holding UTXO size fixed at the size every known success
+used (10,000,000 NIGHT).
+
+No change to transaction construction, signing, or proving — every
+registration involved in the underlying defect was accepted by the ledger,
+so this only classifies what a rejection means after the fact.

--- a/docs/upstream-issues/dust-ledger-wedge-invalid-dust-spend-proof.md
+++ b/docs/upstream-issues/dust-ledger-wedge-invalid-dust-spend-proof.md
@@ -1,0 +1,263 @@
+---
+status: draft — ready to file
+target-repos: midnightntwrk/midnight-node, midnightntwrk/midnight-ledger
+last-updated: 2026-09-02
+---
+
+# Draft upstream issue: a devnet can stop accepting every fee-paying transaction, permanently, after a DUST registration
+
+This is a ready-to-paste GitHub issue body. It is not a Moth defect — every
+registration involved was accepted by the ledger, and no client-side change
+(transaction construction, signing, proving) is implicated in any occurrence.
+It is filed from Moth because Moth's users are the ones who keep hitting it on
+local and shared devnets, and because Moth now ships detection and mitigation
+for it (linked at the bottom) that upstream should be aware duplicates part of
+what a real fix would make unnecessary.
+
+---
+
+## Title
+
+`InvalidDustSpendProof` can become permanent and chain-wide after a DUST registration, with no way for a client to tell it apart from a transient race
+
+## Environment
+
+| Component | Version |
+|---|---|
+| midnight-node | `2.0.0-rc.4` |
+| midnight-ledger | `9.1.0.0-rc.3` (vendored by the node above) |
+| midnight-indexer | `4.4.0-pre-alpha.16-l91r3-n2r3-...` |
+| proof-server | `9.0.0-rc.5_experimental` |
+
+All four occurrences below were observed on local/self-hosted devnet stacks
+running this exact component set.
+
+## Summary
+
+A NIGHT-for-DUST registration transaction is accepted by the node. Within
+roughly 90 seconds, every subsequent DUST spend from **every wallet on the
+chain** — including wallets that never touched the registered UTXO, including
+the genesis wallet — is rejected:
+
+```
+1010: Invalid Transaction: Custom error: 170
+```
+
+The node log is more specific but not more actionable:
+
+```
+Transaction malformed: dust spend proof failed to verify; this is just as likely a disagreement
+on dust state on the declared time (Timestamp(...)) as the proof being invalid: DustSpend { ... }
+Rejected transaction ... : Transaction Error: Malformed(InvalidDustSpendProof)
+```
+
+Blocks continue to be produced on schedule. Nothing recovers the chain except
+starting a new one. This has now been reproduced **four times**, independently,
+across different chains, different client stacks (a browser wallet, a raw
+`wallet-sdk` CLI harness), and different wallet implementations — ruling out a
+client bug as the cause.
+
+**This is the third distinct condition behind the client-visible `Custom error:
+170` / `InvalidDustSpendProof` string**, and the only one that is *absorbing*
+(nothing clears it short of a chain reset):
+
+1. A node↔SDK ledger-tag pairing mismatch — deterministic, present from first
+   deploy.
+2. A transient race, roughly 1 attempt in 3, immediately after the same wallet
+   has spent: the wallet's declared dust-state timestamp disagrees with the
+   node's. **Retrying a freshly built transaction succeeds.**
+3. **This report**: something about a DUST registration leaves the node's dust
+   state unable to reconcile with *any* wallet's, permanently.
+
+A client cannot distinguish (2) from (3) from the error alone — both produce
+the byte-identical rejection.
+
+## Why this matters more than a normal rejection
+
+A retry loop written to handle (2) — the known, real, recoverable transient —
+will spin forever against (3), and the operator gets no signal that the
+**chain**, rather than the transaction, is what broke. Every occurrence below
+involved multiple retries, from multiple wallets, across fresh processes,
+before it was understood that retrying would never help.
+
+## Evidence
+
+### Occurrence 1 — first observed, 2026-09-01
+
+A devnet that had been serving a live session for five hours stopped including
+transactions entirely. From block **3116** (2026-09-01 18:36:00 UTC) onward —
+170+ blocks, roughly 17 minutes, verified by querying every block in the range
+through the indexer — the chain contained **zero** transactions, while blocks
+continued to be produced on schedule.
+
+Every submission after that point failed, from every wallet, regardless of
+what it was:
+
+| Attempt | Wallet | Result |
+|---|---|---|
+| contract deploy (15,462 B), ×6 | genesis | `1010: … Custom error: 170` |
+| contract deploy, ×6 (fresh process each) | fresh probe wallet | `1010: … Custom error: 170` |
+| plain 1-NIGHT transfer | genesis | `1010: … Custom error: 170` |
+| plain 1-NIGHT transfer | fresh probe wallet | `1010: … Custom error: 170` |
+
+The same genesis wallet had completed an identical-shape transfer **20 minutes
+earlier**, and the same probe wallet had been funded and DUST-registered
+successfully at 18:35–18:36 — those four transactions are the last four the
+chain ever accepted. The rejected deploy declared `v_fee: 6853510813656816`
+(≈6.9e15) against a wallet balance of 7.9e19 — four orders of magnitude of
+headroom, growing throughout. This was not a fee-affordability problem.
+
+The correlation available at this point: onset immediately followed two large
+NIGHT UTXOs being newly registered for DUST generation, on a chain that had
+also been under a sustained retry load (~6 rejections per 35s throughout).
+Causality between either factor and the wedge was, at this point, untested.
+
+Six retries with 12s backoff, then fresh processes, then a different wallet —
+all failed identically. Only starting a fresh node cleared it: an identical
+deploy, from an identical wallet, against the same image and code, succeeded
+**on the first attempt** on a newly started chain.
+
+### Occurrence 2 — 2026-09-02, sharper correlation
+
+A fresh devnet wedged identically roughly 3.5 hours after genesis. The last
+transaction the chain ever accepted was block **2289** (2026-09-02 01:34:18
+UTC, tx `010060c3…`) — a **fee-less DUST registration**, a self-send of a
+single 1,000,000-NIGHT UTXO whose only dust event was one `DustInitialUtxo`
+(no `DustSpendProcessed`), submitted from a browser wallet (Moth).
+
+The first rejection followed within **90 seconds** (01:35:46). From then on,
+every dust spend from every wallet failed: four join attempts from the browser
+wallet, and — decisively — a plain funding transfer from the **genesis
+wallet**, via a CLI stack whose identical transfer had landed successfully at
+01:17 on the same chain.
+
+Registration is not sufficient on its own to trigger this — routine automated
+funding flows on the same stacks register small wallets constantly without
+incident — but two occurrences in a row now share the shape: a DUST
+registration lands, and the chain stops reconciling anyone's dust state within
+one to two minutes. Both times the immediately preceding write involved a
+large, newly registered UTXO.
+
+### Occurrence 3 — reproduced on demand; kills the "size" theory
+
+On another fresh chain, a harness funded a fresh wallet with **300,000
+NIGHT** and registered it. The registration landed, the wallet computed a
+healthy DUST balance — and its very next spend, and **every other wallet's**
+including genesis, failed `InvalidDustSpendProof` from that moment.
+
+On the *next* fresh chain, the identical code registering **10,000,000 NIGHT**
+(the same size used by every previously *successful* registration in this
+environment) worked twice in a row, each proven by a post-registration spend.
+
+So: the trigger is a DUST registration; wallet implementation is irrelevant
+(a from-scratch CLI harness reproduces it as readily as a browser extension);
+and UTXO size is **not monotonic** — 10,000,000 NIGHT is fine in some runs
+while 300,000 and 1,000,000 have each killed a chain in others.
+
+### Occurrence 4 — 2026-09-02, and the size theory is dead
+
+A chain that had been healthy for roughly 90 minutes wedged the moment a
+**10,000,000-NIGHT** registration landed — the same size as every previously
+*successful* registration on this stack. The distinguishing variable this
+time: the UTXO had been funded **39 minutes earlier**, by a provisioning run
+that had stalled between funding and registering.
+
+## The fund-to-register delay table
+
+Every known outcome across all four occurrences, by size and delay:
+
+| UTXO size | Fund → register delay | Outcome |
+|---:|---:|---|
+| 10,000,000 NIGHT | seconds | succeeded (10+ times) |
+| 300,000 NIGHT | ~22 seconds | **wedged the chain** |
+| 1,000,000 NIGHT | ~60 seconds (self-send) | **wedged the chain** |
+| 10,000,000 NIGHT | 39 minutes | **wedged the chain** |
+
+**Neither size nor delay alone explains this pattern.** The only rule with
+zero observed failures across every occurrence is: *fund, then register
+within seconds.* That is not a mechanism — it is the surviving correlation
+after size was ruled out — and it is offered here as evidence, not as a
+diagnosis this report is claiming to have made.
+
+## Detection, for anyone else who hits this
+
+Cheaper than reading the node log: ask the indexer whether any block in the
+recent range contains a transaction.
+
+```graphql
+{
+  block(offset: { height: N }) {
+    height
+    transactions {
+      hash
+    }
+  }
+}
+```
+
+A run of empty blocks spanning several minutes, on a chain that is otherwise
+being written to, means the **chain** is wedged — not that any one submitted
+transaction was malformed. This is the same check used to corroborate the
+occurrences above, and the same one a client-side detector (linked below) uses
+before concluding a wedge rather than a transient race.
+
+## What we are asking for
+
+1. **Distinguish "this proof is invalid" from "the node's dust state cannot be
+   reconciled with any client's."** As it stands, `InvalidDustSpendProof` /
+   client error 170 conflates at least three conditions of very different
+   severity — a config mismatch, a retryable race, and unrecoverable chain
+   corruption — and a client cannot tell them apart without reading the node's
+   own log, which most clients (including every wallet SDK consumer) never
+   see. A distinct error variant, or even a distinct field on the existing
+   one, would let SDKs and wallets stop retrying the unrecoverable case
+   immediately instead of burning the user's time on a loop that cannot
+   succeed.
+2. **A node whose dust state has diverged such that no wallet can pay a fee
+   should say so once, at the node level, rather than silently rejecting every
+   transaction individually forever.** A node-level health signal (a log line,
+   a metric, an RPC field) that a devnet operator or a monitoring harness can
+   check would turn "the chain silently stopped working an hour ago" into
+   "the chain flagged its own dust-reconciliation failure at 01:35:46."
+
+This supersedes nothing: the transient race in condition (2) is real, separate,
+and already understood to be a client-visible-but-recoverable timing issue —
+any fix for this report should keep that path retryable.
+
+## Reproduction
+
+A harness that isolates the fund-to-register delay as the one uncontrolled
+variable, holding UTXO size fixed at the one size every known success used
+(10,000,000 NIGHT), ships alongside this report:
+`packages/cli/tests/integration/daemon/dust-wedge-repro.test.ts` in
+[`shieldedtech/moth-wallet`](https://github.com/shieldedtech/moth-wallet). It
+funds a fresh wallet, waits a configurable delay (`MOTH_TEST_WEDGE_WAIT_MS`,
+default 90s; set to `2340000` for the exact 39-minute occurrence above),
+registers, then attempts one spend from the freshly registered wallet and one
+from genesis, and fails loudly — printing a full evidence report — only if
+both spends show the `InvalidDustSpendProof` signature while the indexer
+confirms blocks kept advancing. It has not (yet) reproduced the wedge on
+demand within a short wait; the 39-minute case is the one worth running it
+against.
+
+## What Moth changed on the client side in the meantime
+
+Because this is unfixed and absorbing, `shieldedtech/moth-wallet` ships
+client-side mitigation that does not change any transaction's construction,
+signing, or proving:
+
+- **Detection**: a wallet whose dust spends are repeatedly rejected with this
+  signature, while sync stays healthy, blocks keep advancing, and the
+  wallet's own ledger version matches the network's, is told plainly that the
+  network's dust ledger is wedged and needs a reset — instead of being left to
+  retry forever against a generic failure
+  (`packages/core/src/sync/dust-ledger-health.ts`).
+- **UX**: the "Register for DUST" flow now warns before registering a NIGHT
+  coin that has sat unregistered for more than a minute, and a wallet that has
+  never registered is nudged to do so as soon as new NIGHT is observed —
+  matching the only pattern with zero known failures above.
+
+Neither of these is a fix. Both exist because retrying blindly, or registering
+however the user happens to get to it, is actively dangerous on a devnet
+carrying this defect, and upstream not yet having distinguished the three
+conditions behind error 170 leaves a client with no other lever to pull.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -102,6 +102,12 @@ export {
   deriveWalletKeys,
 } from '@shieldedtech/moth-wallet/sync/operations';
 export type { SwapInput, WalletKeys } from '@shieldedtech/moth-wallet/sync/operations';
+export {
+  summarizeTransaction,
+  summarizeConnectorTransaction,
+  decodeConnectorTransaction,
+} from '@shieldedtech/moth-wallet/sync/tx-summary';
+export type { TransactionSummary, TxTokenAmount } from '@shieldedtech/moth-wallet/sync/tx-summary';
 
 import {
   canonicalNetworkId,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -109,6 +109,20 @@ export {
   decodeConnectorTransaction,
 } from '@shieldedtech/moth-wallet/sync/tx-summary';
 export type { TransactionSummary, TxTokenAmount } from '@shieldedtech/moth-wallet/sync/tx-summary';
+export {
+  isDustSpendProofRejection,
+  diagnoseSubmissionFailure,
+  dustSpendHealthTracker,
+  resetDustSpendHealthTrackers,
+  DustSpendHealthTracker,
+  DustLedgerWedgedError,
+  DEFAULT_WEDGE_THRESHOLD,
+  submitWithHealthTracking,
+} from '@shieldedtech/moth-wallet/sync/dust-ledger-health';
+export type {
+  DustLedgerHealthContext,
+  SubmitHealthContext,
+} from '@shieldedtech/moth-wallet/sync/dust-ledger-health';
 
 import {
   canonicalNetworkId,

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -34,6 +34,7 @@ export type {
 export {
   warmEmptyRefCache,
   preseedReferenceStatus,
+  clearEmptyRefCache,
   type WarmProgress,
 } from '@shieldedtech/moth-wallet/sync/preseed';
 export { WalletManager } from '@shieldedtech/moth-wallet/wallet/manager';

--- a/packages/cli/src/commands/dust/register.ts
+++ b/packages/cli/src/commands/dust/register.ts
@@ -8,6 +8,8 @@ import {
   describeWait,
   DustRegistrationNotYetError,
   startWalletSync,
+  submitWithHealthTracking,
+  activeLedgerVersion,
 } from '@shieldedtech/moth-wallet';
 
 export default class DustRegister extends BaseCommand {
@@ -110,12 +112,18 @@ export default class DustRegister extends BaseCommand {
         }
       }
 
-      const txHash = await designateForDustWithKeys(
-        syncedWallet.facade,
-        wallet.walletKeys,
-        network.id,
-        flags.receiver,
-        (stage) => { process.stderr.write(`DUST register: ${stage}\n`); },
+      // Reclassifies a persistent run of InvalidDustSpendProof rejections as a
+      // wedged devnet dust ledger (docs/bugs-found #15) instead of a normal
+      // failure the operator retries forever — see core/sync/dust-ledger-health.ts.
+      const txHash = await submitWithHealthTracking(
+        () => designateForDustWithKeys(
+          syncedWallet.facade,
+          wallet.walletKeys,
+          network.id,
+          flags.receiver,
+          (stage) => { process.stderr.write(`DUST register: ${stage}\n`); },
+        ),
+        {network, walletName, usingLedger: activeLedgerVersion()},
       );
 
       if (txHash) {

--- a/packages/cli/src/commands/transfer.ts
+++ b/packages/cli/src/commands/transfer.ts
@@ -11,6 +11,8 @@ import {
   NIGHT_TOKEN_ID,
   InvalidAmountError,
   parseNightAmount,
+  submitWithHealthTracking,
+  activeLedgerVersion,
   type SendRequest,
   type SyncedWallet,
   type WalletBalances,
@@ -151,9 +153,15 @@ export default class Transfer extends BaseCommand {
 
       let txHash: string;
       try {
-        txHash = await sendTokensWithKeys(syncedWallet.facade, wallet.walletKeys, network.id, [req], (stage) => {
-          process.stderr.write(`Transfer: ${stage}\n`);
-        });
+        // Reclassifies a persistent run of InvalidDustSpendProof rejections as a
+        // wedged devnet dust ledger (docs/bugs-found #15) instead of a normal
+        // failure retried forever — see core/sync/dust-ledger-health.ts.
+        txHash = await submitWithHealthTracking(
+          () => sendTokensWithKeys(syncedWallet.facade, wallet.walletKeys, network.id, [req], (stage) => {
+            process.stderr.write(`Transfer: ${stage}\n`);
+          }),
+          {network, walletName, usingLedger: activeLedgerVersion()},
+        );
       } catch (err) {
         // "Insufficient funds" on a wallet that just reported a sufficient
         // balance is not a contradiction: the balance counts coins reserved by

--- a/packages/cli/tests/integration/daemon/dust-wedge-repro.test.ts
+++ b/packages/cli/tests/integration/daemon/dust-wedge-repro.test.ts
@@ -1,0 +1,229 @@
+// Repro harness for the devnet dust-ledger wedge documented upstream (a
+// midnight-node 2.0.0-rc.4 / midnight-ledger 9.1.0.0-rc.3 defect, not a Moth
+// bug — see docs/upstream-issues/dust-ledger-wedge-invalid-dust-spend-proof.md
+// for the full writeup and evidence table this test is built from).
+//
+// The observed shape: a DUST registration lands, and within ~90 seconds every
+// subsequent dust spend from every wallet on the chain — including the
+// genesis wallet, which never touched the registered coin — starts failing
+// with `1010: Invalid Transaction: Custom error: 170`
+// (`Malformed(InvalidDustSpendProof)`). Blocks keep being produced. Nothing
+// but a chain reset clears it.
+//
+// Four field occurrences narrowed the trigger to a DUST registration, and
+// ruled out coin size as the sole variable (a 10,000,000-NIGHT registration
+// wedged a chain on its 39-minutes-after-funding occurrence, after 10+
+// identical-size registrations had succeeded when done within seconds of
+// funding). This test isolates the ONE surviving variable those occurrences
+// didn't control for: the delay between funding and registering. Coin size is
+// held fixed at 10,000,000 NIGHT throughout — the size every known SUCCESS
+// used — so a wedge observed here cannot be blamed on size.
+//
+// Sequence: fund a fresh wallet, wait `MOTH_TEST_WEDGE_WAIT_MS` (default 90s;
+// set to e.g. 39 * 60_000 to reproduce the fourth occurrence exactly), then
+// register, then attempt ONE spend from the freshly registered wallet and ONE
+// from the genesis wallet (the second `airdrop` in this harness — the only
+// spend this CLI stack can make the genesis wallet perform on demand). If both
+// fail with the ambiguous InvalidDustSpendProof signature (checked with the
+// same classifier Moth uses to detect this in production —
+// `isDustSpendProofRejection`, core/sync/dust-ledger-health.ts) AND the
+// indexer confirms blocks kept being produced meanwhile, the chain matches the
+// wedge shape and the test fails loudly, printing the evidence a bug report
+// needs rather than a bare assertion error.
+//
+// A pass does NOT prove the defect is fixed — the trigger is not fully
+// understood, and most registrations (particularly at this size, done
+// promptly) succeed. Run this repeatedly, and with a long wait, to chase it.
+//
+// Requires a fresh devnet the test is allowed to leave wedged: unlike every
+// other file in this directory, a positive result here is destructive to the
+// chain. Point MOTH_DEVNET_URL at a disposable stack, never a shared one.
+
+import {describe, it, expect, afterAll} from 'vitest';
+import {isDustSpendProofRejection} from '@shieldedtech/moth-wallet';
+import {DEFAULT_NETWORKS} from '@shieldedtech/moth-wallet/types/network';
+import {
+  DEVNET_URL,
+  NETWORK,
+  setupTestWallet,
+  cleanupTestWallet,
+  waitForSynced,
+  waitForDust,
+  runMoth,
+  runMothJson,
+  runMidnight,
+  getReceiveAddress,
+} from './helpers.js';
+
+// The size every known-good registration in docs/bugs-found #15 used. Fixed
+// here so this run's only variable is the wait below.
+const REGISTRATION_NIGHT = process.env.MOTH_TEST_WEDGE_NIGHT ?? '10000000';
+
+// 90s by default — enough to clear the documented ~90-second onset window
+// without making a routine CI run pay minutes for a repro that usually won't
+// fire. Override to chase a specific occurrence, e.g.:
+//   MOTH_TEST_WEDGE_WAIT_MS=2340000 npx vitest run dust-wedge-repro   # 39 min, occurrence 4
+//   MOTH_TEST_WEDGE_WAIT_MS=22000   npx vitest run dust-wedge-repro   # 22s, occurrence 3
+const WAIT_MS = Number(process.env.MOTH_TEST_WEDGE_WAIT_MS ?? 90_000);
+
+const INDEXER_URL = DEFAULT_NETWORKS[NETWORK]?.indexerUrl;
+
+interface IndexerBlock {
+  height: number;
+  transactions: {hash: string}[];
+}
+
+async function graphql<T>(query: string): Promise<T> {
+  const res = await fetch(INDEXER_URL!, {
+    method: 'POST',
+    headers: {'content-type': 'application/json'},
+    body: JSON.stringify({query}),
+  });
+  const body = (await res.json()) as {data?: T; errors?: unknown};
+  if (!body.data) throw new Error(`indexer query failed: ${JSON.stringify(body.errors ?? body)}`);
+  return body.data;
+}
+
+async function currentTip(): Promise<number> {
+  const data = await graphql<{block: {height: number} | null}>('{ block { height } }');
+  return data.block?.height ?? 0;
+}
+
+async function fetchBlock(height: number): Promise<IndexerBlock | null> {
+  const data = await graphql<{block: IndexerBlock | null}>(
+    `{ block(offset: { height: ${height} }) { height transactions { hash } } }`,
+  );
+  return data.block;
+}
+
+/** The detection query docs/bugs-found #15 itself proposes: a run of blocks
+ *  with zero transactions, on a chain that is being written to, means the
+ *  chain is wedged — not that any one transaction was malformed. */
+async function emptyBlockRun(fromHeight: number, toHeight: number): Promise<{checked: number; empty: number}> {
+  let empty = 0;
+  let checked = 0;
+  for (let h = fromHeight; h <= toHeight; h++) {
+    const block = await fetchBlock(h);
+    if (!block) continue;
+    checked += 1;
+    if (block.transactions.length === 0) empty += 1;
+  }
+  return {checked, empty};
+}
+
+describe.skipIf(!DEVNET_URL)('dust-ledger wedge repro (docs/bugs-found #15) — delay axis', () => {
+  let subjectWallet: string | undefined;
+  let throwawayWallet: string | undefined;
+
+  afterAll(() => {
+    if (subjectWallet) cleanupTestWallet(subjectWallet);
+    if (throwawayWallet) cleanupTestWallet(throwawayWallet);
+  });
+
+  it(
+    `wedges neither the subject wallet's own spend nor genesis's, after a ${(WAIT_MS / 1000).toFixed(0)}s ` +
+      `fund-to-register delay at ${REGISTRATION_NIGHT} NIGHT`,
+    async () => {
+      // --- Fund -----------------------------------------------------------
+      subjectWallet = await setupTestWallet('wedge-subject', NETWORK, REGISTRATION_NIGHT);
+      const fundedAt = Date.now();
+      const subjectAddress = getReceiveAddress(subjectWallet, NETWORK);
+
+      // A second, throwaway address the harness can airdrop to on demand —
+      // the only lever this CLI stack has to make the genesis wallet spend
+      // whenever we ask, which is what "attempt one spend from genesis" means
+      // here: docs/bugs-found #15's second occurrence used exactly this (a
+      // plain genesis-funded transfer) to prove the wedge was chain-wide, not
+      // wallet-specific.
+      throwawayWallet = await setupTestWallet('wedge-genesis-probe', NETWORK, '0');
+      const throwawayAddress = getReceiveAddress(throwawayWallet, NETWORK);
+
+      // --- Wait -------------------------------------------------------------
+      const elapsed = Date.now() - fundedAt;
+      const remaining = WAIT_MS - elapsed;
+      if (remaining > 0) {
+        process.stderr.write(
+          `[wedge-repro] waiting ${(remaining / 1000).toFixed(0)}s more before registering ` +
+            `(target delay ${(WAIT_MS / 1000).toFixed(0)}s since funding)...\n`,
+        );
+        await new Promise((r) => setTimeout(r, remaining));
+      }
+
+      const heightBeforeRegister = await currentTip();
+
+      // --- Register ---------------------------------------------------------
+      const register = runMothJson<{txHash: string | null; status: string}>([
+        'dust', 'register',
+        '--wallet', subjectWallet,
+        '--network', NETWORK,
+        '--yes',
+      ]);
+      expect(register.exitCode, register.raw.stderr || register.raw.stdout).toBe(0);
+      const registeredAt = Date.now();
+      process.stderr.write(
+        `[wedge-repro] registered at ${new Date(registeredAt).toISOString()}, ` +
+          `${((registeredAt - fundedAt) / 1000).toFixed(1)}s after funding: ${JSON.stringify(register.data)}\n`,
+      );
+
+      // A registration needs a moment for its dust event to reach the sub-
+      // wallet's own view before a spend against it can prove correctly.
+      await waitForSynced(subjectWallet, NETWORK, 120_000);
+      await waitForDust(subjectWallet, NETWORK, 300_000, 1n);
+
+      // --- Spend #1: the freshly registered wallet, on itself ---------------
+      const selfSpend = runMothJson<{txHash: string}>([
+        'transfer', '1',
+        '--to', subjectAddress,
+        '--wallet', subjectWallet,
+        '--network', NETWORK,
+        '--yes',
+      ]);
+      const selfSpendFailed = selfSpend.exitCode !== 0;
+      const selfSpendIsWedgeSignature =
+        selfSpendFailed && isDustSpendProofRejection(new Error(selfSpend.raw.stderr || selfSpend.raw.stdout));
+
+      // --- Spend #2: genesis, via a second airdrop to the throwaway address -
+      const genesisSpend = await runMidnight(['airdrop', '1', '--wallet', throwawayAddress]);
+      const genesisSpendFailed = genesisSpend.exitCode !== 0;
+      const genesisSpendIsWedgeSignature =
+        genesisSpendFailed && isDustSpendProofRejection(new Error(genesisSpend.stderr || genesisSpend.stdout));
+
+      // --- Corroborate against the indexer directly --------------------------
+      const heightAfter = await currentTip();
+      const {checked, empty} = await emptyBlockRun(heightBeforeRegister, heightAfter);
+      const blocksAdvanced = heightAfter > heightBeforeRegister;
+
+      const report = {
+        network: NETWORK,
+        registrationNight: REGISTRATION_NIGHT,
+        fundToRegisterDelayMs: registeredAt - fundedAt,
+        registerResult: register.data,
+        selfSpend: {failed: selfSpendFailed, wedgeSignature: selfSpendIsWedgeSignature, output: selfSpend.raw},
+        genesisSpend: {failed: genesisSpendFailed, wedgeSignature: genesisSpendIsWedgeSignature, output: genesisSpend},
+        heightBeforeRegister,
+        heightAfter,
+        blocksAdvanced,
+        blocksChecked: checked,
+        emptyBlocks: empty,
+      };
+      process.stderr.write(`[wedge-repro] report: ${JSON.stringify(report, null, 2)}\n`);
+
+      // A wedge is BOTH spends failing with the same ambiguous signature WHILE
+      // the chain kept producing blocks — the same two gates Moth's own
+      // detector applies (core/sync/dust-ledger-health.ts), so this harness and
+      // production disagree about nothing.
+      const wedged = selfSpendIsWedgeSignature && genesisSpendIsWedgeSignature && blocksAdvanced;
+
+      expect(
+        wedged,
+        'DUST LEDGER WEDGED: both the subject wallet and genesis failed InvalidDustSpendProof ' +
+          `after this registration, with the chain still producing blocks (${empty}/${checked} empty in the ` +
+          `probed range). This chain is now unusable for further tests. See the printed report above for the ' +
+          'upstream issue, and docs/upstream-issues/dust-ledger-wedge-invalid-dust-spend-proof.md.`,
+      ).toBe(false);
+    },
+    // Generous: registration + two spends + sync waits, plus whatever
+    // MOTH_TEST_WEDGE_WAIT_MS asks for.
+    WAIT_MS + 600_000,
+  );
+});

--- a/packages/cli/tests/integration/daemon/helpers.ts
+++ b/packages/cli/tests/integration/daemon/helpers.ts
@@ -209,7 +209,15 @@ export async function startDaemon(walletName: string, network: string): Promise<
  * stop the pre-seed daemon; the per-test daemon spawned later
  * restores from that cache and observes NIGHT immediately.
  */
-export async function setupTestWallet(prefix: string, network: string): Promise<string> {
+export async function setupTestWallet(
+  prefix: string,
+  network: string,
+  /** NIGHT to airdrop; defaults to AIRDROP_NIGHT (env-overridable). Callers
+   *  investigating the DUST-registration wedge (docs/bugs-found #15) pin this
+   *  explicitly so wallet size is a controlled variable, not an env default
+   *  that could silently change between runs. */
+  nightAmount: string = AIRDROP_NIGHT,
+): Promise<string> {
   if (network !== 'undeployed') {
     throw new Error(`setupTestWallet only supports 'undeployed' (genesis airdrop scope); got ${network}`);
   }
@@ -256,7 +264,7 @@ export async function setupTestWallet(prefix: string, network: string): Promise<
 
     // Phase 2 — fund via the midnight CLI (waits for finalization).
     const air = await runMidnight([
-      'airdrop', AIRDROP_NIGHT,
+      'airdrop', nightAmount,
       '--wallet', bech32m,
     ]);
     if (air.exitCode !== 0) {
@@ -384,8 +392,11 @@ export function getReceiveAddress(walletName: string, network: string): string {
 }
 
 /** Spawn `npx midnight-wallet-cli@latest midnight <args>` and collect
- *  stdout/stderr. Used for funding via the genesis wallet. */
-async function runMidnight(args: string[]): Promise<CliResult> {
+ *  stdout/stderr. Used for funding via the genesis wallet — and, in the
+ *  dust-wedge repro, as the only available way to make the genesis wallet
+ *  spend on demand (a second `airdrop` to a throwaway address is a genesis
+ *  wallet transaction like any other). */
+export async function runMidnight(args: string[]): Promise<CliResult> {
   return new Promise((resolveOuter) => {
     const child = spawn('npx', ['-y', '-p', 'midnight-wallet-cli@latest', 'midnight', ...args], {
       env: process.env,

--- a/packages/core/src/daemon/wallet-handlers.ts
+++ b/packages/core/src/daemon/wallet-handlers.ts
@@ -44,6 +44,7 @@ import type {
 } from './wallet-rpc-types.js';
 
 import {sendTokensWithKeys, designateForDustWithKeys, dedesignateFromDustWithKeys} from '../sync/operations.js';
+import {submitWithHealthTracking} from '../sync/dust-ledger-health.js';
 import type {WalletKeys} from '../sync/operations.js';
 import {callCircuit} from '../contract/call.js';
 import {deployContract} from '../contract/deploy.js';
@@ -352,17 +353,23 @@ export function buildWalletHandlers(deps: WalletHandlerDeps): Record<string, Rpc
               `transfer of ${amountLabel} exceeds the --max-spend cap of ${formatBalance(deps.maxSpendRaw, NIGHT_DENOMINATION)} NIGHT`,
             );
           }
-          const txId = await sendTokensWithKeys(
-            facade,
-            walletKeys,
-            network.id,
-            [{
-              type: params.type,
-              tokenId: params.tokenId,
-              amount: amountBig,
-              to: params.to,
-            }],
-            (stage) => log('info', `[transferTokens] ${stage}`),
+          // Reclassifies a persistent run of InvalidDustSpendProof rejections as
+          // a wedged devnet dust ledger (docs/bugs-found #15) instead of a
+          // normal failure the operator retries forever — dust-ledger-health.ts.
+          const txId = await submitWithHealthTracking(
+            () => sendTokensWithKeys(
+              facade,
+              walletKeys,
+              network.id,
+              [{
+                type: params.type,
+                tokenId: params.tokenId,
+                amount: amountBig,
+                to: params.to,
+              }],
+              (stage) => log('info', `[transferTokens] ${stage}`),
+            ),
+            {network, walletName, usingLedger: activeLedgerVersion()},
           );
           return {txId: String(txId)};
         },
@@ -533,12 +540,15 @@ export function buildWalletHandlers(deps: WalletHandlerDeps): Record<string, Rpc
         ],
         ctx,
         async () => {
-          const txId = await designateForDustWithKeys(
-            facade,
-            walletKeys,
-            network.id,
-            params.receiver,
-            (stage) => log('info', `[dustRegister] ${stage}`),
+          const txId = await submitWithHealthTracking(
+            () => designateForDustWithKeys(
+              facade,
+              walletKeys,
+              network.id,
+              params.receiver,
+              (stage) => log('info', `[dustRegister] ${stage}`),
+            ),
+            {network, walletName, usingLedger: activeLedgerVersion()},
           );
           return {txId, registered: txId !== null};
         },
@@ -562,11 +572,14 @@ export function buildWalletHandlers(deps: WalletHandlerDeps): Record<string, Rpc
         ctx,
         async () => {
           try {
-            const txId = await dedesignateFromDustWithKeys(
-              facade,
-              walletKeys,
-              network.id,
-              (stage) => log('info', `[dustDeregister] ${stage}`),
+            const txId = await submitWithHealthTracking(
+              () => dedesignateFromDustWithKeys(
+                facade,
+                walletKeys,
+                network.id,
+                (stage) => log('info', `[dustDeregister] ${stage}`),
+              ),
+              {network, walletName, usingLedger: activeLedgerVersion()},
             );
             return {txId};
           } catch (err) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,6 +116,12 @@ export {
   type TransactionSummary, type TxTokenAmount,
 } from './sync/tx-summary.js';
 export {
+  isDustSpendProofRejection, diagnoseSubmissionFailure, dustSpendHealthTracker,
+  resetDustSpendHealthTrackers, DustSpendHealthTracker, DustLedgerWedgedError,
+  DEFAULT_WEDGE_THRESHOLD, submitWithHealthTracking,
+  type DustLedgerHealthContext, type SubmitHealthContext,
+} from './sync/dust-ledger-health.js';
+export {
   InMemorySyncStateStore, syncStateKey, emptyRefStateKey, emptyRefMnemonicKey, emptyRefHeightKey,
   type SyncStateStore, type WalletPart,
 } from './sync/sync-store.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,7 +138,7 @@ export {
   type WitnessStream,
   type WitnessVerdict,
 } from './sync/cursor-witness.js';
-export { ensureEmptyRefCache, warmEmptyRefCache, refreshEmptyRefCache, preseedReferenceStatus, preSeedNewWallet, type WarmProgress } from './sync/preseed.js';
+export { ensureEmptyRefCache, warmEmptyRefCache, clearEmptyRefCache, refreshEmptyRefCache, preseedReferenceStatus, preSeedNewWallet, type WarmProgress } from './sync/preseed.js';
 
 // Contract
 export { loadContractArtifact, type ContractArtifact } from './contract/artifact-loader.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,10 @@ export {
   type SendRequest, type TxStage, type NightUtxo, type FinalizedTransaction, type WalletKeys,
 } from './sync/operations.js';
 export {
+  summarizeTransaction, summarizeConnectorTransaction, decodeConnectorTransaction,
+  type TransactionSummary, type TxTokenAmount,
+} from './sync/tx-summary.js';
+export {
   InMemorySyncStateStore, syncStateKey, emptyRefStateKey, emptyRefMnemonicKey, emptyRefHeightKey,
   type SyncStateStore, type WalletPart,
 } from './sync/sync-store.js';

--- a/packages/core/src/sync/dust-ledger-health.ts
+++ b/packages/core/src/sync/dust-ledger-health.ts
@@ -1,0 +1,270 @@
+// Detecting a wedged devnet dust ledger — see docs/bugs-found.md-style report
+// filed upstream: a devnet's dust state can enter a state where NO wallet can
+// spend DUST any more, and every rejection carries the exact same client
+// signature ("1010: Invalid Transaction: Custom error: 170" /
+// `Malformed(InvalidDustSpendProof)`) as two entirely different, recoverable
+// conditions:
+//
+//   1. A transient race (~1 in 3 attempts, immediately after the same wallet
+//      spent): the wallet's declared dust-state timestamp disagreed with the
+//      node's. Retrying a FRESH build+submit (never a byte-for-byte resend —
+//      that proves nothing new) succeeds.
+//   2. A wallet/node ledger-version mismatch (ADR-0006): the wallet is on the
+//      wrong ledger generation for the network it is talking to. Reconnecting
+//      to pick up the right ledger fixes it.
+//   3. The wedge itself: something about a DUST registration (size and delay
+//      both ruled out individually) leaves the node's dust state unable to
+//      reconcile with ANY wallet's, permanently. Blocks keep being produced;
+//      nothing but a chain reset clears it.
+//
+// A single rejection proves nothing — (1) alone produces the identical string.
+// This module exists to tell (3) apart from (1)/(2) without guessing: rule out
+// (2) directly (it is checkable), then require the SAME signature to repeat
+// across several INDEPENDENT submissions while the chain keeps producing new
+// blocks. Only then is a wedge, rather than bad luck, the better explanation.
+//
+// Deliberately does not change how a transaction is built, signed or proven —
+// this only classifies what a rejection means, after the ledger/SDK has
+// already accepted or refused it.
+
+import {WalletError} from '../types/errors.js';
+import {assertLedgerForNetwork, ledgerVersionForProtocol} from '../ledger/protocol-version.js';
+import type {LedgerVersion} from '../types/network.js';
+
+/** Consecutive independently-built submissions carrying the same ambiguous
+ *  signature before Moth calls the network wedged rather than unlucky.
+ *  Chosen above the ~1-in-3 rate of the known transient (docs bugs #6): three
+ *  in a row is already an unlikely coincidence if each attempt were an
+ *  independent 1/3 chance, and every documented wedge is "the first spend
+ *  after registration, and every one since" — a wedge fails at 100%, not 33%.
+ */
+export const DEFAULT_WEDGE_THRESHOLD = 3;
+
+/** Matches the client-visible shape of an InvalidDustSpendProof rejection,
+ *  under whichever wrapping the SDK / RPC layer puts around the node's raw
+ *  `1010: Invalid Transaction: Custom error: 170` or the node-log spelling
+ *  `Malformed(InvalidDustSpendProof)` (surfaced to a client that reads node
+ *  logs directly, e.g. a devnet operator's tooling). */
+export function isDustSpendProofRejection(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return /custom error:\s*170\b|invaliddustspendproof/i.test(msg);
+}
+
+/**
+ * The network's dust ledger can no longer verify anyone's spends. Distinct
+ * from a normal submission failure: retrying does not help, importing a
+ * different wallet does not help, and the only known fix is resetting the
+ * chain (a fresh chain has never reproduced this on its first transaction).
+ */
+export class DustLedgerWedgedError extends WalletError {
+  readonly networkId: string;
+  readonly consecutiveRejections: number;
+
+  constructor(networkId: string, consecutiveRejections: number, cause?: unknown) {
+    super(
+      'NETWORK_ERROR',
+      `${networkId}'s dust ledger can no longer verify anyone's spends (known devnet defect). ` +
+        `${consecutiveRejections} independent submissions in a row were rejected with the same ` +
+        `"invalid dust spend proof" signature while the chain kept producing new blocks — that ` +
+        `rules out a one-off race. This is not something retrying, reconnecting, or switching ` +
+        `wallets fixes: the network needs a reset. If you operate ${networkId}, reset the chain; ` +
+        `otherwise wait for its operator to, or switch to a different network.`,
+      cause,
+    );
+    this.name = 'DustLedgerWedgedError';
+    this.networkId = networkId;
+    this.consecutiveRejections = consecutiveRejections;
+  }
+}
+
+/**
+ * One wallet's run of consecutive InvalidDustSpendProof outcomes on one
+ * network, across independently built-and-submitted transactions.
+ *
+ * A hit anywhere else — a success, or a failure with a different signature —
+ * resets the streak: only a run of the identical ambiguous signature, back to
+ * back, with nothing else happening in between, is evidence of anything.
+ */
+export class DustSpendHealthTracker {
+  private streak = 0;
+  private heightAtFirstRejection: number | undefined;
+
+  get consecutiveRejections(): number {
+    return this.streak;
+  }
+
+  /** A dust spend went through. Whatever was happening before, it isn't now. */
+  recordSuccess(): void {
+    this.streak = 0;
+    this.heightAtFirstRejection = undefined;
+  }
+
+  /** A submission failed for some other reason (or this one couldn't be
+   *  classified — e.g. the indexer was unreachable). Breaks the streak: a
+   *  wedge is a run of the SAME signature, not failures in general. */
+  recordUnrelatedFailure(): void {
+    this.streak = 0;
+    this.heightAtFirstRejection = undefined;
+  }
+
+  /** Record one InvalidDustSpendProof rejection observed at chain height
+   *  `tipHeight`. Returns the streak length after recording. */
+  recordProofRejection(tipHeight: number): number {
+    if (this.streak === 0) this.heightAtFirstRejection = tipHeight;
+    this.streak += 1;
+    return this.streak;
+  }
+
+  /** Whether the chain has produced at least one new block since this streak
+   *  began. Separates a wedged dust ledger (blocks keep coming; nothing
+   *  reconciles) from a stalled node or indexer, where every read — including
+   *  this one — would already be failing the same way and there would be
+   *  nothing distinctive to detect. */
+  blocksAdvancedSince(tipHeight: number): boolean {
+    return this.heightAtFirstRejection !== undefined && tipHeight > this.heightAtFirstRejection;
+  }
+}
+
+const trackers = new Map<string, DustSpendHealthTracker>();
+
+/** One tracker per (network, wallet), shared by every submission path so a
+ *  registration's rejection and a transfer's rejection on the same wallet
+ *  count toward the same streak. */
+export function dustSpendHealthTracker(networkId: string, walletName: string): DustSpendHealthTracker {
+  const key = `${networkId}/${walletName}`;
+  let tracker = trackers.get(key);
+  if (!tracker) {
+    tracker = new DustSpendHealthTracker();
+    trackers.set(key, tracker);
+  }
+  return tracker;
+}
+
+/** Test-only: drop every tracker between cases. */
+export function resetDustSpendHealthTrackers(): void {
+  trackers.clear();
+}
+
+export interface DustLedgerHealthContext {
+  readonly network: {readonly id: string; readonly indexerUrl: string};
+  /** The ledger this wallet has loaded for `network` — `activeLedgerVersion()`. */
+  readonly usingLedger: LedgerVersion;
+  /** Consecutive rejections required before declaring a wedge. */
+  readonly threshold?: number;
+  /** Injectable for tests; defaults to one indexer read. */
+  readonly probeBlock?: (indexerUrl: string) => Promise<{height: number; protocolVersion: number} | undefined>;
+}
+
+/**
+ * Classify one submission failure and return the error Moth should surface:
+ * the original error, a ledger-version mismatch (recoverable — reconnect
+ * picks up the right ledger), or {@link DustLedgerWedgedError} (not
+ * recoverable from the client). Never throws itself; the caller throws
+ * whatever comes back, e.g.:
+ *
+ * ```ts
+ * try {
+ *   const hash = await submitFinalizedTransaction(facade, finalized);
+ *   tracker.recordSuccess();
+ *   return hash;
+ * } catch (err) {
+ *   throw await diagnoseSubmissionFailure(tracker, err, { network, usingLedger });
+ * }
+ * ```
+ *
+ * Costs one indexer round trip, and only when the rejection actually matches
+ * the ambiguous signature — every other failure returns immediately.
+ */
+export async function diagnoseSubmissionFailure(
+  tracker: DustSpendHealthTracker,
+  error: unknown,
+  context: DustLedgerHealthContext,
+): Promise<Error> {
+  const original = error instanceof Error ? error : new Error(String(error));
+  if (!isDustSpendProofRejection(error)) {
+    tracker.recordUnrelatedFailure();
+    return original;
+  }
+
+  const probe = context.probeBlock ?? defaultProbeBlock;
+  const block = await probe(context.network.indexerUrl).catch(() => undefined);
+  if (!block) {
+    // Can't confirm the chain is even producing blocks, so nothing here is
+    // conclusive — but it also isn't evidence of a wedge, since a wedge is
+    // defined by everything else working while dust alone fails.
+    tracker.recordUnrelatedFailure();
+    return original;
+  }
+
+  // Rule out condition (2) before counting toward a wedge: a mismatched
+  // ledger produces this exact signature and IS recoverable, so it must never
+  // be miscounted as chain corruption.
+  const expected = ledgerVersionForProtocol(block.protocolVersion);
+  if (expected !== undefined && expected !== context.usingLedger) {
+    tracker.recordUnrelatedFailure();
+    try {
+      assertLedgerForNetwork({
+        networkId: context.network.id,
+        using: context.usingLedger,
+        observedProtocolVersion: block.protocolVersion,
+        action: 'submit',
+      });
+    } catch (mismatch) {
+      return mismatch as Error;
+    }
+  }
+
+  const streak = tracker.recordProofRejection(block.height);
+  const threshold = context.threshold ?? DEFAULT_WEDGE_THRESHOLD;
+  if (streak < threshold) return original; // condition (1): too early to tell from a transient race
+
+  if (!tracker.blocksAdvancedSince(block.height)) return original; // chain itself may be stalled — a different, undiagnosed problem
+
+  return new DustLedgerWedgedError(context.network.id, streak, original);
+}
+
+export interface SubmitHealthContext {
+  readonly network: {readonly id: string; readonly indexerUrl: string};
+  readonly walletName: string;
+  /** This wallet's loaded ledger version, if known (`activeLedgerVersion()`).
+   *  Without it a rejection cannot be checked for a ledger mismatch, so it is
+   *  surfaced as-is rather than guessed at. */
+  readonly usingLedger?: LedgerVersion;
+  readonly threshold?: number;
+  readonly probeBlock?: DustLedgerHealthContext['probeBlock'];
+}
+
+/**
+ * Wrap one fee-paying submission with wedge detection: run `submit`, clear the
+ * wallet's rejection streak on success, and on failure reclassify the error
+ * through {@link diagnoseSubmissionFailure} before rethrowing. Shared by every
+ * surface that submits transactions directly — the extension's offscreen host,
+ * the CLI's transfer/dust commands, and the daemon — so a registration's
+ * rejection and a transfer's rejection on the same wallet count toward the
+ * same streak regardless of which surface made them.
+ */
+export async function submitWithHealthTracking<T>(
+  submit: () => Promise<T>,
+  context: SubmitHealthContext,
+): Promise<T> {
+  const tracker = dustSpendHealthTracker(context.network.id, context.walletName);
+  try {
+    const result = await submit();
+    tracker.recordSuccess();
+    return result;
+  } catch (e) {
+    if (!context.usingLedger) throw e;
+    throw await diagnoseSubmissionFailure(tracker, e, {
+      network: context.network,
+      usingLedger: context.usingLedger,
+      threshold: context.threshold,
+      probeBlock: context.probeBlock,
+    });
+  }
+}
+
+async function defaultProbeBlock(indexerUrl: string): Promise<{height: number; protocolVersion: number} | undefined> {
+  const {IndexerClient} = await import('../network/indexer-client.js');
+  const block = await new IndexerClient(indexerUrl).getBlock();
+  return block ? {height: block.height, protocolVersion: block.protocolVersion} : undefined;
+}

--- a/packages/core/src/sync/preseed.ts
+++ b/packages/core/src/sync/preseed.ts
@@ -376,6 +376,40 @@ export function warmEmptyRefCache(
  * Lets a UI distinguish "not started" from "in progress" from "done" — a build
  * runs for an hour, so reporting it as perpetually in progress is misleading.
  */
+/**
+ * Forget the pre-seed reference for a network: its three state parts, its
+ * height, its cursor witnesses, the reference mnemonic, and the in-process memo
+ * `ensureEmptyRefCache` hands out.
+ *
+ * For a chain that restarted from genesis. The reference is chain state, so on a
+ * new chain it is wrong in every part, and the wallet-level cache clear does not
+ * reach it: every new sync would be seeded from the old chain's tip. Deleting
+ * the memo matters as much as the store — a verified reference is memoised per
+ * process, so without it the next sync in the same worker would still get the
+ * stale one. A network whose reference ships in the package reinstalls it on the
+ * next sync; its witnesses are then checked against the chain, and a reset chain
+ * refuses them, so the wallet walks from genesis rather than trusting it.
+ */
+export async function clearEmptyRefCache(networkId: string, store?: SyncStateStore): Promise<void> {
+  refCache.delete(networkId);
+  const resolved = await resolveSyncStore(store);
+  const keys = [
+    ...REF_PARTS.map(part => emptyRefStateKey(networkId, part)),
+    ...REF_PARTS.map(part => cursorWitnessKey(networkId, EMPTY_REF_WALLET, part)),
+    emptyRefHeightKey(networkId),
+    emptyRefMnemonicKey(networkId),
+  ];
+  for (const key of keys) {
+    try {
+      await resolved.delete(key);
+    } catch {
+      /* absent already */
+    }
+  }
+}
+
+const REF_PARTS: WalletPart[] = ['shielded', 'unshielded', 'dust'];
+
 export async function preseedReferenceStatus(
   network: NetworkConfig,
   store?: SyncStateStore

--- a/packages/core/src/sync/tx-summary.ts
+++ b/packages/core/src/sync/tx-summary.ts
@@ -1,0 +1,115 @@
+// What a dApp-supplied transaction asks of the wallet, read off the transaction
+// itself before the wallet balances it.
+//
+// The connector's balance{Sealed,Unsealed}Transaction hands the wallet a
+// transaction the dApp built. The wallet then covers whatever the transaction
+// is short of — inputs for every deficit, plus fees — so the deficit IS the
+// amount that leaves the wallet, and the user needs to see it before approving.
+// The ledger reports it directly: `Transaction.imbalances(segment)` is the
+// surplus or deficit per token type for one segment, no key material needed.
+//
+// Sign convention (verified against ledger-v8 in tests/unit/sync/tx-summary.test.ts):
+// negative means the segment spends more than it provides — the wallet must
+// supply that much — and positive means the segment provides more than it
+// spends, which the wallet collects as change. Segments are summed, because the
+// approval question is "what does this cost me overall": segment 0 is the
+// guaranteed section; every intent (and every fallible Zswap offer) occupies its
+// own numbered segment.
+
+import type * as ledger from '@midnight-ntwrk/ledger-v8';
+import {ledger as activeLedger} from '../ledger/index.js';
+
+/** One token amount the balancing step moves in or out of the wallet. */
+export interface TxTokenAmount {
+  kind: 'shielded' | 'unshielded' | 'dust';
+  /** Raw token type as hex; empty for DUST, which has a single type. */
+  tokenId: string;
+  /** Always positive; direction is given by which list it sits in. */
+  amount: bigint;
+}
+
+export interface TransactionSummary {
+  /** Deficits: what the wallet must put in, and so what leaves it. */
+  spends: TxTokenAmount[];
+  /** Surpluses: what the wallet receives back as change. */
+  receives: TxTokenAmount[];
+  /** Contract calls, deploys and maintenance updates across all intents. */
+  contractActions: number;
+}
+
+type AnyTransaction = ledger.Transaction<ledger.Signaturish, ledger.Proofish, ledger.Bindingish>;
+
+/**
+ * Deserialize a transaction at the stage the connector accepts for balancing:
+ * signed and proven, sealed (bound) or unsealed (pre-binding). Same markers the
+ * balancing path in operations.ts uses, so what is summarized is exactly what
+ * will be balanced.
+ */
+export function decodeConnectorTransaction(txBytes: Uint8Array, sealed: boolean): AnyTransaction {
+  const Transaction = activeLedger().Transaction;
+  return sealed
+    ? Transaction.deserialize<ledger.SignatureEnabled, ledger.Proof, ledger.Binding>(
+        'signature',
+        'proof',
+        'binding',
+        txBytes
+      )
+    : Transaction.deserialize<ledger.SignatureEnabled, ledger.Proof, ledger.PreBinding>(
+        'signature',
+        'proof',
+        'pre-binding',
+        txBytes
+      );
+}
+
+/** Every segment id the transaction carries: the guaranteed section plus one per intent / fallible offer. */
+function segmentIds(tx: AnyTransaction): number[] {
+  const ids = new Set<number>([0]);
+  for (const id of tx.intents?.keys() ?? []) ids.add(id);
+  for (const id of tx.fallibleOffer?.keys() ?? []) ids.add(id);
+  return [...ids].sort((a, b) => a - b);
+}
+
+function tokenKey(type: ledger.TokenType): string {
+  return type.tag === 'dust' ? 'dust' : `${type.tag}:${type.raw}`;
+}
+
+function toTokenAmount(type: ledger.TokenType, amount: bigint): TxTokenAmount {
+  return type.tag === 'dust'
+    ? {kind: 'dust', tokenId: '', amount}
+    : {kind: type.tag, tokenId: type.raw, amount};
+}
+
+/**
+ * Sum the per-segment imbalances into what the wallet pays and what it gets
+ * back. Fees are not included: they are computed only once the wallet has
+ * balanced and proven its own segment, and they are always paid in DUST.
+ */
+export function summarizeTransaction(tx: AnyTransaction): TransactionSummary {
+  const totals = new Map<string, {type: ledger.TokenType; amount: bigint}>();
+  for (const segment of segmentIds(tx)) {
+    for (const [type, delta] of tx.imbalances(segment)) {
+      const key = tokenKey(type);
+      const entry = totals.get(key) ?? {type, amount: 0n};
+      entry.amount += delta;
+      totals.set(key, entry);
+    }
+  }
+
+  const spends: TxTokenAmount[] = [];
+  const receives: TxTokenAmount[] = [];
+  for (const {type, amount} of totals.values()) {
+    if (amount < 0n) spends.push(toTokenAmount(type, -amount));
+    else if (amount > 0n) receives.push(toTokenAmount(type, amount));
+  }
+
+  let contractActions = 0;
+  for (const intent of tx.intents?.values() ?? []) contractActions += intent.actions.length;
+
+  return {spends, receives, contractActions};
+}
+
+/** Decode + summarize in one step, for the connector's approval prompt. */
+export function summarizeConnectorTransaction(txBytes: Uint8Array, sealed: boolean): TransactionSummary {
+  return summarizeTransaction(decodeConnectorTransaction(txBytes, sealed));
+}

--- a/packages/core/src/sync/wallet-sync.ts
+++ b/packages/core/src/sync/wallet-sync.ts
@@ -241,6 +241,12 @@ export interface UnshieldedCoinInfo {
   value: bigint;
   type: string;
   registeredForDustGeneration: boolean;
+  /** When this UTXO was created, epoch ms — null if the SDK reported none.
+   *  Powers the "register promptly" guidance in dust registration UX: a
+   *  devnet defect (docs/bugs-found #15) has been triggered by registering
+   *  NIGHT that sat unregistered for minutes, never by registering within
+   *  seconds of it arriving. */
+  ctimeMs: number | null;
 }
 
 export interface DustCoinInfo {
@@ -970,6 +976,7 @@ function extractBalancesPartial(
         value: c.utxo?.value ?? 0n,
         type: c.utxo?.type ?? '',
         registeredForDustGeneration: c.meta?.registeredForDustGeneration === true,
+        ctimeMs: c.meta?.ctime ? c.meta.ctime.getTime() : null,
       });
     }
     for (const c of state.unshielded?.pendingCoins ?? []) {
@@ -979,6 +986,7 @@ function extractBalancesPartial(
         value,
         type,
         registeredForDustGeneration: c.meta?.registeredForDustGeneration === true,
+        ctimeMs: c.meta?.ctime ? c.meta.ctime.getTime() : null,
       });
       // Count booked inputs toward the displayed balance. A send or DUST
       // registration reserves its own NIGHT UTxOs (moved available→pending)

--- a/packages/core/src/sync/wallet-sync.ts
+++ b/packages/core/src/sync/wallet-sync.ts
@@ -1192,6 +1192,11 @@ export async function clearSyncCache(walletName: string, networkId: string, stor
   const resolved = await resolveSyncStore(store);
   await evictCachedState(resolved, walletName, networkId, 'shielded');
   await evictCachedState(resolved, walletName, networkId, 'unshielded');
+  // An ECDSA wallet keeps its unshielded cache under a second identity (see
+  // cacheIdentity). The caller does not know the wallet's kind, so evict both:
+  // deleting an absent key costs nothing, leaving a stale cache behind costs a
+  // "cleared" wallet that resumes from the state the user just asked to drop.
+  await evictCachedState(resolved, walletName, networkId, 'unshielded', 'ecdsa');
   await evictCachedState(resolved, walletName, networkId, 'dust');
   await evictCachedState(resolved, walletName, networkId, 'history');
 }

--- a/packages/core/tests/unit/sync/cache-reset.test.ts
+++ b/packages/core/tests/unit/sync/cache-reset.test.ts
@@ -1,0 +1,82 @@
+// A local network brought back up from genesis leaves every cached artefact
+// wrong: the account's sync state, and the network's pre-seed reference that
+// new syncs are seeded from. "Clear cache and resync" has to reach both, or the
+// resync restarts from a chain that no longer exists.
+
+import {beforeEach, describe, expect, it} from 'vitest';
+import {
+  InMemorySyncStateStore,
+  EMPTY_REF_WALLET,
+  cursorWitnessKey,
+  emptyRefHeightKey,
+  emptyRefMnemonicKey,
+  emptyRefStateKey,
+  syncStateKey,
+} from '../../../src/sync/sync-store.js';
+import {clearEmptyRefCache, preseedReferenceStatus} from '../../../src/sync/preseed.js';
+import {clearSyncCache} from '../../../src/sync/wallet-sync.js';
+import type {NetworkConfig} from '../../../src/types/network.js';
+
+const NETWORK = 'undeployed';
+const network = {id: NETWORK, nodeUrl: 'ws://localhost:9944', indexerUrl: 'http://localhost:8088'} as NetworkConfig;
+
+let store: InMemorySyncStateStore;
+
+beforeEach(() => {
+  store = new InMemorySyncStateStore();
+});
+
+describe('clearEmptyRefCache', () => {
+  it('removes every reference artefact for the network and leaves other networks alone', async () => {
+    for (const part of ['shielded', 'unshielded', 'dust'] as const) {
+      await store.put(emptyRefStateKey(NETWORK, part), 'state');
+      await store.put(cursorWitnessKey(NETWORK, EMPTY_REF_WALLET, part), '{"id":1}');
+      await store.put(emptyRefStateKey('preprod', part), 'state');
+    }
+    await store.put(emptyRefHeightKey(NETWORK), '4200');
+    await store.put(emptyRefMnemonicKey(NETWORK), 'word '.repeat(24).trim());
+    await store.put(emptyRefHeightKey('preprod'), '99');
+
+    await clearEmptyRefCache(NETWORK, store);
+
+    for (const part of ['shielded', 'unshielded', 'dust'] as const) {
+      expect(await store.get(emptyRefStateKey(NETWORK, part))).toBeNull();
+      expect(await store.get(cursorWitnessKey(NETWORK, EMPTY_REF_WALLET, part))).toBeNull();
+      expect(await store.get(emptyRefStateKey('preprod', part))).toBe('state');
+    }
+    expect(await store.get(emptyRefHeightKey(NETWORK))).toBeNull();
+    expect(await store.get(emptyRefMnemonicKey(NETWORK))).toBeNull();
+    expect(await store.get(emptyRefHeightKey('preprod'))).toBe('99');
+  });
+
+  it('leaves the network with no usable reference', async () => {
+    // A minimal reference the status check accepts: non-empty parts with a
+    // positive offset is checked by snapshotOffset, so use the status before and
+    // after only as "did the height survive" — the height alone gates usability.
+    await store.put(emptyRefHeightKey(NETWORK), '4200');
+    await clearEmptyRefCache(NETWORK, store);
+    expect(await preseedReferenceStatus(network, store)).toEqual({ready: false, height: null});
+  });
+
+  it('is a no-op on a network that never had a reference', async () => {
+    await expect(clearEmptyRefCache('never-seen', store)).resolves.toBeUndefined();
+  });
+});
+
+describe('clearSyncCache', () => {
+  it('evicts every part, including the ECDSA unshielded identity', async () => {
+    for (const part of ['shielded', 'unshielded', 'dust', 'history'] as const) {
+      await store.put(syncStateKey(NETWORK, 'alice', part), 'state');
+    }
+    await store.put(syncStateKey(NETWORK, 'alice#ecdsa', 'unshielded'), 'state');
+    await store.put(syncStateKey(NETWORK, 'bob', 'shielded'), 'state');
+
+    await clearSyncCache('alice', NETWORK, store);
+
+    for (const part of ['shielded', 'unshielded', 'dust', 'history'] as const) {
+      expect(await store.get(syncStateKey(NETWORK, 'alice', part))).toBeNull();
+    }
+    expect(await store.get(syncStateKey(NETWORK, 'alice#ecdsa', 'unshielded'))).toBeNull();
+    expect(await store.get(syncStateKey(NETWORK, 'bob', 'shielded'))).toBe('state');
+  });
+});

--- a/packages/core/tests/unit/sync/dust-ledger-health.test.ts
+++ b/packages/core/tests/unit/sync/dust-ledger-health.test.ts
@@ -1,0 +1,218 @@
+// The wedge-detection logic (docs/bugs-found.md-style report filed upstream):
+// InvalidDustSpendProof is one client-visible signature covering a transient
+// race, a ledger-version mismatch, and a permanently wedged devnet dust ledger.
+// These tests pin the two gates that separate "wedged" from "unlucky": a
+// streak of N independent rejections, AND blocks still being produced while
+// it happens.
+
+import {beforeEach, describe, expect, it} from 'vitest';
+import {
+  DEFAULT_WEDGE_THRESHOLD,
+  DustLedgerWedgedError,
+  DustSpendHealthTracker,
+  diagnoseSubmissionFailure,
+  isDustSpendProofRejection,
+  dustSpendHealthTracker,
+  resetDustSpendHealthTrackers,
+} from '../../../src/sync/dust-ledger-health.js';
+import {WalletError} from '../../../src/types/errors.js';
+
+const V8_PROTOCOL = 1_000_000;
+const V9_PROTOCOL = 2_000_000;
+const NETWORK = {id: 'undeployed', indexerUrl: 'http://indexer.example'};
+
+function proofRejection(): Error {
+  return new Error('1010: Invalid Transaction: Custom error: 170');
+}
+
+function probeAt(height: number, protocolVersion = V8_PROTOCOL) {
+  return async () => ({height, protocolVersion});
+}
+
+describe('isDustSpendProofRejection', () => {
+  it('matches the client-visible custom-error-170 string', () => {
+    expect(isDustSpendProofRejection(new Error('1010: Invalid Transaction: Custom error: 170'))).toBe(true);
+  });
+
+  it('matches the node-log spelling, case-insensitively', () => {
+    expect(isDustSpendProofRejection(new Error('Malformed(InvalidDustSpendProof)'))).toBe(true);
+  });
+
+  it('does not match an unrelated rejection', () => {
+    expect(isDustSpendProofRejection(new Error('1010: Invalid Transaction: Custom error: 231'))).toBe(false);
+    expect(isDustSpendProofRejection(new Error('socket hang up'))).toBe(false);
+  });
+});
+
+describe('DustSpendHealthTracker', () => {
+  it('counts a consecutive streak and resets it on success', () => {
+    const tracker = new DustSpendHealthTracker();
+    expect(tracker.recordProofRejection(10)).toBe(1);
+    expect(tracker.recordProofRejection(11)).toBe(2);
+    tracker.recordSuccess();
+    expect(tracker.consecutiveRejections).toBe(0);
+    expect(tracker.recordProofRejection(20)).toBe(1);
+  });
+
+  it('resets on an unrelated failure, not just on success', () => {
+    const tracker = new DustSpendHealthTracker();
+    tracker.recordProofRejection(10);
+    tracker.recordProofRejection(11);
+    tracker.recordUnrelatedFailure();
+    expect(tracker.consecutiveRejections).toBe(0);
+  });
+
+  it('reports blocksAdvancedSince relative to the height of the FIRST rejection in the streak, not the latest', () => {
+    const tracker = new DustSpendHealthTracker();
+    tracker.recordProofRejection(100);
+    tracker.recordProofRejection(100); // same height as attempt 1 — still no progress
+    expect(tracker.blocksAdvancedSince(100)).toBe(false);
+    expect(tracker.blocksAdvancedSince(101)).toBe(true);
+  });
+
+  it('reports no advancement before any rejection has been recorded', () => {
+    expect(new DustSpendHealthTracker().blocksAdvancedSince(999)).toBe(false);
+  });
+});
+
+describe('dustSpendHealthTracker registry', () => {
+  beforeEach(() => resetDustSpendHealthTrackers());
+
+  it('returns the same tracker for the same network+wallet key', () => {
+    expect(dustSpendHealthTracker('undeployed', 'alice')).toBe(dustSpendHealthTracker('undeployed', 'alice'));
+  });
+
+  it('keeps trackers for different wallets and networks independent', () => {
+    expect(dustSpendHealthTracker('undeployed', 'alice')).not.toBe(dustSpendHealthTracker('undeployed', 'bob'));
+    expect(dustSpendHealthTracker('undeployed', 'alice')).not.toBe(dustSpendHealthTracker('preprod', 'alice'));
+  });
+});
+
+describe('diagnoseSubmissionFailure', () => {
+  let tracker: DustSpendHealthTracker;
+
+  beforeEach(() => {
+    tracker = new DustSpendHealthTracker();
+  });
+
+  it('passes through an unrelated error untouched, without consuming the streak', async () => {
+    const err = new Error('Insufficient Funds');
+    const result = await diagnoseSubmissionFailure(tracker, err, {
+      network: NETWORK,
+      usingLedger: 'v8',
+      probeBlock: probeAt(10),
+    });
+    expect(result).toBe(err);
+    expect(tracker.consecutiveRejections).toBe(0);
+  });
+
+  it('never declares a wedge before the threshold, even with blocks advancing', async () => {
+    let height = 100;
+    for (let i = 0; i < DEFAULT_WEDGE_THRESHOLD - 1; i++) {
+      const result = await diagnoseSubmissionFailure(tracker, proofRejection(), {
+        network: NETWORK,
+        usingLedger: 'v8',
+        probeBlock: probeAt(height++),
+      });
+      expect(result).not.toBeInstanceOf(DustLedgerWedgedError);
+    }
+  });
+
+  it('declares a wedge once the threshold is met and blocks kept advancing', async () => {
+    let height = 100;
+    let result: Error | undefined;
+    for (let i = 0; i < DEFAULT_WEDGE_THRESHOLD; i++) {
+      result = await diagnoseSubmissionFailure(tracker, proofRejection(), {
+        network: NETWORK,
+        usingLedger: 'v8',
+        probeBlock: probeAt(height++),
+      });
+    }
+    expect(result).toBeInstanceOf(DustLedgerWedgedError);
+    expect((result as DustLedgerWedgedError).networkId).toBe('undeployed');
+    expect((result as DustLedgerWedgedError).consecutiveRejections).toBe(DEFAULT_WEDGE_THRESHOLD);
+    expect((result as DustLedgerWedgedError).message).toMatch(/reset/i);
+  });
+
+  it('does NOT declare a wedge if the chain height never moved — a stalled indexer looks identical from here', async () => {
+    let result: Error | undefined;
+    for (let i = 0; i < DEFAULT_WEDGE_THRESHOLD; i++) {
+      result = await diagnoseSubmissionFailure(tracker, proofRejection(), {
+        network: NETWORK,
+        usingLedger: 'v8',
+        probeBlock: probeAt(100), // same height every time
+      });
+    }
+    expect(result).not.toBeInstanceOf(DustLedgerWedgedError);
+  });
+
+  it('resets the streak on a genuine success in between, so a lone flaky attempt never wedges', async () => {
+    let height = 100;
+    for (let i = 0; i < DEFAULT_WEDGE_THRESHOLD - 1; i++) {
+      await diagnoseSubmissionFailure(tracker, proofRejection(), {
+        network: NETWORK,
+        usingLedger: 'v8',
+        probeBlock: probeAt(height++),
+      });
+    }
+    tracker.recordSuccess(); // the retry-with-a-fresh-timestamp that #6 documents succeeding
+    const result = await diagnoseSubmissionFailure(tracker, proofRejection(), {
+      network: NETWORK,
+      usingLedger: 'v8',
+      probeBlock: probeAt(height++),
+    });
+    expect(result).not.toBeInstanceOf(DustLedgerWedgedError);
+    expect(tracker.consecutiveRejections).toBe(1);
+  });
+
+  it('reports a ledger-version mismatch instead of counting toward a wedge — that condition is recoverable by reconnecting', async () => {
+    const result = await diagnoseSubmissionFailure(tracker, proofRejection(), {
+      network: NETWORK,
+      usingLedger: 'v8',
+      probeBlock: probeAt(100, V9_PROTOCOL), // network is actually on v9
+    });
+    expect(result).not.toBeInstanceOf(DustLedgerWedgedError);
+    expect(result).toBeInstanceOf(WalletError);
+    expect(result.message).toMatch(/ledger v9/i);
+    expect(tracker.consecutiveRejections).toBe(0);
+
+    // And it never accumulates toward a wedge verdict, however many times it repeats.
+    for (let i = 0; i < DEFAULT_WEDGE_THRESHOLD + 2; i++) {
+      const again = await diagnoseSubmissionFailure(tracker, proofRejection(), {
+        network: NETWORK,
+        usingLedger: 'v8',
+        probeBlock: probeAt(100 + i, V9_PROTOCOL),
+      });
+      expect(again).not.toBeInstanceOf(DustLedgerWedgedError);
+    }
+  });
+
+  it('treats an unreachable indexer as inconclusive rather than as a wedge', async () => {
+    let result: Error | undefined;
+    for (let i = 0; i < DEFAULT_WEDGE_THRESHOLD; i++) {
+      result = await diagnoseSubmissionFailure(tracker, proofRejection(), {
+        network: NETWORK,
+        usingLedger: 'v8',
+        probeBlock: async () => {
+          throw new Error('fetch failed');
+        },
+      });
+    }
+    expect(result).not.toBeInstanceOf(DustLedgerWedgedError);
+    expect(tracker.consecutiveRejections).toBe(0);
+  });
+
+  it('honors a caller-supplied threshold', async () => {
+    let height = 100;
+    let result: Error | undefined;
+    for (let i = 0; i < 2; i++) {
+      result = await diagnoseSubmissionFailure(tracker, proofRejection(), {
+        network: NETWORK,
+        usingLedger: 'v8',
+        threshold: 2,
+        probeBlock: probeAt(height++),
+      });
+    }
+    expect(result).toBeInstanceOf(DustLedgerWedgedError);
+  });
+});

--- a/packages/core/tests/unit/sync/tx-summary.test.ts
+++ b/packages/core/tests/unit/sync/tx-summary.test.ts
@@ -1,0 +1,112 @@
+// Pins the ledger's imbalance sign convention, which the approval screen turns
+// into "You pay" / "You get back". If a ledger release flipped it, the wallet
+// would tell the user they receive what they are about to spend.
+
+import {beforeAll, describe, expect, it} from 'vitest';
+import {
+  CostModel,
+  Intent,
+  Transaction,
+  UnshieldedOffer,
+  nativeToken,
+  sampleSigningKey,
+  signatureVerifyingKey,
+  type ProvingProvider,
+  type UtxoOutput,
+  type UtxoSpend,
+} from '@midnight-ntwrk/ledger-v8';
+import {initLedger} from '../../../src/ledger/index.js';
+import {
+  decodeConnectorTransaction,
+  summarizeConnectorTransaction,
+  summarizeTransaction,
+} from '../../../src/sync/tx-summary.js';
+
+const OWNER = 'be5eb2579464f606ed883d18831617302f484e6ce3602b0e2725801b653cd19d';
+const OTHER_TOKEN = 'ab'.repeat(32);
+
+// An input names its owner by verifying key, not by address, and the ledger
+// checks the key's shape when the offer is built.
+const nightInput = (value: bigint): UtxoSpend => ({
+  value,
+  owner: signatureVerifyingKey(sampleSigningKey()),
+  type: nativeToken().raw,
+  intentHash: '00'.repeat(32),
+  outputNo: 0,
+});
+
+// The fixtures carry no contract calls, so proving only advances the stage
+// marker; a provider that is ever consulted is a fixture bug.
+const noProofs: ProvingProvider = {
+  async check() {
+    throw new Error('unexpected proof check');
+  },
+  async prove() {
+    throw new Error('unexpected proving');
+  },
+};
+
+async function unsealedTx(inputs: UtxoSpend[], outputs: UtxoOutput[]): Promise<Uint8Array> {
+  const intent = Intent.new(new Date(Date.now() + 60_000));
+  intent.fallibleUnshieldedOffer = UnshieldedOffer.new(inputs, outputs, []);
+  const unproven = Transaction.fromParts('preprod', undefined, undefined, intent);
+  const unbound = await unproven.prove(noProofs, CostModel.initialCostModel());
+  return unbound.serialize();
+}
+
+beforeAll(async () => {
+  await initLedger('v8');
+});
+
+describe('summarizeConnectorTransaction', () => {
+  it('reports an output the dApp left unfunded as a spend from the wallet', async () => {
+    const bytes = await unsealedTx([], [{owner: OWNER, type: nativeToken().raw, value: 1_000_000n}]);
+
+    expect(summarizeConnectorTransaction(bytes, false)).toEqual({
+      spends: [{kind: 'unshielded', tokenId: nativeToken().raw, amount: 1_000_000n}],
+      receives: [],
+      contractActions: 0,
+    });
+  });
+
+  it('sums several outputs of one token and keeps distinct tokens apart', async () => {
+    const bytes = await unsealedTx(
+      [],
+      [
+        {owner: OWNER, type: nativeToken().raw, value: 250_000n},
+        {owner: OWNER, type: nativeToken().raw, value: 750_000n},
+        {owner: OWNER, type: OTHER_TOKEN, value: 7n},
+      ]
+    );
+
+    const summary = summarizeConnectorTransaction(bytes, false);
+    expect(summary.receives).toEqual([]);
+    expect(summary.spends).toHaveLength(2);
+    expect(summary.spends).toContainEqual({kind: 'unshielded', tokenId: nativeToken().raw, amount: 1_000_000n});
+    expect(summary.spends).toContainEqual({kind: 'unshielded', tokenId: OTHER_TOKEN, amount: 7n});
+  });
+
+  it('reports an input without a matching output as change back to the wallet', async () => {
+    const bytes = await unsealedTx([nightInput(3_000_000n)], [{owner: OWNER, type: nativeToken().raw, value: 1_000_000n}]);
+
+    expect(summarizeConnectorTransaction(bytes, false)).toEqual({
+      spends: [],
+      receives: [{kind: 'unshielded', tokenId: nativeToken().raw, amount: 2_000_000n}],
+      contractActions: 0,
+    });
+  });
+
+  it('reports nothing for a transaction that is already balanced', async () => {
+    const bytes = await unsealedTx([nightInput(1_000_000n)], [{owner: OWNER, type: nativeToken().raw, value: 1_000_000n}]);
+
+    expect(summarizeConnectorTransaction(bytes, false)).toEqual({spends: [], receives: [], contractActions: 0});
+  });
+
+  it('decodes with the markers the balancing path uses, so the summary matches what gets balanced', async () => {
+    const bytes = await unsealedTx([], [{owner: OWNER, type: nativeToken().raw, value: 1n}]);
+    const tx = decodeConnectorTransaction(bytes, false);
+    expect(summarizeTransaction(tx).spends).toEqual([{kind: 'unshielded', tokenId: nativeToken().raw, amount: 1n}]);
+    // A pre-binding transaction is not a bound one; asking for the wrong stage must fail loudly.
+    expect(() => decodeConnectorTransaction(bytes, true)).toThrow();
+  });
+});

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -82,6 +82,13 @@ the release tag manually.
 
 - **tsconfig deviation:** this package extends WXT's generated `.wxt/tsconfig.json` (path aliases, extension globals) instead of the repo's `tsconfig.base.json` — the base config's `rootDir`/`outDir`/`declaration` assumptions don't fit a Vite-bundled app. Run `yarn workspace @shieldedtech/moth-extension compile` for a typecheck.
 - Wallet keys live encrypted (ChaCha20-Poly1305) in IndexedDB via `@shieldedtech/moth-browser`; the unlocked seed is held only in `browser.storage.session` (memory-backed, cleared when the browser exits). Locking is explicit — lock button, account removal, network switch; there is no inactivity auto-lock for now (its timer used to kill a sync in progress).
+- **Settings → Network → Clear cache and resync** forgets everything synced for
+  the active account on its network — sync state, cached balances, pending
+  activity, and the network's pre-seed reference — and syncs again from genesis.
+  It is the recovery for a local devnet that was taken down and brought back up
+  as a new chain: every cached artefact then describes a chain that no longer
+  exists, and the sync engine cannot tell. Nothing is spent; on the new chain the
+  balance simply reflects what that chain holds.
 - The proving method selected under Settings → Network is used for wallet and
   dApp transactions. Local WASM proving is recommended for simple transactions,
   such as token transfers. Complex transactions, such as contract calls, require

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -88,3 +88,12 @@ the release tag manually.
   a proof server (default `http://localhost:6300`). WASM parameters and built-in
   keys are fetched on demand from the Midnight SDK's key source.
 - The dApp connector implements the [Midnight dApp connector API](https://docs.midnight.network/api-reference/dapp-connector) as `window.midnight.moth`, including a functional `getProvingProvider` backed by the wallet's selected proving method.
+- When a dApp asks the wallet to balance a transaction it built
+  (`balanceSealedTransaction` / `balanceUnsealedTransaction`), the approval
+  screen lists what the transaction takes from the wallet — every token and
+  amount the wallet has to supply, and any change it gets back — read from the
+  transaction's own per-segment imbalances (`Transaction.imbalances`) before
+  anything is spent. Fees are not in that list: they are only known once the
+  wallet has balanced and proven its segment, and are always paid in DUST. If
+  the transaction cannot be decoded, the screen says so instead of showing an
+  empty list.

--- a/packages/extension/components/screens/Approval.tsx
+++ b/packages/extension/components/screens/Approval.tsx
@@ -5,9 +5,12 @@ import { useEffect, useState } from 'react';
 import { Moon, TriangleAlert } from 'lucide-react';
 import { t } from '../../lib/i18n';
 import { sendMessage } from '../../lib/messaging/protocol';
+import { useTokenNames } from '../../lib/ui/client';
 import { accountLabel } from '../../lib/ui/format';
 import { nativeAssetLabelsForNetwork } from '../../lib/ui/token-labels';
+import { txSummaryRows } from '../../lib/ui/tx-summary-view';
 import type { PendingApproval } from '../../lib/background/approvals';
+import type { BalanceApprovalPayload } from '../../lib/background/connector-handlers';
 import { Button } from '../ui/button';
 import { Badge, Card, Separator } from '../ui/card';
 import { Input } from '../ui/input';
@@ -53,6 +56,7 @@ export function Approval({
 }) {
   const [approval, setApproval] = useState<PendingApproval | null>(null);
   const [missing, setMissing] = useState(false);
+  const { names: tokenNames } = useTokenNames();
   const shownName = walletName ? accountLabel(walletName, walletLabel) : null;
 
   useEffect(() => {
@@ -178,10 +182,24 @@ export function Approval({
               {t('approval_balanceSubtitle', [host])}
             </p>
           </div>
+          <BalanceSummary
+            payload={approval.payload as BalanceApprovalPayload}
+            host={host}
+            labels={labels}
+            tokenNames={tokenNames}
+          />
           <DetailCard
             rows={[
               { label: t('approval_fromLabel'), value: shownName ?? '—' },
               { label: t('approval_networkFeeLabel'), value: t('approval_paidIn', [labels.dust]) },
+              ...((approval.payload as BalanceApprovalPayload).summary?.contractActions
+                ? [
+                    {
+                      label: t('approval_contractCallsLabel'),
+                      value: String((approval.payload as BalanceApprovalPayload).summary?.contractActions),
+                    },
+                  ]
+                : []),
             ]}
           />
           <NoteCard icon={TriangleAlert}>
@@ -226,6 +244,61 @@ export function Approval({
 
       {locked && <ApprovalUnlock walletName={walletName} onUnlocked={onUnlocked} />}
     </PanelScreen>
+  );
+}
+
+/**
+ * What a dApp-built transaction takes from the wallet, token by token, before
+ * the user approves balancing it. The one thing this screen must never do is
+ * stay quiet: no summary means a visible warning, and a summary with nothing in
+ * it says so in words.
+ */
+function BalanceSummary({
+  payload,
+  host,
+  labels,
+  tokenNames,
+}: {
+  payload: BalanceApprovalPayload;
+  host: string;
+  labels: ReturnType<typeof nativeAssetLabelsForNetwork>;
+  tokenNames: Record<string, string>;
+}) {
+  if (!payload.summary) {
+    return (
+      <NoteCard icon={TriangleAlert}>
+        {t('approval_summaryUnavailable', [host])}
+      </NoteCard>
+    );
+  }
+  const rows = txSummaryRows(payload.summary, labels, tokenNames);
+  if (rows.length === 0) {
+    return (
+      <Card className="p-4">
+        <p className="m-0 text-[13.5px] text-muted-foreground">{t('approval_spendsNothing')}</p>
+      </Card>
+    );
+  }
+  return (
+    <Card className="p-0">
+      {rows.map((row, index) => (
+        <div key={`${row.direction}-${row.symbol}-${index}`}>
+          {index > 0 && <Separator />}
+          <div className="flex items-center gap-3 px-4 py-[15px]">
+            <TokenIcon kind={row.icon} />
+            <span className="flex-1">
+              <span className="block text-[12px] text-muted-foreground">
+                {row.direction === 'pay' ? t('approval_youPay') : t('approval_youGetBack')}
+              </span>
+              <span className="block text-[15px] font-bold">
+                {row.amount} {row.symbol}
+              </span>
+            </span>
+            {row.detail && <span className="font-mono text-xs text-muted-foreground">{row.detail}</span>}
+          </div>
+        </div>
+      ))}
+    </Card>
   );
 }
 

--- a/packages/extension/components/screens/DustDetail.tsx
+++ b/packages/extension/components/screens/DustDetail.tsx
@@ -9,7 +9,7 @@
 // the last, never the whole balance.
 
 import { useEffect, useRef, useState } from 'react';
-import { LoaderCircle, Moon } from 'lucide-react';
+import { LoaderCircle, Moon, TriangleAlert } from 'lucide-react';
 import { NIGHT_TOKEN_ID } from '@shieldedtech/moth-wallet/types/tokens';
 import {
   registerOutcome,
@@ -19,6 +19,7 @@ import {
 } from '../../lib/ui/dust-register-outcome';
 import { waitPhrase } from '../../lib/ui/wait-phrase';
 import type { DustNotYet, NightCoinRow } from '../../lib/messaging/protocol';
+import { isStaleUnregistered, oldestUnregisteredCoinAge } from '../../lib/ui/dust-register-timing';
 
 /** Why registration is not possible yet, in the user's language. A null wait
  *  means no amount of waiting helps — the holding's ceiling is below the fee. */
@@ -92,10 +93,30 @@ export function DustDetail({
   // Latches once the rebuild is requested: the sync restart it triggers takes
   // minutes, and re-requesting it would only start the rescan over.
   const [rebuilding, setRebuilding] = useState(false);
+  // Powers the "register promptly" warning below — fetched independently of
+  // the collapsible coin breakdown (NightCoinBreakdown), which only loads on
+  // demand, so the warning is available the moment the register button is
+  // pressed even if the breakdown was never opened.
+  const [coinRows, setCoinRows] = useState<NightCoinRow[] | null>(null);
   const dustSynced = useSyncRegressionGrace(
     balances?.syncProgress.dustSynced ?? false,
     balances !== null,
   );
+
+  useEffect(() => {
+    if (!dustSynced) return;
+    let live = true;
+    void sendMessage('dustNightCoins', undefined)
+      .then((rows) => {
+        if (live) setCoinRows(rows);
+      })
+      .catch(() => {
+        /* the warning just stays silent — nothing was spent, nothing to recover */
+      });
+    return () => {
+      live = false;
+    };
+  }, [dustSynced]);
 
   if (!balances) {
     return (
@@ -203,6 +224,8 @@ export function DustDetail({
     setReceiver(ownDustAddress);
     setConfirm('register');
   };
+
+  const staleRegistration = isStaleUnregistered(oldestUnregisteredCoinAge(coinRows ?? []));
 
   return (
     <PanelScreen
@@ -316,6 +339,11 @@ export function DustDetail({
           <p className="m-0">
             {t('dust_generateBodyReceiver', [labels.night, labels.dust])}
           </p>
+          {staleRegistration && (
+            <NoteCard variant="error" icon={TriangleAlert}>
+              {t('dust_staleRegisterWarning', [labels.night])}
+            </NoteCard>
+          )}
           <label className="flex flex-col gap-1.5">
             <span className="text-[12px] font-semibold uppercase tracking-wide">{t('dust_addressLabel', [labels.dust])}</span>
             <AddressPicker

--- a/packages/extension/components/screens/Settings.tsx
+++ b/packages/extension/components/screens/Settings.tsx
@@ -298,7 +298,7 @@ export function Settings({ onBack, navigate }: { onBack: () => void; navigate: (
           <span className="min-w-0 pr-3">
             <span className="block text-sm font-medium">{t('settings_resync')}</span>
             <span className="block text-[12.5px] text-muted-foreground">
-              {t('settings_resyncDescription', [networkLabel(settings.network)])}
+              {t('settings_resyncDescription')}
             </span>
           </span>
           <Button size="sm" variant="secondary" className="shrink-0" onClick={() => setConfirmingResync(true)}>

--- a/packages/extension/components/screens/Settings.tsx
+++ b/packages/extension/components/screens/Settings.tsx
@@ -15,6 +15,7 @@ import { cn } from '../../lib/ui/cn';
 import { Card, Separator } from '../ui/card';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
+import { DialogShell } from '../ui/dialog';
 import { PanelScreen, PanelHeader } from '../moth/panel';
 import { networkLabel } from './NetworkConfig';
 import { preseedControl } from '../../lib/ui/preseed-control';
@@ -57,6 +58,27 @@ export function Settings({ onBack, navigate }: { onBack: () => void; navigate: (
   const [resolverDraft, setResolverDraft] = useState('');
   const [appearance, setAppearance] = useState<Appearance>(() => loadAppearance());
   const [copiedDiagnostics, setCopiedDiagnostics] = useState(false);
+  // "Clear cache and resync": confirm first, because it discards an hour of
+  // sync on a slow network even though it moves no funds.
+  const [confirmingResync, setConfirmingResync] = useState(false);
+  const [resyncing, setResyncing] = useState(false);
+  const [resyncError, setResyncError] = useState<string | null>(null);
+
+  const resync = async () => {
+    setResyncing(true);
+    setResyncError(null);
+    try {
+      await sendMessage('resyncFromScratch', undefined);
+      setConfirmingResync(false);
+      // The background dropped the snapshot, so the router shows the loading
+      // screen for the fresh sync as soon as we leave Settings.
+      navigate('home');
+    } catch {
+      setResyncError(t('settings_resyncError'));
+    } finally {
+      setResyncing(false);
+    }
+  };
 
   const updateAppearance = (patch: Partial<Appearance>) => {
     const next = { ...appearance, ...patch };
@@ -274,6 +296,17 @@ export function Settings({ onBack, navigate }: { onBack: () => void; navigate: (
         )}
         <div className="flex items-center justify-between px-4 py-[13px]">
           <span className="min-w-0 pr-3">
+            <span className="block text-sm font-medium">{t('settings_resync')}</span>
+            <span className="block text-[12.5px] text-muted-foreground">
+              {t('settings_resyncDescription', [networkLabel(settings.network)])}
+            </span>
+          </span>
+          <Button size="sm" variant="secondary" className="shrink-0" onClick={() => setConfirmingResync(true)}>
+            {t('settings_resyncButton')}
+          </Button>
+        </div>
+        <div className="flex items-center justify-between px-4 py-[13px]">
+          <span className="min-w-0 pr-3">
             <span className="block text-sm font-medium">{t('settings_developerMode')}</span>
             <span className="block text-[12.5px] text-muted-foreground">
               {t('settings_developerModeDescription')}
@@ -401,6 +434,31 @@ export function Settings({ onBack, navigate }: { onBack: () => void; navigate: (
       <p className="m-0 pb-2 text-center text-xs text-muted-foreground">
         {t('settings_version', [browser.runtime.getManifest().version])}
       </p>
+
+      <DialogShell
+        open={confirmingResync}
+        onOpenChange={(open) => {
+          if (!resyncing) setConfirmingResync(open);
+        }}
+        title={t('settings_resyncTitle')}
+        actions={
+          <>
+            <Button variant="outline" disabled={resyncing} onClick={() => setConfirmingResync(false)}>
+              {t('common_cancel')}
+            </Button>
+            <Button loading={resyncing} onClick={() => void resync()}>
+              {resyncing ? t('settings_resyncWorking') : t('settings_resyncConfirm')}
+            </Button>
+          </>
+        }
+      >
+        <p className="m-0">{t('settings_resyncBody', [networkLabel(settings.network)])}</p>
+        {resyncError && (
+          <p className="mb-0 mt-3 text-destructive" role="alert">
+            {resyncError}
+          </p>
+        )}
+      </DialogShell>
     </PanelScreen>
   );
 }

--- a/packages/extension/entrypoints/sidepanel/App.tsx
+++ b/packages/extension/entrypoints/sidepanel/App.tsx
@@ -2,8 +2,17 @@
 // dApp approvals take over the panel while pending.
 
 import { useEffect, useRef, useState } from 'react';
-import { Toaster } from 'sonner';
-import { useSession, useWallets, usePanelEvents, useSelectedProverType, useSlowSync } from '../../lib/ui/client';
+import { Toaster, toast } from 'sonner';
+import {
+  useSession,
+  useWallets,
+  usePanelEvents,
+  useSelectedProverType,
+  useSlowSync,
+  useRegisterNudge,
+} from '../../lib/ui/client';
+import { t } from '../../lib/i18n';
+import { nativeAssetLabelsForNetwork } from '../../lib/ui/token-labels';
 import { accountLabel } from '../../lib/ui/format';
 import type { Screen } from '../../components/screens/navigation';
 import { GetStarted, openSetupTab } from '../../components/screens/GetStarted';
@@ -28,6 +37,15 @@ export function App() {
   const events = usePanelEvents();
   const prover = useSelectedProverType(session.status?.network);
   const slowSync = useSlowSync(!events.balances);
+  // Suggest registering for DUST the moment this wallet first shows
+  // unregistered NIGHT, rather than waiting for the user to find the Dust
+  // screen on their own — see dust-nudge.ts.
+  const registerNudgeDue = useRegisterNudge(events.balances);
+  useEffect(() => {
+    if (!registerNudgeDue) return;
+    const labels = nativeAssetLabelsForNetwork(session.status?.network ?? '');
+    toast(t('dust_receiveRegisterNudge', [labels.night, labels.dust]));
+  }, [registerNudgeDue, session.status?.network]);
   const [screen, setScreen] = useState<Screen>('home');
   // Set when the user asks to switch accounts: the target's storage name. The
   // current session stays alive and syncing until this unlock succeeds, so

--- a/packages/extension/lib/background/connector-handlers.ts
+++ b/packages/extension/lib/background/connector-handlers.ts
@@ -13,7 +13,7 @@ import { onMessage, deserializeBalances } from '../messaging/protocol';
 import { encodeBigintJson, decodeBigintJson } from '../messaging/bigint-json';
 import { connectorError, serializeError, type ErrorCode } from '../connector/errors';
 import { NOT_IMPLEMENTED_METHODS, type ConnectorMethod } from '../connector/constants';
-import type { TransferRequestDTO, SwapInputDTO, ProvingKeyMaterialDTO } from '../offscreen/messaging';
+import type { TransferRequestDTO, SwapInputDTO, ProvingKeyMaterialDTO, TxSummaryDTO } from '../offscreen/messaging';
 import { getSettings, getNetworkConfig } from './settings';
 import { getSession, type Session } from './session';
 import { isAllowed, grant, revoke, listAll } from './permissions';
@@ -146,8 +146,16 @@ function addressFor(session: Session, role: keyof Session['addresses'], networkI
   return encoded[networkId] ?? Object.values(encoded)[0] ?? '';
 }
 
+/** Display data for a `balance` approval. `summary` is null when the transaction
+ *  could not be read; the screen then says so instead of showing nothing. */
+export interface BalanceApprovalPayload {
+  sealed: boolean;
+  summary: TxSummaryDTO | null;
+}
+
 // Shared by balanceSealedTransaction / balanceUnsealedTransaction: validate the
-// tx hex, prompt for approval (balancing spends wallet funds to cover fees and
+// tx hex, read what the transaction takes from the wallet, prompt for approval
+// with that in view (balancing spends wallet funds to cover fees and
 // imbalances), then balance + prove in the offscreen host. `sealed` selects the
 // input binding stage.
 async function balance(
@@ -163,10 +171,22 @@ async function balance(
   if (options.payFees === false) {
     throw connectorError('InvalidRequest', 'Moth always pays fees; payFees: false is unsupported');
   }
-  const approved = await requestApproval('balance', origin, { sealed }, senderTabId, preparedPanel);
+  const network = await getNetworkConfig();
+  // The user is about to authorize spending, so the approval must say what
+  // leaves the wallet. A summary that cannot be produced (a stage the ledger
+  // won't decode, a ledger mismatch) is not a reason to hide the request: the
+  // screen states plainly that the amounts are unknown, and balancing itself
+  // will surface the underlying error if the user goes ahead.
+  let summary: TxSummaryDTO | null = null;
+  try {
+    summary = await offscreen.txSummary({ network, txHex: tx, sealed });
+  } catch {
+    summary = null;
+  }
+  const payload: BalanceApprovalPayload = { sealed, summary };
+  const approved = await requestApproval('balance', origin, payload, senderTabId, preparedPanel);
   if (!approved) throw connectorError('Rejected', 'User rejected the transaction');
 
-  const network = await getNetworkConfig();
   const { txHex } = await offscreen.balanceTransaction({
     seedHex: session.seedHex,
     walletName: session.walletName,

--- a/packages/extension/lib/background/handlers.ts
+++ b/packages/extension/lib/background/handlers.ts
@@ -220,6 +220,40 @@ export async function saveNetworkConfig(data: {
 }
 
 /**
+ * Drop everything cached for the unlocked account on its network and sync again
+ * from genesis. The recovery for a local devnet that went down and came back as
+ * a new chain: the cached sync state, pending submissions and the network's
+ * pre-seed reference all describe the old chain, and the engine has no way to
+ * notice on its own beyond failing in ways that name none of this.
+ *
+ * Same shape as the indexer-change branch of saveNetworkConfig — stop, clear,
+ * drop the snapshot so the panel shows the loading screen, restart — and, like
+ * it, bracketed as one op so idle teardown cannot close the offscreen document
+ * between the clear and the restart. Nothing is spent and nothing on chain
+ * changes.
+ */
+export async function resyncFromScratch(): Promise<void> {
+  const session = await getSession();
+  if (!session) throw new Error('Wallet is locked');
+  const network = await getNetworkConfig();
+
+  beginOp();
+  try {
+    await stopSync();
+    try {
+      await offscreen.syncCacheReset({ walletName: session.walletName, network });
+      await clearSnapshot();
+    } finally {
+      // Whether the clear succeeded or not, the engine must come back: a wallet
+      // left stopped looks exactly like a wallet that is stuck.
+      void startSync(session, network).catch(broadcastSyncFailure);
+    }
+  } finally {
+    endOp();
+  }
+}
+
+/**
  * Close the transaction timeline.
  *
  * `tx: submitting` is emitted before submitWithRetry, and nothing was recorded
@@ -548,6 +582,8 @@ export function registerHandlers(): void {
       return null;
     }
   });
+
+  onMessage('resyncFromScratch', () => resyncFromScratch());
 
   // Spends nothing, but brackets the op anyway: it stops and restarts the sync
   // engine, and the service worker must not suspend underneath that.

--- a/packages/extension/lib/background/offscreen-client.ts
+++ b/packages/extension/lib/background/offscreen-client.ts
@@ -267,6 +267,10 @@ export const offscreen = {
     });
     return decodeBigintJson<Uint8Array>(resultJson);
   },
+  async txSummary(data: { network: NetworkConfig; txHex: string; sealed: boolean }) {
+    await ensureOffscreen();
+    return offscreenSend('os/txSummary', data);
+  },
   async balanceTransaction(data: SyncTarget & { txHex: string; sealed: boolean }) {
     await ensureOffscreen();
     return offscreenSend('os/balanceTransaction', data);

--- a/packages/extension/lib/background/offscreen-client.ts
+++ b/packages/extension/lib/background/offscreen-client.ts
@@ -160,6 +160,10 @@ export const offscreen = {
     await ensureOffscreen();
     return offscreenSend('os/syncCacheClear', data);
   },
+  async syncCacheReset(data: { walletName: string; network: NetworkConfig }) {
+    await ensureOffscreen();
+    return offscreenSend('os/syncCacheReset', data);
+  },
   async balancesGet(data: SyncTarget) {
     await ensureOffscreen();
     return offscreenSend('os/balancesGet', data);

--- a/packages/extension/lib/i18n/messages/approval.ts
+++ b/packages/extension/lib/i18n/messages/approval.ts
@@ -30,6 +30,12 @@ export const approval = {
   approval_paidIn: 'Paid in $1',
   approval_balanceNote:
     'Your wallet may add its own funds to balance this transaction. Only approve transactions from sites you trust.',
+  approval_youPay: 'You pay',
+  approval_youGetBack: 'You get back',
+  approval_contractCallsLabel: 'Contract calls',
+  approval_spendsNothing: 'This transaction takes nothing from your wallet apart from the network fee.',
+  approval_summaryUnavailable:
+    'Moth could not read what this transaction spends. Approve it only if you trust $1 and know what it does.',
   approval_transferSubtitle: 'Nothing moves until you approve.',
   approval_youSend: 'You send',
   approval_usingLabel: 'Using',

--- a/packages/extension/lib/i18n/messages/dust.ts
+++ b/packages/extension/lib/i18n/messages/dust.ts
@@ -34,6 +34,9 @@ export const dust = {
   dust_generateBody: 'This registers your $1 so it starts generating $2. Any $1 you receive later registers automatically.',
   dust_generateBodyReceiver:
     'This registers your unregistered $1 so it starts generating $2. You can do this again whenever you receive more $1.',
+  dust_receiveRegisterNudge: 'Received $1 — register it now so it starts generating $2 right away.',
+  dust_staleRegisterWarning:
+    "Some of this $1 has been sitting unregistered for a while. On some networks, registering $1 long after receiving it — rather than right away — has been linked to a rare, serious network fault with no fix but a network reset. It's safest to register $1 as soon as it arrives.",
   dust_deregisterBody:
     "This deregisters your $1 from $2 generation. The $2 you have stays and still pays fees, but it won't refill. You can register again anytime.",
   dust_addressLabel: '$1 address',

--- a/packages/extension/lib/i18n/messages/settings.ts
+++ b/packages/extension/lib/i18n/messages/settings.ts
@@ -29,6 +29,16 @@ export const settings = {
   settings_preseedWarmingDescriptionOn:
     'Preparing $1 in the background. It takes about an hour and continues whenever the wallet is open. Accounts created after it finishes start in seconds.',
   settings_networkConfig: 'Network config',
+  settings_resync: 'Clear cache and resync',
+  settings_resyncDescription:
+    'Forget everything synced for this account on $1 and scan the chain again from the start. Use it after a local network was reset.',
+  settings_resyncButton: 'Clear',
+  settings_resyncTitle: 'Clear cache and resync?',
+  settings_resyncBody:
+    'Moth deletes this account\u2019s synced state, cached balances, pending activity and the prepared reference for $1, then syncs from the beginning of the chain. Nothing on chain changes and your funds stay where they are. On a network that was reset, the balance will reflect the new chain.',
+  settings_resyncConfirm: 'Clear & resync',
+  settings_resyncWorking: 'Clearing\u2026',
+  settings_resyncError: 'Could not clear the cache. Try again.',
   settings_sectionSecurity: 'Security',
   settings_autoLock: 'Auto-lock',
   settings_autoLockDemo: 'The wallet never locks itself on its own.',

--- a/packages/extension/lib/i18n/messages/settings.ts
+++ b/packages/extension/lib/i18n/messages/settings.ts
@@ -31,7 +31,7 @@ export const settings = {
   settings_networkConfig: 'Network config',
   settings_resync: 'Clear cache and resync',
   settings_resyncDescription:
-    'Forget everything synced for this account on $1 and scan the chain again from the start. Use it after a local network was reset.',
+    'Forget everything synced for this account on the current chain and scan the chain again from the start.',
   settings_resyncButton: 'Clear',
   settings_resyncTitle: 'Clear cache and resync?',
   settings_resyncBody:

--- a/packages/extension/lib/messaging/protocol.ts
+++ b/packages/extension/lib/messaging/protocol.ts
@@ -297,6 +297,13 @@ interface ProtocolMap {
    *  stream over the port. */
   deregisterDust(): { txHash: string };
 
+  /** Forget everything synced for the unlocked account on its network — sync
+   *  state, cached balances, pending activity, and the network's prepared
+   *  reference — and sync again from the start of the chain. For a local
+   *  network that was brought back up from genesis, where the cached state
+   *  describes a chain that no longer exists. Spends nothing. */
+  resyncFromScratch(): void;
+
   /** Rebuild the local DUST view: evict the dust sync cache and rescan. Spends
    *  nothing. `started` is false when a transaction was in flight. */
 

--- a/packages/extension/lib/messaging/protocol.ts
+++ b/packages/extension/lib/messaging/protocol.ts
@@ -205,6 +205,11 @@ export interface NightCoinRow {
    *  count toward the displayed balance but cannot be registered, which is how a
    *  wallet shows 500 NIGHT and still reports nothing to register. */
   booked: boolean;
+  /** When this UTXO arrived, epoch ms — null if unknown. Powers the "register
+   *  promptly" warning: a devnet defect (docs/bugs-found #15) has so far only
+   *  ever been triggered by registering NIGHT that sat unregistered for
+   *  minutes, never by registering within seconds of it arriving. */
+  ctimeMs: number | null;
 }
 
 interface ProtocolMap {

--- a/packages/extension/lib/offscreen/host-dispatch.ts
+++ b/packages/extension/lib/offscreen/host-dispatch.ts
@@ -41,6 +41,7 @@ export const hostDispatch: Dispatch = {
   },
   'os/syncStop': (host) => host.syncStop(),
   'os/syncCacheClear': (host, d) => host.syncCacheClear(d.walletName, d.networkIds),
+  'os/syncCacheReset': (host, d) => host.syncCacheReset(d.walletName, d.network),
   'os/balancesGet': (host, d) => host.balancesGet(d.seedHex, d.walletName, d.network),
   'os/sendTokens': (host, d) => host.sendTokens(d.seedHex, d.walletName, d.network, d.requests),
   'os/estimateTransferFee': (host, d) =>

--- a/packages/extension/lib/offscreen/host-dispatch.ts
+++ b/packages/extension/lib/offscreen/host-dispatch.ts
@@ -83,6 +83,7 @@ export const hostDispatch: Dispatch = {
   },
   'os/balanceTransaction': (host, d) =>
     host.balanceTransaction(d.seedHex, d.walletName, d.network, d.txHex, d.sealed),
+  'os/txSummary': (host, d) => host.txSummary(d.network, d.txHex, d.sealed),
   'os/makeIntent': (host, d) =>
     host.makeIntent(d.seedHex, d.walletName, d.network, d.inputs, d.outputs, d.payFees),
 };

--- a/packages/extension/lib/offscreen/messaging.ts
+++ b/packages/extension/lib/offscreen/messaging.ts
@@ -35,6 +35,30 @@ export interface SwapInputDTO {
   amount: string;
 }
 
+/** One token amount a dApp transaction moves in or out of the wallet; amount as a decimal string. */
+export interface TxTokenAmountDTO {
+  kind: 'shielded' | 'unshielded' | 'dust';
+  /** Raw token type hex; empty for DUST. */
+  tokenId: string;
+  /** Always positive; direction is the list it sits in. */
+  amount: string;
+}
+
+/**
+ * What balancing a dApp-supplied transaction costs the wallet, read off the
+ * transaction before the user approves it (core sync/tx-summary.ts). Fees are
+ * not part of it — they are only known once the wallet has balanced and proven
+ * its own segment, and are always paid in DUST.
+ */
+export interface TxSummaryDTO {
+  /** What the wallet must supply — the tokens that leave it. */
+  spends: TxTokenAmountDTO[];
+  /** Surplus the wallet collects back as change. */
+  receives: TxTokenAmountDTO[];
+  /** Contract calls, deploys and maintenance updates in the transaction. */
+  contractActions: number;
+}
+
 /** Contract circuit material supplied by a connected dApp for one proof call. */
 export interface ProvingKeyMaterialDTO {
   zkir: Uint8Array;
@@ -217,6 +241,12 @@ export interface OffscreenProtocol {
     txHex: string;
     sealed: boolean;
   }): { txHex: string };
+
+  /** Read what a dApp-supplied transaction would take from (and return to) the
+   *  wallet once balanced, for the approval prompt. Needs the network's ledger
+   *  loaded but no keys and no sync. `sealed` selects the deserialization stage,
+   *  exactly as os/balanceTransaction does. */
+  'os/txSummary'(data: { network: NetworkConfig; txHex: string; sealed: boolean }): TxSummaryDTO;
 
   /** Build a swap intent (`makeIntent`); returns the unproven, unbound tx hex. */
   'os/makeIntent'(data: {

--- a/packages/extension/lib/offscreen/messaging.ts
+++ b/packages/extension/lib/offscreen/messaging.ts
@@ -149,6 +149,12 @@ export interface OffscreenProtocol {
   'os/syncStop'(): void;
   /** Clear persisted sync state after the running engine has stopped. */
   'os/syncCacheClear'(data: { walletName: string; networkIds: string[] }): void;
+  /** Forget everything cached for this account on this network and start over:
+   *  the account's sync state (every part, every identity), its pending
+   *  submissions, and the network's pre-seed reference — store and in-process
+   *  memo. For a local chain restarted from genesis, where all of it describes a
+   *  chain that no longer exists. Stops the engine first; the caller restarts it. */
+  'os/syncCacheReset'(data: { walletName: string; network: NetworkConfig }): void;
 
   /** Ensure sync, wait for a synced snapshot, and return serialized balances. */
   'os/balancesGet'(data: { seedHex: string; walletName: string; network: NetworkConfig }): string;

--- a/packages/extension/lib/offscreen/wallet-host.ts
+++ b/packages/extension/lib/offscreen/wallet-host.ts
@@ -23,6 +23,7 @@ import {
   deriveWalletKeys,
   clearSyncCache,
   clearDustSyncCache,
+  clearEmptyRefCache,
   warmEmptyRefCache,
   preseedReferenceStatus,
   DustRegistrationNotYetError,
@@ -505,6 +506,19 @@ export async function syncCacheClear(walletName: string, networkIds: string[]): 
     // not revive pending rows for a chain state the user explicitly cleared.
     await store.delete(submissionsKey(networkId, walletName)).catch(() => {});
   }
+}
+
+// Everything syncCacheClear drops, plus what it deliberately leaves alone: the
+// network's pre-seed reference. A wallet-scoped clear keeps the reference because
+// it is still right for the chain — but when a local chain came back from
+// genesis, the reference describes the old chain and every fresh sync would be
+// seeded from it. The DUST-heal stamp goes too, so the rebuild heuristic starts
+// from a clean slate on the new chain.
+export async function syncCacheReset(walletName: string, network: NetworkConfig): Promise<void> {
+  await syncCacheClear(walletName, [network.id]);
+  const store = new IdbSyncStateStore();
+  await clearEmptyRefCache(network.id, store);
+  await store.delete(dustHealKey(network.id, walletName)).catch(() => {});
 }
 
 export async function balancesGet(

--- a/packages/extension/lib/offscreen/wallet-host.ts
+++ b/packages/extension/lib/offscreen/wallet-host.ts
@@ -14,6 +14,7 @@ import {
   buildTransferTransaction,
   estimateTransferFee as coreEstimateTransferFee,
   balanceTransaction as coreBalanceTransaction,
+  summarizeConnectorTransaction,
   buildSwapIntent,
   designateForDust as coreDesignateForDust,
   dedesignateFromDust as coreDedesignateFromDust,
@@ -66,6 +67,7 @@ import type {
   SwapInputDTO,
   UnlockedWallet,
   ProvingKeyMaterialDTO,
+  TxSummaryDTO,
 } from './messaging';
 import type { DustNotYet } from '../messaging/protocol';
 import type { HostEvent, HostEventData } from './worker-rpc';
@@ -720,6 +722,18 @@ export async function transferBuild(
     );
     return { txHex: toHex(finalized.serialize()) };
   });
+}
+
+// What balancing a dApp-supplied transaction would take from the wallet, for the
+// approval prompt that precedes balanceTransaction below. Reads the transaction's
+// own per-segment imbalances, so it needs the ledger loaded but neither keys nor
+// a synced wallet, and never books or spends anything.
+export async function txSummary(network: NetworkConfig, txHex: string, sealed: boolean): Promise<TxSummaryDTO> {
+  await initSdk((await detectLedgerVersion(network)).version);
+  const summary = summarizeConnectorTransaction(fromHex(txHex), sealed);
+  const dto = (entries: typeof summary.spends) =>
+    entries.map((entry) => ({ kind: entry.kind, tokenId: entry.tokenId, amount: entry.amount.toString() }));
+  return { spends: dto(summary.spends), receives: dto(summary.receives), contractActions: summary.contractActions };
 }
 
 // Balance a dApp-supplied transaction (connector balance*Transaction). Needs a

--- a/packages/extension/lib/offscreen/wallet-host.ts
+++ b/packages/extension/lib/offscreen/wallet-host.ts
@@ -45,6 +45,10 @@ import {
   type SignEncoding,
   type SignedMessage,
   ledger as activeLedger,
+  activeLedgerVersion,
+  submitWithHealthTracking,
+  dustSpendHealthTracker,
+  diagnoseSubmissionFailure,
 } from '@shieldedtech/moth-browser';
 import { deriveAllAddressesFromSeed } from '@shieldedtech/moth-wallet/wallet/address';
 import type * as ledger from '@midnight-ntwrk/ledger-v8';
@@ -548,10 +552,18 @@ export async function nightCoins(
   const wallet = await syncEnsure(seedHex, walletName, network);
   const balances = await waitForSyncedBalances(wallet, SYNC_WAIT_MS);
   const rows: NightCoinRow[] = [];
-  const push = (list: readonly { value: bigint; type: string; registeredForDustGeneration?: boolean }[], booked: boolean) => {
+  const push = (
+    list: readonly { value: bigint; type: string; registeredForDustGeneration?: boolean; ctimeMs?: number | null }[],
+    booked: boolean,
+  ) => {
     for (const c of list) {
       if (c.type !== NIGHT_TOKEN_ID) continue;
-      rows.push({ valueStars: c.value.toString(), registered: c.registeredForDustGeneration === true, booked });
+      rows.push({
+        valueStars: c.value.toString(),
+        registered: c.registeredForDustGeneration === true,
+        booked,
+        ctimeMs: c.ctimeMs ?? null,
+      });
     }
   };
   push(balances.coins.unshielded.available, false);
@@ -576,6 +588,22 @@ function enqueueTransferOperation<T>(operation: () => Promise<T>): Promise<T> {
     () => undefined,
   );
   return run;
+}
+
+// Every fee-paying submission funnels through here (or through the inline
+// try/catch in registerDust, which needs to special-case a preflight bail-out
+// that never reaches the node). A run of InvalidDustSpendProof rejections
+// covers three unrelated conditions — a transient race, a wallet/node ledger
+// mismatch, and a wedged devnet dust ledger that only a chain reset clears —
+// and none of them can be told apart from one rejection alone. See
+// core/sync/dust-ledger-health.ts and the upstream report it exists to back:
+// docs/bugs-found.md-style evidence of a devnet whose dust state stops
+// reconciling with any wallet's, permanently, while blocks keep being
+// produced. A success clears the streak; only a persistent run, with the
+// chain still advancing and this wallet's ledger confirmed correct, is
+// surfaced as DustLedgerWedgedError instead of the raw rejection.
+function submitTracked<T>(network: NetworkConfig, walletName: string, submit: () => Promise<T>): Promise<T> {
+  return submitWithHealthTracking(submit, {network, walletName, usingLedger: activeLedgerVersion()});
 }
 
 // Best effort: a bookkeeping failure must never turn a submitted transaction
@@ -605,7 +633,7 @@ export function sendTokens(
       (stage) => emit('os/eventTxStage', stage),
     );
     emit('os/eventTxStage', 'submitting');
-    const txHash = await submitFinalizedTransaction(wallet.facade, finalized);
+    const txHash = await submitTracked(network, walletName, () => submitFinalizedTransaction(wallet.facade, finalized));
     // The activity feed's pending row is single-output. Record the rich detail
     // only for a lone output; a batch records a plain pending send (the applied
     // chain entry supplies every delta once it lands).
@@ -669,10 +697,14 @@ export async function registerDust(
         dustAddress,
         (stage) => emit('os/eventTxStage', stage),
       );
+      dustSpendHealthTracker(network.id, walletName).recordSuccess();
     } catch (e) {
       // Returned rather than rethrown: the panel needs the figures to render a
       // localized wait, and an Error crossing this channel arrives as a bare
-      // string. Everything else still throws and surfaces as a failure.
+      // string. Everything else still throws and surfaces as a failure. A
+      // DustRegistrationNotYetError never reached the node — it is a
+      // preflight bail-out — so it must not count toward (or reset) the
+      // wedge-detection streak either way; only skip it below.
       if (e instanceof DustRegistrationNotYetError) {
         return {
           txHash: null,
@@ -683,7 +715,10 @@ export async function registerDust(
           },
         };
       }
-      throw e;
+      const usingLedger = activeLedgerVersion();
+      throw usingLedger
+        ? await diagnoseSubmissionFailure(dustSpendHealthTracker(network.id, walletName), e, {network, usingLedger})
+        : e;
     }
     if (txHash) {
       await noteSubmitted(network.id, walletName, { hash: txHash, submittedAt: Date.now(), kind: 'dust' });
@@ -705,12 +740,13 @@ export async function deregisterDust(
   return trackOp(async () => {
     await ensureProver(network);
     const wallet = await syncEnsure(seedHex, walletName, network);
-    const txHash = await coreDedesignateFromDust(
-      wallet.facade,
-      seedHex,
-      network.id,
-      (stage) => emit('os/eventTxStage', stage),
-    );
+    const txHash = await submitTracked(network, walletName, () =>
+      coreDedesignateFromDust(
+        wallet.facade,
+        seedHex,
+        network.id,
+        (stage) => emit('os/eventTxStage', stage),
+      ));
     await noteSubmitted(network.id, walletName, { hash: txHash, submittedAt: Date.now(), kind: 'dust' });
     return { txHash };
   });
@@ -824,7 +860,7 @@ export async function transferSubmit(
       'binding',
       fromHex(txHex),
     );
-    await submitFinalizedTransaction(wallet.facade, transaction);
+    await submitTracked(network, walletName, () => submitFinalizedTransaction(wallet.facade, transaction));
   });
 }
 

--- a/packages/extension/lib/ui/client.ts
+++ b/packages/extension/lib/ui/client.ts
@@ -16,6 +16,7 @@ import {
 import { deserializeActivity } from '../messaging/activity-json';
 import type { AddressBookEntry } from '../background/address-book';
 import type { AddressKind } from './address';
+import { hasUnregisteredNightToNudge } from './dust-nudge';
 
 /** Fired on the window when the background reports an out-of-band lock, so the
  *  session hook re-reads status without the shell having to wire the two hooks
@@ -127,6 +128,21 @@ export function useSlowSync(waiting: boolean, delayMs = 20_000): boolean {
   }, [waiting, delayMs]);
 
   return slow;
+}
+
+/**
+ * True exactly once per mount, the first time this wallet shows unregistered
+ * NIGHT, fully synced — see dust-nudge.ts. Latched (never resets to false)
+ * so a caller driving a one-shot toast off it does not need its own guard.
+ */
+export function useRegisterNudge(balances: WalletBalances | null): boolean {
+  const [due, setDue] = useState(false);
+
+  useEffect(() => {
+    if (!due && hasUnregisteredNightToNudge(balances)) setDue(true);
+  }, [balances, due]);
+
+  return due;
 }
 
 export function useSelectedProverType(network: string | undefined) {

--- a/packages/extension/lib/ui/dust-nudge.ts
+++ b/packages/extension/lib/ui/dust-nudge.ts
@@ -1,0 +1,26 @@
+// When to suggest registering NIGHT for DUST generation, unprompted.
+//
+// Registration binds the NIGHT signing key (DustRegistration), so NIGHT
+// received AFTER a first registration auto-registers — see DustDetail.tsx.
+// The gap this closes is the FIRST registration: a wallet that has never
+// registered gets no nudge otherwise, and the register flow's own warning
+// (dust-register-timing.ts) only fires once the user is already in that
+// flow. Registering promptly, at the moment NIGHT is first observed, has
+// never been linked to the devnet dust-ledger defect docs/bugs-found.md
+// reports (#15); waiting has.
+
+import { NIGHT_TOKEN_ID } from '@shieldedtech/moth-wallet/types/tokens';
+import type { WalletBalances } from '@shieldedtech/moth-browser';
+
+/**
+ * True the moment a wallet that has never registered any NIGHT shows
+ * unregistered NIGHT, fully synced. Not true again for the same wallet once
+ * it has registered — deregistering is a deliberate choice this should not
+ * second-guess.
+ */
+export function hasUnregisteredNightToNudge(balances: WalletBalances | null): boolean {
+  if (!balances || !balances.syncProgress.dustSynced) return false;
+  const night = balances.unshielded[NIGHT_TOKEN_ID] ?? 0n;
+  const registered = balances.dustGeneration?.registered === true;
+  return night > 0n && !registered;
+}

--- a/packages/extension/lib/ui/dust-register-timing.ts
+++ b/packages/extension/lib/ui/dust-register-timing.ts
@@ -1,0 +1,41 @@
+// How long a NIGHT coin has sat unregistered before the register flow warns
+// about it.
+//
+// Grounded in observed evidence, not theory (docs/bugs-found.md-style report
+// filed upstream against a devnet defect): every registration known to
+// succeed on this class of devnet registered its coin within seconds of
+// funding — 10+ times, with no failures. Every documented chain-wide wedge
+// involved a coin that had sat unregistered for 22 seconds or longer, up to
+// 39 minutes. Neither coin size nor delay alone explains the pattern, but
+// "fund, then register immediately" is the only pattern with zero known
+// failures — so that's what this warns toward, without claiming to know why.
+export const STALE_UNREGISTERED_MS = 60_000;
+
+export interface UnregisteredCoinAge {
+  /** Age of the oldest unregistered, unbooked NIGHT coin, in ms — null if
+   *  there is none, or none report a creation time. */
+  oldestMs: number | null;
+}
+
+/** The oldest unregistered coin's age among `rows`. Booked coins (reserved by
+ *  a pending transaction) are excluded — they cannot be registered yet, so
+ *  their age is not actionable. */
+export function oldestUnregisteredCoinAge(
+  rows: readonly { registered: boolean; booked: boolean; ctimeMs: number | null }[],
+  now: number = Date.now(),
+): UnregisteredCoinAge {
+  let oldestMs: number | null = null;
+  for (const row of rows) {
+    if (row.registered || row.booked || row.ctimeMs === null) continue;
+    const age = now - row.ctimeMs;
+    if (oldestMs === null || age > oldestMs) oldestMs = age;
+  }
+  return { oldestMs };
+}
+
+/** Whether the register flow should warn: the oldest unregistered coin has
+ *  been sitting long enough that immediate registration is no longer what
+ *  is about to happen. */
+export function isStaleUnregistered(age: UnregisteredCoinAge, thresholdMs: number = STALE_UNREGISTERED_MS): boolean {
+  return age.oldestMs !== null && age.oldestMs >= thresholdMs;
+}

--- a/packages/extension/lib/ui/tx-summary-view.ts
+++ b/packages/extension/lib/ui/tx-summary-view.ts
@@ -1,0 +1,65 @@
+// Turns the balance-approval summary (what a dApp transaction takes from the
+// wallet) into display rows. Kept apart from the Approval screen so the mapping
+// is testable, like dust-view.ts and token-list.ts. WASM-free: only the NIGHT
+// token id constant crosses over from core.
+
+import { NIGHT_TOKEN_ID } from '@shieldedtech/moth-wallet/types/tokens';
+import type { TxSummaryDTO, TxTokenAmountDTO } from '../offscreen/messaging';
+import { formatDustFee, formatTokenBalance } from './format';
+import type { NativeAssetLabels } from './token-labels';
+import type { TokenKind } from '../../components/moth/token';
+
+export interface TxSummaryRow {
+  /** Which list the row came from. */
+  direction: 'pay' | 'receive';
+  icon: TokenKind;
+  /** "1.5", "7", "< 0.000001" — formatted in the token's own denomination. */
+  amount: string;
+  /** "tNIGHT", "DUST", a user-assigned token name, or a truncated token id. */
+  symbol: string;
+  /** Truncated token id when `symbol` is a user-assigned name, so the token stays identifiable. */
+  detail: string | null;
+}
+
+/**
+ * Display rows for a summary, spends first. Amounts follow the conventions the
+ * rest of the wallet uses: NIGHT has six decimals, DUST its own denomination,
+ * and every other token is a whole-unit count. A negative or malformed amount
+ * is rendered as received rather than dropped, so nothing silently vanishes.
+ */
+export function txSummaryRows(
+  summary: TxSummaryDTO,
+  labels: NativeAssetLabels,
+  tokenNames: Record<string, string> = {},
+): TxSummaryRow[] {
+  const toRow = (direction: TxSummaryRow['direction']) => (entry: TxTokenAmountDTO): TxSummaryRow => {
+    const raw = parseAmount(entry.amount);
+    if (entry.kind === 'dust') {
+      return { direction, icon: 'dust', amount: formatDustFee(raw), symbol: labels.dust, detail: null };
+    }
+    if (entry.kind === 'unshielded' && entry.tokenId === NIGHT_TOKEN_ID) {
+      return { direction, icon: 'night', amount: formatTokenBalance(raw, 6), symbol: labels.night, detail: null };
+    }
+    const custom = tokenNames[entry.tokenId];
+    return {
+      direction,
+      icon: entry.kind,
+      amount: formatTokenBalance(raw, 0),
+      symbol: custom ?? shortId(entry.tokenId),
+      detail: custom ? shortId(entry.tokenId) : null,
+    };
+  };
+  return [...summary.spends.map(toRow('pay')), ...summary.receives.map(toRow('receive'))];
+}
+
+function parseAmount(value: string): bigint {
+  try {
+    return BigInt(value);
+  } catch {
+    return 0n;
+  }
+}
+
+function shortId(id: string): string {
+  return `${id.slice(0, 8)}…`;
+}

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -470,6 +470,12 @@
   "dust_generateBodyReceiver": {
     "message": "This registers your unregistered $1 so it starts generating $2. You can do this again whenever you receive more $1."
   },
+  "dust_receiveRegisterNudge": {
+    "message": "$1 erhalten — registriere es jetzt, damit es sofort mit der $2-Generierung beginnt."
+  },
+  "dust_staleRegisterWarning": {
+    "message": "Ein Teil dieses $1 liegt schon eine Weile unregistriert da. In manchen Netzwerken wurde das späte Registrieren von $1 — statt sofort nach Erhalt — mit einem seltenen, schwerwiegenden Netzwerkfehler in Verbindung gebracht, der sich nur durch einen Netzwerk-Reset beheben lässt. Am sichersten ist es, $1 sofort nach Erhalt zu registrieren."
+  },
   "dust_deregisterBody": {
     "message": "This deregisters your $1 from $2 generation. The $2 you have stays and still pays fees, but it won't refill. You can register again anytime."
   },

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1149,7 +1149,7 @@
     "message": "Cache leeren und neu synchronisieren"
   },
   "settings_resyncDescription": {
-    "message": "Alles vergessen, was für dieses Konto auf $1 synchronisiert wurde, und die Chain von Anfang an neu scannen. Nützlich, nachdem ein lokales Netzwerk zurückgesetzt wurde."
+    "message": "Alles vergessen, was für dieses Konto auf der aktuellen Chain synchronisiert wurde, und die Chain von Anfang an neu scannen."
   },
   "settings_resyncButton": {
     "message": "Leeren"

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1145,6 +1145,30 @@
   "settings_networkConfig": {
     "message": "Netzwerkkonfiguration"
   },
+  "settings_resync": {
+    "message": "Cache leeren und neu synchronisieren"
+  },
+  "settings_resyncDescription": {
+    "message": "Alles vergessen, was für dieses Konto auf $1 synchronisiert wurde, und die Chain von Anfang an neu scannen. Nützlich, nachdem ein lokales Netzwerk zurückgesetzt wurde."
+  },
+  "settings_resyncButton": {
+    "message": "Leeren"
+  },
+  "settings_resyncTitle": {
+    "message": "Cache leeren und neu synchronisieren?"
+  },
+  "settings_resyncBody": {
+    "message": "Moth löscht den synchronisierten Zustand dieses Kontos, zwischengespeicherte Guthaben, ausstehende Aktivitäten und die vorbereitete Referenz für $1 und synchronisiert dann vom Anfang der Chain. Auf der Chain ändert sich nichts, dein Guthaben bleibt, wo es ist. Bei einem zurückgesetzten Netzwerk zeigt das Guthaben die neue Chain."
+  },
+  "settings_resyncConfirm": {
+    "message": "Leeren & neu synchronisieren"
+  },
+  "settings_resyncWorking": {
+    "message": "Wird geleert…"
+  },
+  "settings_resyncError": {
+    "message": "Der Cache konnte nicht geleert werden. Versuche es erneut."
+  },
   "settings_sectionSecurity": {
     "message": "Sicherheit"
   },

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -305,6 +305,21 @@
   "approval_balanceNote": {
     "message": "Deine Wallet kann eigene Mittel beisteuern, um diese Transaktion auszugleichen. Genehmige nur Transaktionen von Seiten, denen du vertraust."
   },
+  "approval_youPay": {
+    "message": "Du zahlst"
+  },
+  "approval_youGetBack": {
+    "message": "Du erhältst zurück"
+  },
+  "approval_contractCallsLabel": {
+    "message": "Vertragsaufrufe"
+  },
+  "approval_spendsNothing": {
+    "message": "Diese Transaktion entnimmt deiner Wallet nichts außer der Netzwerkgebühr."
+  },
+  "approval_summaryUnavailable": {
+    "message": "Moth konnte nicht lesen, was diese Transaktion ausgibt. Genehmige sie nur, wenn du $1 vertraust und weißt, was sie tut."
+  },
   "approval_transferSubtitle": {
     "message": "Nichts wird bewegt, bis du genehmigst."
   },

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1145,6 +1145,30 @@
   "settings_networkConfig": {
     "message": "Configuración de red"
   },
+  "settings_resync": {
+    "message": "Borrar caché y resincronizar"
+  },
+  "settings_resyncDescription": {
+    "message": "Olvida todo lo sincronizado para esta cuenta en $1 y vuelve a escanear la cadena desde el principio. Úsalo después de reiniciar una red local."
+  },
+  "settings_resyncButton": {
+    "message": "Borrar"
+  },
+  "settings_resyncTitle": {
+    "message": "¿Borrar caché y resincronizar?"
+  },
+  "settings_resyncBody": {
+    "message": "Moth elimina el estado sincronizado de esta cuenta, los saldos en caché, la actividad pendiente y la referencia preparada para $1, y luego sincroniza desde el inicio de la cadena. Nada cambia en la cadena y tus fondos siguen donde están. En una red reiniciada, el saldo reflejará la nueva cadena."
+  },
+  "settings_resyncConfirm": {
+    "message": "Borrar y resincronizar"
+  },
+  "settings_resyncWorking": {
+    "message": "Borrando…"
+  },
+  "settings_resyncError": {
+    "message": "No se pudo borrar la caché. Inténtalo de nuevo."
+  },
   "settings_sectionSecurity": {
     "message": "Seguridad"
   },

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -470,6 +470,12 @@
   "dust_generateBodyReceiver": {
     "message": "This registers your unregistered $1 so it starts generating $2. You can do this again whenever you receive more $1."
   },
+  "dust_receiveRegisterNudge": {
+    "message": "$1 recibido: registralo ahora para que empiece a generar $2 de inmediato."
+  },
+  "dust_staleRegisterWarning": {
+    "message": "Parte de este $1 lleva un tiempo sin registrar. En algunas redes, registrar $1 mucho después de recibirlo —en vez de al instante— se ha relacionado con un fallo de red raro y grave que solo se soluciona reiniciando la red. Lo más seguro es registrar $1 en cuanto llega."
+  },
   "dust_deregisterBody": {
     "message": "This deregisters your $1 from $2 generation. The $2 you have stays and still pays fees, but it won't refill. You can register again anytime."
   },

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -305,6 +305,21 @@
   "approval_balanceNote": {
     "message": "Tu billetera puede aportar fondos propios para balancear esta transacción. Aprueba solo transacciones de sitios en los que confíes."
   },
+  "approval_youPay": {
+    "message": "Pagas"
+  },
+  "approval_youGetBack": {
+    "message": "Recibes de vuelta"
+  },
+  "approval_contractCallsLabel": {
+    "message": "Llamadas a contratos"
+  },
+  "approval_spendsNothing": {
+    "message": "Esta transacción no toma nada de tu billetera aparte de la comisión de red."
+  },
+  "approval_summaryUnavailable": {
+    "message": "Moth no pudo leer qué gasta esta transacción. Apruébala solo si confías en $1 y sabes lo que hace."
+  },
   "approval_transferSubtitle": {
     "message": "Nada se mueve hasta que apruebes."
   },

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1149,7 +1149,7 @@
     "message": "Borrar caché y resincronizar"
   },
   "settings_resyncDescription": {
-    "message": "Olvida todo lo sincronizado para esta cuenta en $1 y vuelve a escanear la cadena desde el principio. Úsalo después de reiniciar una red local."
+    "message": "Olvida todo lo sincronizado para esta cuenta en la cadena actual y vuelve a escanear la cadena desde el principio."
   },
   "settings_resyncButton": {
     "message": "Borrar"

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1149,7 +1149,7 @@
     "message": "Vider le cache et resynchroniser"
   },
   "settings_resyncDescription": {
-    "message": "Oublier tout ce qui a été synchronisé pour ce compte sur $1 et parcourir de nouveau la chaîne depuis le début. À utiliser après la réinitialisation d’un réseau local."
+    "message": "Oublier tout ce qui a été synchronisé pour ce compte sur la chaîne actuelle et parcourir de nouveau la chaîne depuis le début."
   },
   "settings_resyncButton": {
     "message": "Vider"

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -470,6 +470,12 @@
   "dust_generateBodyReceiver": {
     "message": "This registers your unregistered $1 so it starts generating $2. You can do this again whenever you receive more $1."
   },
+  "dust_receiveRegisterNudge": {
+    "message": "$1 reçu — enregistrez-le maintenant pour qu'il commence à générer $2 tout de suite."
+  },
+  "dust_staleRegisterWarning": {
+    "message": "Une partie de ce $1 est restée non enregistrée un certain temps. Sur certains réseaux, enregistrer $1 longtemps après l'avoir reçu — plutôt qu'immédiatement — a été associé à un défaut de réseau rare et grave, sans autre solution qu'une réinitialisation du réseau. Le plus sûr est d'enregistrer $1 dès sa réception."
+  },
   "dust_deregisterBody": {
     "message": "This deregisters your $1 from $2 generation. The $2 you have stays and still pays fees, but it won't refill. You can register again anytime."
   },

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1145,6 +1145,30 @@
   "settings_networkConfig": {
     "message": "Configuration réseau"
   },
+  "settings_resync": {
+    "message": "Vider le cache et resynchroniser"
+  },
+  "settings_resyncDescription": {
+    "message": "Oublier tout ce qui a été synchronisé pour ce compte sur $1 et parcourir de nouveau la chaîne depuis le début. À utiliser après la réinitialisation d’un réseau local."
+  },
+  "settings_resyncButton": {
+    "message": "Vider"
+  },
+  "settings_resyncTitle": {
+    "message": "Vider le cache et resynchroniser ?"
+  },
+  "settings_resyncBody": {
+    "message": "Moth supprime l’état synchronisé de ce compte, les soldes en cache, l’activité en attente et la référence préparée pour $1, puis synchronise depuis le début de la chaîne. Rien ne change sur la chaîne et vos fonds restent où ils sont. Sur un réseau réinitialisé, le solde reflétera la nouvelle chaîne."
+  },
+  "settings_resyncConfirm": {
+    "message": "Vider et resynchroniser"
+  },
+  "settings_resyncWorking": {
+    "message": "Vidage…"
+  },
+  "settings_resyncError": {
+    "message": "Impossible de vider le cache. Réessayez."
+  },
   "settings_sectionSecurity": {
     "message": "Sécurité"
   },

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -305,6 +305,21 @@
   "approval_balanceNote": {
     "message": "Votre portefeuille peut ajouter ses propres fonds pour équilibrer cette transaction. N'approuvez que les transactions de sites de confiance."
   },
+  "approval_youPay": {
+    "message": "Vous payez"
+  },
+  "approval_youGetBack": {
+    "message": "Vous récupérez"
+  },
+  "approval_contractCallsLabel": {
+    "message": "Appels de contrat"
+  },
+  "approval_spendsNothing": {
+    "message": "Cette transaction ne prélève rien sur votre portefeuille en dehors des frais de réseau."
+  },
+  "approval_summaryUnavailable": {
+    "message": "Moth n'a pas pu lire ce que cette transaction dépense. N'approuvez que si vous faites confiance à $1 et savez ce qu'elle fait."
+  },
   "approval_transferSubtitle": {
     "message": "Rien ne bouge avant votre approbation."
   },

--- a/packages/extension/tests/connector-handlers.test.ts
+++ b/packages/extension/tests/connector-handlers.test.ts
@@ -11,6 +11,7 @@ const transferSubmit = vi.fn();
 const txHistoryGet = vi.fn();
 const signData = vi.fn();
 const balanceTransaction = vi.fn();
+const txSummary = vi.fn();
 const makeIntent = vi.fn();
 const provingProviderCheck = vi.fn();
 const provingProviderProve = vi.fn();
@@ -22,6 +23,7 @@ vi.mock('../lib/background/offscreen-client', () => ({
     txHistoryGet: (...a: unknown[]) => txHistoryGet(...(a as [])),
     signData: (...a: unknown[]) => signData(...(a as [])),
     balanceTransaction: (...a: unknown[]) => balanceTransaction(...(a as [])),
+    txSummary: (...a: unknown[]) => txSummary(...(a as [])),
     makeIntent: (...a: unknown[]) => makeIntent(...(a as [])),
     provingProviderCheck: (...a: unknown[]) => provingProviderCheck(...(a as [])),
     provingProviderProve: (...a: unknown[]) => provingProviderProve(...(a as [])),
@@ -83,6 +85,13 @@ function sampleBalances(): WalletBalances {
   } as unknown as WalletBalances;
 }
 
+/** What the offscreen summary reports for a dApp tx one NIGHT short. */
+const NIGHT_SPEND = {
+  spends: [{ kind: 'unshielded', tokenId: '0'.repeat(64), amount: '1000000' }],
+  receives: [],
+  contractActions: 0,
+};
+
 async function connect() {
   await grant(ORIGIN, 'devnet');
   await saveSession(SESSION);
@@ -97,6 +106,7 @@ describe('connector dispatch', () => {
     txHistoryGet.mockReset();
     signData.mockReset();
     balanceTransaction.mockReset();
+    txSummary.mockReset();
     makeIntent.mockReset();
     provingProviderCheck.mockReset();
     provingProviderProve.mockReset();
@@ -364,11 +374,59 @@ describe('connector dispatch', () => {
   it('balances a sealed transaction after approval', async () => {
     await connect();
     requestApproval.mockResolvedValue(true);
+    txSummary.mockResolvedValue(NIGHT_SPEND);
     balanceTransaction.mockResolvedValue({ txHex: 'beef' });
     const res = await dispatch(ORIGIN, 'balanceSealedTransaction', ['abcd']);
     expect(res).toEqual({ tx: 'beef' });
-    expect(requestApproval).toHaveBeenCalledWith('balance', ORIGIN, { sealed: true }, undefined, preparedPanel);
+    expect(requestApproval).toHaveBeenCalledWith(
+      'balance',
+      ORIGIN,
+      { sealed: true, summary: NIGHT_SPEND },
+      undefined,
+      preparedPanel,
+    );
     expect(balanceTransaction).toHaveBeenCalledWith(expect.objectContaining({ txHex: 'abcd', sealed: true }));
+  });
+
+  // The user is authorizing a spend, so what the transaction takes from the
+  // wallet is read off the transaction and shown BEFORE the prompt — not after
+  // balancing, when the funds are already committed.
+  it('summarizes the transaction before asking for approval, at the requested stage', async () => {
+    await connect();
+    const order: string[] = [];
+    txSummary.mockImplementation(async () => {
+      order.push('summary');
+      return NIGHT_SPEND;
+    });
+    requestApproval.mockImplementation(async () => {
+      order.push('approval');
+      return true;
+    });
+    balanceTransaction.mockResolvedValue({ txHex: 'beef' });
+
+    await dispatch(ORIGIN, 'balanceUnsealedTransaction', ['abcd']);
+    expect(order).toEqual(['summary', 'approval']);
+    expect(txSummary).toHaveBeenCalledWith(expect.objectContaining({ txHex: 'abcd', sealed: false }));
+  });
+
+  // A transaction the ledger will not decode is still surfaced — with the summary
+  // absent, which the screen renders as an explicit warning — rather than the
+  // request failing before the user ever sees it.
+  it('still prompts when the transaction cannot be summarized, marking the summary unknown', async () => {
+    await connect();
+    txSummary.mockRejectedValue(new Error('unexpected end of input'));
+    requestApproval.mockResolvedValue(true);
+    balanceTransaction.mockResolvedValue({ txHex: 'beef' });
+
+    const res = await dispatch(ORIGIN, 'balanceSealedTransaction', ['abcd']);
+    expect(res).toEqual({ tx: 'beef' });
+    expect(requestApproval).toHaveBeenCalledWith(
+      'balance',
+      ORIGIN,
+      { sealed: true, summary: null },
+      undefined,
+      preparedPanel,
+    );
   });
 
   it('rejects balanceSealedTransaction when the user declines', async () => {
@@ -403,10 +461,17 @@ describe('connector dispatch', () => {
   it('balances an unsealed transaction after approval (sealed: false)', async () => {
     await connect();
     requestApproval.mockResolvedValue(true);
+    txSummary.mockResolvedValue(NIGHT_SPEND);
     balanceTransaction.mockResolvedValue({ txHex: 'cafe' });
     const res = await dispatch(ORIGIN, 'balanceUnsealedTransaction', ['abcd']);
     expect(res).toEqual({ tx: 'cafe' });
-    expect(requestApproval).toHaveBeenCalledWith('balance', ORIGIN, { sealed: false }, undefined, preparedPanel);
+    expect(requestApproval).toHaveBeenCalledWith(
+      'balance',
+      ORIGIN,
+      { sealed: false, summary: NIGHT_SPEND },
+      undefined,
+      preparedPanel,
+    );
     expect(balanceTransaction).toHaveBeenCalledWith(expect.objectContaining({ txHex: 'abcd', sealed: false }));
   });
 

--- a/packages/extension/tests/dust-nudge.test.ts
+++ b/packages/extension/tests/dust-nudge.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { hasUnregisteredNightToNudge } from '../lib/ui/dust-nudge';
+import { makeBalances } from './balances-fixture';
+
+describe('hasUnregisteredNightToNudge', () => {
+  it('is false with no balances yet', () => {
+    expect(hasUnregisteredNightToNudge(null)).toBe(false);
+  });
+
+  it('is false while the dust sub-wallet is still syncing, even with unregistered NIGHT', () => {
+    const balances = makeBalances({ night: 1_000_000n, dustSynced: false });
+    expect(hasUnregisteredNightToNudge(balances)).toBe(false);
+  });
+
+  it('is false with no NIGHT held', () => {
+    const balances = makeBalances({ night: 0n });
+    expect(hasUnregisteredNightToNudge(balances)).toBe(false);
+  });
+
+  it('is true once NIGHT is held, unregistered, fully synced', () => {
+    const balances = makeBalances({ night: 1_000_000n });
+    expect(hasUnregisteredNightToNudge(balances)).toBe(true);
+  });
+
+  it('is false once the wallet has registered', () => {
+    const balances = makeBalances({ night: 1_000_000n, registered: true });
+    expect(hasUnregisteredNightToNudge(balances)).toBe(false);
+  });
+});

--- a/packages/extension/tests/dust-register-timing.test.ts
+++ b/packages/extension/tests/dust-register-timing.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { STALE_UNREGISTERED_MS, isStaleUnregistered, oldestUnregisteredCoinAge } from '../lib/ui/dust-register-timing';
+
+const NOW = 1_800_000_000_000;
+
+function coin(overrides: Partial<{ registered: boolean; booked: boolean; ctimeMs: number | null }> = {}) {
+  return { registered: false, booked: false, ctimeMs: NOW, ...overrides };
+}
+
+describe('oldestUnregisteredCoinAge', () => {
+  it('reports null when there are no coins', () => {
+    expect(oldestUnregisteredCoinAge([], NOW)).toEqual({ oldestMs: null });
+  });
+
+  it('reports null when every coin is registered', () => {
+    expect(oldestUnregisteredCoinAge([coin({ registered: true })], NOW)).toEqual({ oldestMs: null });
+  });
+
+  it('excludes booked coins — they cannot be registered yet, so their age is not actionable', () => {
+    expect(oldestUnregisteredCoinAge([coin({ booked: true, ctimeMs: NOW - 10_000 })], NOW)).toEqual({
+      oldestMs: null,
+    });
+  });
+
+  it('excludes coins with no known creation time', () => {
+    expect(oldestUnregisteredCoinAge([coin({ ctimeMs: null })], NOW)).toEqual({ oldestMs: null });
+  });
+
+  it('computes the age of a single unregistered coin', () => {
+    expect(oldestUnregisteredCoinAge([coin({ ctimeMs: NOW - 5_000 })], NOW)).toEqual({ oldestMs: 5_000 });
+  });
+
+  it('takes the OLDEST among several unregistered coins, not the newest or a sum', () => {
+    const rows = [coin({ ctimeMs: NOW - 1_000 }), coin({ ctimeMs: NOW - 90_000 }), coin({ ctimeMs: NOW - 30_000 })];
+    expect(oldestUnregisteredCoinAge(rows, NOW)).toEqual({ oldestMs: 90_000 });
+  });
+
+  it('ignores registered/booked coins even when they are older than the unregistered ones', () => {
+    const rows = [
+      coin({ registered: true, ctimeMs: NOW - 10_000_000 }),
+      coin({ booked: true, ctimeMs: NOW - 5_000_000 }),
+      coin({ ctimeMs: NOW - 2_000 }),
+    ];
+    expect(oldestUnregisteredCoinAge(rows, NOW)).toEqual({ oldestMs: 2_000 });
+  });
+});
+
+describe('isStaleUnregistered', () => {
+  it('is false below the threshold', () => {
+    expect(isStaleUnregistered({ oldestMs: STALE_UNREGISTERED_MS - 1 })).toBe(false);
+  });
+
+  it('is true at and above the threshold', () => {
+    expect(isStaleUnregistered({ oldestMs: STALE_UNREGISTERED_MS })).toBe(true);
+    expect(isStaleUnregistered({ oldestMs: STALE_UNREGISTERED_MS + 1 })).toBe(true);
+  });
+
+  it('is false when there is nothing to warn about', () => {
+    expect(isStaleUnregistered({ oldestMs: null })).toBe(false);
+  });
+
+  it('honors a caller-supplied threshold', () => {
+    expect(isStaleUnregistered({ oldestMs: 5_000 }, 10_000)).toBe(false);
+    expect(isStaleUnregistered({ oldestMs: 15_000 }, 10_000)).toBe(true);
+  });
+});

--- a/packages/extension/tests/protocol.test.ts
+++ b/packages/extension/tests/protocol.test.ts
@@ -33,7 +33,7 @@ function sampleBalances(): WalletBalances {
     coins: {
       shielded: { available: [{ value: 10n, type: NIGHT }], pending: [] },
       unshielded: {
-        available: [{ value: 42n, type: NIGHT, registeredForDustGeneration: true }],
+        available: [{ value: 42n, type: NIGHT, registeredForDustGeneration: true, ctimeMs: 1_752_753_600_000 }],
         pending: [],
       },
       dust: {

--- a/packages/extension/tests/resync.test.ts
+++ b/packages/extension/tests/resync.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+
+const syncCacheReset = vi.fn<() => Promise<void>>();
+vi.mock('../lib/background/offscreen-client', () => ({
+  offscreen: {
+    syncCacheReset: (...args: unknown[]) => syncCacheReset(...(args as [])),
+  },
+}));
+
+const stopSync = vi.fn<() => Promise<void>>();
+const clearSnapshot = vi.fn<() => Promise<void>>();
+const startSync = vi.fn<() => Promise<void>>();
+const broadcastSyncFailure = vi.fn();
+const beginOp = vi.fn();
+const endOp = vi.fn();
+vi.mock('../lib/background/sync-service', () => ({
+  stopSync: () => stopSync(),
+  clearSnapshot: () => clearSnapshot(),
+  startSync: (...args: unknown[]) => startSync(...(args as [])),
+  broadcastSyncFailure: (error: unknown) => broadcastSyncFailure(error),
+  getSnapshot: vi.fn(),
+  beginOp: () => beginOp(),
+  endOp: () => endOp(),
+  hasOpenPorts: vi.fn(() => true),
+  hasWorkInFlight: vi.fn(() => false),
+  broadcastSessionLocked: vi.fn(),
+  getSetupTabIds: vi.fn(() => []),
+  teardown: vi.fn(),
+}));
+
+import { resyncFromScratch } from '../lib/background/handlers';
+import { saveSession, type Session } from '../lib/background/session';
+import { updateSettings } from '../lib/background/settings';
+
+const SESSION: Session = {
+  walletName: 'alice',
+  seedHex: 'ab'.repeat(32),
+  address: 'mn_unshielded_undeployed',
+  addresses: {
+    nightExternal: { hex: '', bech32m: { undeployed: 'mn_unshielded_undeployed' } },
+  } as unknown as Session['addresses'],
+  shieldedCoinPublicKey: 'c0'.repeat(16),
+  shieldedEncryptionPublicKey: 'e0'.repeat(16),
+  network: 'undeployed',
+  unlockedAt: 1,
+};
+
+describe('resyncFromScratch', () => {
+  beforeEach(async () => {
+    fakeBrowser.reset();
+    syncCacheReset.mockReset().mockResolvedValue(undefined);
+    stopSync.mockReset().mockResolvedValue(undefined);
+    clearSnapshot.mockReset().mockResolvedValue(undefined);
+    startSync.mockReset().mockResolvedValue(undefined);
+    broadcastSyncFailure.mockReset();
+    beginOp.mockReset();
+    endOp.mockReset();
+    await updateSettings({ network: 'undeployed', customEndpoints: null });
+    await saveSession(SESSION);
+  });
+
+  it('stops, clears the account and network caches, drops the snapshot, then restarts sync', async () => {
+    await resyncFromScratch();
+
+    expect(stopSync).toHaveBeenCalledTimes(1);
+    expect(syncCacheReset).toHaveBeenCalledWith({
+      walletName: 'alice',
+      network: expect.objectContaining({ id: 'undeployed' }),
+    });
+    expect(clearSnapshot).toHaveBeenCalledTimes(1);
+    expect(startSync).toHaveBeenCalledWith(
+      expect.objectContaining({ walletName: 'alice', network: 'undeployed' }),
+      expect.objectContaining({ id: 'undeployed' }),
+    );
+
+    // Order matters: the engine writes its final state on stop, so a clear that
+    // ran first would be undone; and the panel must see the reset before the
+    // new sync's first balances arrive.
+    const order = [stopSync, syncCacheReset, clearSnapshot, startSync].map((fn) => fn.mock.invocationCallOrder[0]!);
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+  });
+
+  it('brackets the whole reset as one in-flight op so idle teardown cannot interrupt it', async () => {
+    await resyncFromScratch();
+    expect(beginOp).toHaveBeenCalledTimes(1);
+    expect(endOp).toHaveBeenCalledTimes(1);
+    expect(beginOp.mock.invocationCallOrder[0]!).toBeLessThan(stopSync.mock.invocationCallOrder[0]!);
+    expect(endOp.mock.invocationCallOrder[0]!).toBeGreaterThan(startSync.mock.invocationCallOrder[0]!);
+  });
+
+  it('restarts sync even when the clear fails, and surfaces the failure', async () => {
+    syncCacheReset.mockRejectedValue(new Error('IndexedDB unavailable'));
+
+    await expect(resyncFromScratch()).rejects.toThrow('IndexedDB unavailable');
+    expect(startSync).toHaveBeenCalledTimes(1);
+    expect(clearSnapshot).not.toHaveBeenCalled();
+    expect(endOp).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses when the wallet is locked, touching nothing', async () => {
+    fakeBrowser.reset();
+    await updateSettings({ network: 'undeployed', customEndpoints: null });
+
+    await expect(resyncFromScratch()).rejects.toThrow('Wallet is locked');
+    expect(stopSync).not.toHaveBeenCalled();
+    expect(syncCacheReset).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/tests/tx-summary-view.test.ts
+++ b/packages/extension/tests/tx-summary-view.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { txSummaryRows } from '../lib/ui/tx-summary-view';
+import { TESTNET_NATIVE_ASSET_LABELS, MAINNET_NATIVE_ASSET_LABELS } from '../lib/ui/token-labels';
+import type { TxSummaryDTO } from '../lib/offscreen/messaging';
+
+const NIGHT = '0'.repeat(64);
+const TOKEN = 'd'.repeat(64);
+
+const empty: TxSummaryDTO = { spends: [], receives: [], contractActions: 0 };
+
+describe('txSummaryRows', () => {
+  it('shows a NIGHT deficit as a payment in NIGHT units with the network label', () => {
+    const rows = txSummaryRows(
+      { ...empty, spends: [{ kind: 'unshielded', tokenId: NIGHT, amount: '1500000' }] },
+      TESTNET_NATIVE_ASSET_LABELS,
+    );
+    expect(rows).toEqual([{ direction: 'pay', icon: 'night', amount: '1.5', symbol: 'tNIGHT', detail: null }]);
+  });
+
+  it('uses the mainnet label on mainnet', () => {
+    const rows = txSummaryRows(
+      { ...empty, spends: [{ kind: 'unshielded', tokenId: NIGHT, amount: '1000000' }] },
+      MAINNET_NATIVE_ASSET_LABELS,
+    );
+    expect(rows[0]).toMatchObject({ amount: '1', symbol: 'NIGHT' });
+  });
+
+  it('lists spends before change, and keeps direction on each row', () => {
+    const rows = txSummaryRows(
+      {
+        spends: [{ kind: 'shielded', tokenId: TOKEN, amount: '7' }],
+        receives: [{ kind: 'unshielded', tokenId: NIGHT, amount: '2000000' }],
+        contractActions: 1,
+      },
+      TESTNET_NATIVE_ASSET_LABELS,
+    );
+    expect(rows.map((r) => r.direction)).toEqual(['pay', 'receive']);
+    expect(rows[0]).toMatchObject({ icon: 'shielded', amount: '7', symbol: 'dddddddd…' });
+    expect(rows[1]).toMatchObject({ icon: 'night', amount: '2', symbol: 'tNIGHT' });
+  });
+
+  it('treats non-NIGHT tokens as whole units, never dividing by a million', () => {
+    const rows = txSummaryRows(
+      { ...empty, spends: [{ kind: 'unshielded', tokenId: TOKEN, amount: '1234567' }] },
+      TESTNET_NATIVE_ASSET_LABELS,
+    );
+    expect(rows[0]).toMatchObject({ icon: 'unshielded', amount: '1,234,567' });
+  });
+
+  it('prefers the user-assigned token name and keeps the id as detail', () => {
+    const rows = txSummaryRows(
+      { ...empty, spends: [{ kind: 'shielded', tokenId: TOKEN, amount: '3' }] },
+      TESTNET_NATIVE_ASSET_LABELS,
+      { [TOKEN]: 'Loyalty points' },
+    );
+    expect(rows[0]).toMatchObject({ symbol: 'Loyalty points', detail: 'dddddddd…' });
+  });
+
+  it('renders DUST in its own denomination, not NIGHT decimals', () => {
+    const rows = txSummaryRows(
+      { ...empty, spends: [{ kind: 'dust', tokenId: '', amount: String(10n ** 15n / 2n) }] },
+      TESTNET_NATIVE_ASSET_LABELS,
+    );
+    expect(rows[0]).toMatchObject({ icon: 'dust', amount: '0.5', symbol: 'tDUST' });
+  });
+
+  it('returns no rows for a balanced transaction', () => {
+    expect(txSummaryRows(empty, TESTNET_NATIVE_ASSET_LABELS)).toEqual([]);
+  });
+});

--- a/packages/extension/tests/wallet-host-unlock.test.ts
+++ b/packages/extension/tests/wallet-host-unlock.test.ts
@@ -29,6 +29,7 @@ vi.mock('@shieldedtech/moth-browser', () => ({
   buildTransferTransaction: vi.fn(),
   estimateTransferFee: vi.fn(),
   balanceTransaction: vi.fn(),
+  summarizeConnectorTransaction: vi.fn(),
   buildSwapIntent: vi.fn(),
   designateForDust: vi.fn(),
   dedesignateFromDust: vi.fn(),

--- a/packages/extension/tests/wallet-host-unlock.test.ts
+++ b/packages/extension/tests/wallet-host-unlock.test.ts
@@ -37,6 +37,7 @@ vi.mock('@shieldedtech/moth-browser', () => ({
   deriveWalletKeys: vi.fn(),
   clearSyncCache: vi.fn(),
   clearDustSyncCache: vi.fn(),
+  clearEmptyRefCache: vi.fn(),
   signMessage: vi.fn(),
   deriveActivity: vi.fn(),
   IdbSyncStateStore: class {},

--- a/packages/extension/tests/worker-rpc.test.ts
+++ b/packages/extension/tests/worker-rpc.test.ts
@@ -66,6 +66,7 @@ describe('HOST_METHODS', () => {
     'os/syncEnsure',
     'os/syncStop',
     'os/syncCacheClear',
+    'os/syncCacheReset',
     'os/balancesGet',
     'os/sendTokens',
     'os/estimateTransferFee',

--- a/packages/extension/tests/worker-rpc.test.ts
+++ b/packages/extension/tests/worker-rpc.test.ts
@@ -81,6 +81,7 @@ describe('HOST_METHODS', () => {
     'os/transferBuild',
     'os/transferSubmit',
     'os/txHistoryGet',
+    'os/txSummary',
     'os/activityGet',
     'os/signData',
     'os/deriveAppSecret',


### PR DESCRIPTION
## Problem

When a connected dApp calls `balanceSealedTransaction` / `balanceUnsealedTransaction`, the wallet covers whatever the dApp's transaction is short of. The approval screen said only "Network fee: paid in DUST" plus the note *"Your wallet may add its own funds to balance this transaction"*. The user was authorizing a spend with no way to see which tokens, or how much, would leave the wallet.

## Change

The balance-approval screen now lists, per token, what the wallet has to supply (**You pay**) and any surplus it collects back (**You get back**), with a **Contract calls** row when the transaction carries any. A balanced transaction says in words that nothing beyond the fee is taken. A transaction Moth cannot decode produces a visible warning instead of an empty card.

The amounts are read off the transaction itself, before anything is balanced, booked or spent:

- **core** — new `sync/tx-summary.ts` with `summarizeTransaction` / `summarizeConnectorTransaction`. Deserializes at the same stage the balancing path uses and sums the ledger's `Transaction.imbalances(segment)` over the guaranteed section and every intent. Negative = the wallet must put it in; positive = change. Exported from core and browser barrels.
- **extension** — new offscreen RPC `os/txSummary` (needs the ledger loaded, no keys, no sync). `connector-handlers.ts` computes it before `requestApproval`; the `balance` payload becomes `{ sealed, summary | null }`. `lib/ui/tx-summary-view.ts` maps the summary to rows (NIGHT 6 decimals, DUST its own denomination, other tokens whole units with user-assigned names). New i18n keys in en/de/es/fr.

Fees are deliberately not included: they are only known once the wallet has balanced and proven its own segment, and are always paid in DUST, so that row still reads "Paid in DUST".

## Tests

- `packages/core/tests/unit/sync/tx-summary.test.ts` pins the imbalance sign convention against the real ledger-v8 WASM: unfunded output → spend, over-funded input → change, balanced → nothing, wrong stage marker → throws.
- `packages/extension/tests/tx-summary-view.test.ts` covers formatting per token kind and row ordering.
- `connector-handlers.test.ts`: summary is computed before the prompt at the requested stage; a summary failure still prompts with `summary: null`.
- Full suites: core 392 pass, extension 440 pass, browser boundary guards pass. `npm run compile` and `wxt build` succeed.

Stacked on #30 (`feat/ledger-v9-support`); the diff here is the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
