### PR TITLE
extension: add "Clear cache and resync" to Settings

### DIFF
--- a/.changeset/clear-cache-and-resync.md
+++ b/.changeset/clear-cache-and-resync.md
@@ -1,0 +1,23 @@
+---
+'@shieldedtech/moth-extension': minor
+'@shieldedtech/moth-wallet': patch
+---
+
+Settings → Network gains "Clear cache and resync".
+
+A local network that goes down and comes back as a new chain from genesis
+leaves the wallet holding state for a chain that no longer exists: the
+account's serialized sync state, its pending submissions, and the network's
+pre-seed reference that every fresh sync is seeded from. The engine cannot
+tell, and the only ways out were switching indexer URLs or removing the
+account. The new action, behind a confirmation, stops sync, drops all of that
+for the active account on its network, clears the cached balance snapshot so
+the loading screen shows, and starts syncing again from the start of the
+chain. Nothing is spent.
+
+Core gains `clearEmptyRefCache(networkId, store)` (`sync/preseed.ts`), which
+removes the reference's state parts, height, cursor witnesses and mnemonic and
+forgets the in-process memo — without the last, a worker that had already
+verified the reference would keep handing the stale one out. `clearSyncCache`
+now also evicts the ECDSA unshielded cache identity, which it previously left
+behind for wallets of that kind.

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -34,6 +34,7 @@ export type {
 export {
   warmEmptyRefCache,
   preseedReferenceStatus,
+  clearEmptyRefCache,
   type WarmProgress,
 } from '@shieldedtech/moth-wallet/sync/preseed';
 export { WalletManager } from '@shieldedtech/moth-wallet/wallet/manager';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -138,7 +138,7 @@ export {
   type WitnessStream,
   type WitnessVerdict,
 } from './sync/cursor-witness.js';
-export { ensureEmptyRefCache, warmEmptyRefCache, refreshEmptyRefCache, preseedReferenceStatus, preSeedNewWallet, type WarmProgress } from './sync/preseed.js';
+export { ensureEmptyRefCache, warmEmptyRefCache, clearEmptyRefCache, refreshEmptyRefCache, preseedReferenceStatus, preSeedNewWallet, type WarmProgress } from './sync/preseed.js';
 
 // Contract
 export { loadContractArtifact, type ContractArtifact } from './contract/artifact-loader.js';

--- a/packages/core/src/sync/preseed.ts
+++ b/packages/core/src/sync/preseed.ts
@@ -376,6 +376,40 @@ export function warmEmptyRefCache(
  * Lets a UI distinguish "not started" from "in progress" from "done" — a build
  * runs for an hour, so reporting it as perpetually in progress is misleading.
  */
+/**
+ * Forget the pre-seed reference for a network: its three state parts, its
+ * height, its cursor witnesses, the reference mnemonic, and the in-process memo
+ * `ensureEmptyRefCache` hands out.
+ *
+ * For a chain that restarted from genesis. The reference is chain state, so on a
+ * new chain it is wrong in every part, and the wallet-level cache clear does not
+ * reach it: every new sync would be seeded from the old chain's tip. Deleting
+ * the memo matters as much as the store — a verified reference is memoised per
+ * process, so without it the next sync in the same worker would still get the
+ * stale one. A network whose reference ships in the package reinstalls it on the
+ * next sync; its witnesses are then checked against the chain, and a reset chain
+ * refuses them, so the wallet walks from genesis rather than trusting it.
+ */
+export async function clearEmptyRefCache(networkId: string, store?: SyncStateStore): Promise<void> {
+  refCache.delete(networkId);
+  const resolved = await resolveSyncStore(store);
+  const keys = [
+    ...REF_PARTS.map(part => emptyRefStateKey(networkId, part)),
+    ...REF_PARTS.map(part => cursorWitnessKey(networkId, EMPTY_REF_WALLET, part)),
+    emptyRefHeightKey(networkId),
+    emptyRefMnemonicKey(networkId),
+  ];
+  for (const key of keys) {
+    try {
+      await resolved.delete(key);
+    } catch {
+      /* absent already */
+    }
+  }
+}
+
+const REF_PARTS: WalletPart[] = ['shielded', 'unshielded', 'dust'];
+
 export async function preseedReferenceStatus(
   network: NetworkConfig,
   store?: SyncStateStore

--- a/packages/core/src/sync/wallet-sync.ts
+++ b/packages/core/src/sync/wallet-sync.ts
@@ -1192,6 +1192,11 @@ export async function clearSyncCache(walletName: string, networkId: string, stor
   const resolved = await resolveSyncStore(store);
   await evictCachedState(resolved, walletName, networkId, 'shielded');
   await evictCachedState(resolved, walletName, networkId, 'unshielded');
+  // An ECDSA wallet keeps its unshielded cache under a second identity (see
+  // cacheIdentity). The caller does not know the wallet's kind, so evict both:
+  // deleting an absent key costs nothing, leaving a stale cache behind costs a
+  // "cleared" wallet that resumes from the state the user just asked to drop.
+  await evictCachedState(resolved, walletName, networkId, 'unshielded', 'ecdsa');
   await evictCachedState(resolved, walletName, networkId, 'dust');
   await evictCachedState(resolved, walletName, networkId, 'history');
 }

--- a/packages/core/tests/unit/sync/cache-reset.test.ts
+++ b/packages/core/tests/unit/sync/cache-reset.test.ts
@@ -1,0 +1,82 @@
+// A local network brought back up from genesis leaves every cached artefact
+// wrong: the account's sync state, and the network's pre-seed reference that
+// new syncs are seeded from. "Clear cache and resync" has to reach both, or the
+// resync restarts from a chain that no longer exists.
+
+import {beforeEach, describe, expect, it} from 'vitest';
+import {
+  InMemorySyncStateStore,
+  EMPTY_REF_WALLET,
+  cursorWitnessKey,
+  emptyRefHeightKey,
+  emptyRefMnemonicKey,
+  emptyRefStateKey,
+  syncStateKey,
+} from '../../../src/sync/sync-store.js';
+import {clearEmptyRefCache, preseedReferenceStatus} from '../../../src/sync/preseed.js';
+import {clearSyncCache} from '../../../src/sync/wallet-sync.js';
+import type {NetworkConfig} from '../../../src/types/network.js';
+
+const NETWORK = 'undeployed';
+const network = {id: NETWORK, nodeUrl: 'ws://localhost:9944', indexerUrl: 'http://localhost:8088'} as NetworkConfig;
+
+let store: InMemorySyncStateStore;
+
+beforeEach(() => {
+  store = new InMemorySyncStateStore();
+});
+
+describe('clearEmptyRefCache', () => {
+  it('removes every reference artefact for the network and leaves other networks alone', async () => {
+    for (const part of ['shielded', 'unshielded', 'dust'] as const) {
+      await store.put(emptyRefStateKey(NETWORK, part), 'state');
+      await store.put(cursorWitnessKey(NETWORK, EMPTY_REF_WALLET, part), '{"id":1}');
+      await store.put(emptyRefStateKey('preprod', part), 'state');
+    }
+    await store.put(emptyRefHeightKey(NETWORK), '4200');
+    await store.put(emptyRefMnemonicKey(NETWORK), 'word '.repeat(24).trim());
+    await store.put(emptyRefHeightKey('preprod'), '99');
+
+    await clearEmptyRefCache(NETWORK, store);
+
+    for (const part of ['shielded', 'unshielded', 'dust'] as const) {
+      expect(await store.get(emptyRefStateKey(NETWORK, part))).toBeNull();
+      expect(await store.get(cursorWitnessKey(NETWORK, EMPTY_REF_WALLET, part))).toBeNull();
+      expect(await store.get(emptyRefStateKey('preprod', part))).toBe('state');
+    }
+    expect(await store.get(emptyRefHeightKey(NETWORK))).toBeNull();
+    expect(await store.get(emptyRefMnemonicKey(NETWORK))).toBeNull();
+    expect(await store.get(emptyRefHeightKey('preprod'))).toBe('99');
+  });
+
+  it('leaves the network with no usable reference', async () => {
+    // A minimal reference the status check accepts: non-empty parts with a
+    // positive offset is checked by snapshotOffset, so use the status before and
+    // after only as "did the height survive" — the height alone gates usability.
+    await store.put(emptyRefHeightKey(NETWORK), '4200');
+    await clearEmptyRefCache(NETWORK, store);
+    expect(await preseedReferenceStatus(network, store)).toEqual({ready: false, height: null});
+  });
+
+  it('is a no-op on a network that never had a reference', async () => {
+    await expect(clearEmptyRefCache('never-seen', store)).resolves.toBeUndefined();
+  });
+});
+
+describe('clearSyncCache', () => {
+  it('evicts every part, including the ECDSA unshielded identity', async () => {
+    for (const part of ['shielded', 'unshielded', 'dust', 'history'] as const) {
+      await store.put(syncStateKey(NETWORK, 'alice', part), 'state');
+    }
+    await store.put(syncStateKey(NETWORK, 'alice#ecdsa', 'unshielded'), 'state');
+    await store.put(syncStateKey(NETWORK, 'bob', 'shielded'), 'state');
+
+    await clearSyncCache('alice', NETWORK, store);
+
+    for (const part of ['shielded', 'unshielded', 'dust', 'history'] as const) {
+      expect(await store.get(syncStateKey(NETWORK, 'alice', part))).toBeNull();
+    }
+    expect(await store.get(syncStateKey(NETWORK, 'alice#ecdsa', 'unshielded'))).toBeNull();
+    expect(await store.get(syncStateKey(NETWORK, 'bob', 'shielded'))).toBe('state');
+  });
+});

--- a/packages/extension/README.md
+++ b/packages/extension/README.md
@@ -82,6 +82,13 @@ the release tag manually.
 
 - **tsconfig deviation:** this package extends WXT's generated `.wxt/tsconfig.json` (path aliases, extension globals) instead of the repo's `tsconfig.base.json` — the base config's `rootDir`/`outDir`/`declaration` assumptions don't fit a Vite-bundled app. Run `yarn workspace @shieldedtech/moth-extension compile` for a typecheck.
 - Wallet keys live encrypted (ChaCha20-Poly1305) in IndexedDB via `@shieldedtech/moth-browser`; the unlocked seed is held only in `browser.storage.session` (memory-backed, cleared when the browser exits). Locking is explicit — lock button, account removal, network switch; there is no inactivity auto-lock for now (its timer used to kill a sync in progress).
+- **Settings → Network → Clear cache and resync** forgets everything synced for
+  the active account on its network — sync state, cached balances, pending
+  activity, and the network's pre-seed reference — and syncs again from genesis.
+  It is the recovery for a local devnet that was taken down and brought back up
+  as a new chain: every cached artefact then describes a chain that no longer
+  exists, and the sync engine cannot tell. Nothing is spent; on the new chain the
+  balance simply reflects what that chain holds.
 - The proving method selected under Settings → Network is used for wallet and
   dApp transactions. Local WASM proving is recommended for simple transactions,
   such as token transfers. Complex transactions, such as contract calls, require

--- a/packages/extension/components/screens/Settings.tsx
+++ b/packages/extension/components/screens/Settings.tsx
@@ -298,7 +298,7 @@ export function Settings({ onBack, navigate }: { onBack: () => void; navigate: (
           <span className="min-w-0 pr-3">
             <span className="block text-sm font-medium">{t('settings_resync')}</span>
             <span className="block text-[12.5px] text-muted-foreground">
-              {t('settings_resyncDescription', [networkLabel(settings.network)])}
+              {t('settings_resyncDescription')}
             </span>
           </span>
           <Button size="sm" variant="secondary" className="shrink-0" onClick={() => setConfirmingResync(true)}>

--- a/packages/extension/components/screens/Settings.tsx
+++ b/packages/extension/components/screens/Settings.tsx
@@ -15,6 +15,7 @@ import { cn } from '../../lib/ui/cn';
 import { Card, Separator } from '../ui/card';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
+import { DialogShell } from '../ui/dialog';
 import { PanelScreen, PanelHeader } from '../moth/panel';
 import { networkLabel } from './NetworkConfig';
 import { preseedControl } from '../../lib/ui/preseed-control';
@@ -57,6 +58,27 @@ export function Settings({ onBack, navigate }: { onBack: () => void; navigate: (
   const [resolverDraft, setResolverDraft] = useState('');
   const [appearance, setAppearance] = useState<Appearance>(() => loadAppearance());
   const [copiedDiagnostics, setCopiedDiagnostics] = useState(false);
+  // "Clear cache and resync": confirm first, because it discards an hour of
+  // sync on a slow network even though it moves no funds.
+  const [confirmingResync, setConfirmingResync] = useState(false);
+  const [resyncing, setResyncing] = useState(false);
+  const [resyncError, setResyncError] = useState<string | null>(null);
+
+  const resync = async () => {
+    setResyncing(true);
+    setResyncError(null);
+    try {
+      await sendMessage('resyncFromScratch', undefined);
+      setConfirmingResync(false);
+      // The background dropped the snapshot, so the router shows the loading
+      // screen for the fresh sync as soon as we leave Settings.
+      navigate('home');
+    } catch {
+      setResyncError(t('settings_resyncError'));
+    } finally {
+      setResyncing(false);
+    }
+  };
 
   const updateAppearance = (patch: Partial<Appearance>) => {
     const next = { ...appearance, ...patch };
@@ -274,6 +296,17 @@ export function Settings({ onBack, navigate }: { onBack: () => void; navigate: (
         )}
         <div className="flex items-center justify-between px-4 py-[13px]">
           <span className="min-w-0 pr-3">
+            <span className="block text-sm font-medium">{t('settings_resync')}</span>
+            <span className="block text-[12.5px] text-muted-foreground">
+              {t('settings_resyncDescription', [networkLabel(settings.network)])}
+            </span>
+          </span>
+          <Button size="sm" variant="secondary" className="shrink-0" onClick={() => setConfirmingResync(true)}>
+            {t('settings_resyncButton')}
+          </Button>
+        </div>
+        <div className="flex items-center justify-between px-4 py-[13px]">
+          <span className="min-w-0 pr-3">
             <span className="block text-sm font-medium">{t('settings_developerMode')}</span>
             <span className="block text-[12.5px] text-muted-foreground">
               {t('settings_developerModeDescription')}
@@ -401,6 +434,31 @@ export function Settings({ onBack, navigate }: { onBack: () => void; navigate: (
       <p className="m-0 pb-2 text-center text-xs text-muted-foreground">
         {t('settings_version', [browser.runtime.getManifest().version])}
       </p>
+
+      <DialogShell
+        open={confirmingResync}
+        onOpenChange={(open) => {
+          if (!resyncing) setConfirmingResync(open);
+        }}
+        title={t('settings_resyncTitle')}
+        actions={
+          <>
+            <Button variant="outline" disabled={resyncing} onClick={() => setConfirmingResync(false)}>
+              {t('common_cancel')}
+            </Button>
+            <Button loading={resyncing} onClick={() => void resync()}>
+              {resyncing ? t('settings_resyncWorking') : t('settings_resyncConfirm')}
+            </Button>
+          </>
+        }
+      >
+        <p className="m-0">{t('settings_resyncBody', [networkLabel(settings.network)])}</p>
+        {resyncError && (
+          <p className="mb-0 mt-3 text-destructive" role="alert">
+            {resyncError}
+          </p>
+        )}
+      </DialogShell>
     </PanelScreen>
   );
 }

--- a/packages/extension/lib/background/handlers.ts
+++ b/packages/extension/lib/background/handlers.ts
@@ -220,6 +220,40 @@ export async function saveNetworkConfig(data: {
 }
 
 /**
+ * Drop everything cached for the unlocked account on its network and sync again
+ * from genesis. The recovery for a local devnet that went down and came back as
+ * a new chain: the cached sync state, pending submissions and the network's
+ * pre-seed reference all describe the old chain, and the engine has no way to
+ * notice on its own beyond failing in ways that name none of this.
+ *
+ * Same shape as the indexer-change branch of saveNetworkConfig — stop, clear,
+ * drop the snapshot so the panel shows the loading screen, restart — and, like
+ * it, bracketed as one op so idle teardown cannot close the offscreen document
+ * between the clear and the restart. Nothing is spent and nothing on chain
+ * changes.
+ */
+export async function resyncFromScratch(): Promise<void> {
+  const session = await getSession();
+  if (!session) throw new Error('Wallet is locked');
+  const network = await getNetworkConfig();
+
+  beginOp();
+  try {
+    await stopSync();
+    try {
+      await offscreen.syncCacheReset({ walletName: session.walletName, network });
+      await clearSnapshot();
+    } finally {
+      // Whether the clear succeeded or not, the engine must come back: a wallet
+      // left stopped looks exactly like a wallet that is stuck.
+      void startSync(session, network).catch(broadcastSyncFailure);
+    }
+  } finally {
+    endOp();
+  }
+}
+
+/**
  * Close the transaction timeline.
  *
  * `tx: submitting` is emitted before submitWithRetry, and nothing was recorded
@@ -548,6 +582,8 @@ export function registerHandlers(): void {
       return null;
     }
   });
+
+  onMessage('resyncFromScratch', () => resyncFromScratch());
 
   // Spends nothing, but brackets the op anyway: it stops and restarts the sync
   // engine, and the service worker must not suspend underneath that.

--- a/packages/extension/lib/background/offscreen-client.ts
+++ b/packages/extension/lib/background/offscreen-client.ts
@@ -160,6 +160,10 @@ export const offscreen = {
     await ensureOffscreen();
     return offscreenSend('os/syncCacheClear', data);
   },
+  async syncCacheReset(data: { walletName: string; network: NetworkConfig }) {
+    await ensureOffscreen();
+    return offscreenSend('os/syncCacheReset', data);
+  },
   async balancesGet(data: SyncTarget) {
     await ensureOffscreen();
     return offscreenSend('os/balancesGet', data);

--- a/packages/extension/lib/i18n/messages/settings.ts
+++ b/packages/extension/lib/i18n/messages/settings.ts
@@ -29,6 +29,16 @@ export const settings = {
   settings_preseedWarmingDescriptionOn:
     'Preparing $1 in the background. It takes about an hour and continues whenever the wallet is open. Accounts created after it finishes start in seconds.',
   settings_networkConfig: 'Network config',
+  settings_resync: 'Clear cache and resync',
+  settings_resyncDescription:
+    'Forget everything synced for this account on $1 and scan the chain again from the start. Use it after a local network was reset.',
+  settings_resyncButton: 'Clear',
+  settings_resyncTitle: 'Clear cache and resync?',
+  settings_resyncBody:
+    'Moth deletes this account\u2019s synced state, cached balances, pending activity and the prepared reference for $1, then syncs from the beginning of the chain. Nothing on chain changes and your funds stay where they are. On a network that was reset, the balance will reflect the new chain.',
+  settings_resyncConfirm: 'Clear & resync',
+  settings_resyncWorking: 'Clearing\u2026',
+  settings_resyncError: 'Could not clear the cache. Try again.',
   settings_sectionSecurity: 'Security',
   settings_autoLock: 'Auto-lock',
   settings_autoLockDemo: 'The wallet never locks itself on its own.',

--- a/packages/extension/lib/i18n/messages/settings.ts
+++ b/packages/extension/lib/i18n/messages/settings.ts
@@ -31,7 +31,7 @@ export const settings = {
   settings_networkConfig: 'Network config',
   settings_resync: 'Clear cache and resync',
   settings_resyncDescription:
-    'Forget everything synced for this account on $1 and scan the chain again from the start. Use it after a local network was reset.',
+    'Forget everything synced for this account on the current chain and scan the chain again from the start.',
   settings_resyncButton: 'Clear',
   settings_resyncTitle: 'Clear cache and resync?',
   settings_resyncBody:

--- a/packages/extension/lib/messaging/protocol.ts
+++ b/packages/extension/lib/messaging/protocol.ts
@@ -297,6 +297,13 @@ interface ProtocolMap {
    *  stream over the port. */
   deregisterDust(): { txHash: string };
 
+  /** Forget everything synced for the unlocked account on its network — sync
+   *  state, cached balances, pending activity, and the network's prepared
+   *  reference — and sync again from the start of the chain. For a local
+   *  network that was brought back up from genesis, where the cached state
+   *  describes a chain that no longer exists. Spends nothing. */
+  resyncFromScratch(): void;
+
   /** Rebuild the local DUST view: evict the dust sync cache and rescan. Spends
    *  nothing. `started` is false when a transaction was in flight. */
 

--- a/packages/extension/lib/offscreen/host-dispatch.ts
+++ b/packages/extension/lib/offscreen/host-dispatch.ts
@@ -41,6 +41,7 @@ export const hostDispatch: Dispatch = {
   },
   'os/syncStop': (host) => host.syncStop(),
   'os/syncCacheClear': (host, d) => host.syncCacheClear(d.walletName, d.networkIds),
+  'os/syncCacheReset': (host, d) => host.syncCacheReset(d.walletName, d.network),
   'os/balancesGet': (host, d) => host.balancesGet(d.seedHex, d.walletName, d.network),
   'os/sendTokens': (host, d) => host.sendTokens(d.seedHex, d.walletName, d.network, d.requests),
   'os/estimateTransferFee': (host, d) =>

--- a/packages/extension/lib/offscreen/messaging.ts
+++ b/packages/extension/lib/offscreen/messaging.ts
@@ -149,6 +149,12 @@ export interface OffscreenProtocol {
   'os/syncStop'(): void;
   /** Clear persisted sync state after the running engine has stopped. */
   'os/syncCacheClear'(data: { walletName: string; networkIds: string[] }): void;
+  /** Forget everything cached for this account on this network and start over:
+   *  the account's sync state (every part, every identity), its pending
+   *  submissions, and the network's pre-seed reference — store and in-process
+   *  memo. For a local chain restarted from genesis, where all of it describes a
+   *  chain that no longer exists. Stops the engine first; the caller restarts it. */
+  'os/syncCacheReset'(data: { walletName: string; network: NetworkConfig }): void;
 
   /** Ensure sync, wait for a synced snapshot, and return serialized balances. */
   'os/balancesGet'(data: { seedHex: string; walletName: string; network: NetworkConfig }): string;

--- a/packages/extension/lib/offscreen/wallet-host.ts
+++ b/packages/extension/lib/offscreen/wallet-host.ts
@@ -23,6 +23,7 @@ import {
   deriveWalletKeys,
   clearSyncCache,
   clearDustSyncCache,
+  clearEmptyRefCache,
   warmEmptyRefCache,
   preseedReferenceStatus,
   DustRegistrationNotYetError,
@@ -505,6 +506,19 @@ export async function syncCacheClear(walletName: string, networkIds: string[]): 
     // not revive pending rows for a chain state the user explicitly cleared.
     await store.delete(submissionsKey(networkId, walletName)).catch(() => {});
   }
+}
+
+// Everything syncCacheClear drops, plus what it deliberately leaves alone: the
+// network's pre-seed reference. A wallet-scoped clear keeps the reference because
+// it is still right for the chain — but when a local chain came back from
+// genesis, the reference describes the old chain and every fresh sync would be
+// seeded from it. The DUST-heal stamp goes too, so the rebuild heuristic starts
+// from a clean slate on the new chain.
+export async function syncCacheReset(walletName: string, network: NetworkConfig): Promise<void> {
+  await syncCacheClear(walletName, [network.id]);
+  const store = new IdbSyncStateStore();
+  await clearEmptyRefCache(network.id, store);
+  await store.delete(dustHealKey(network.id, walletName)).catch(() => {});
 }
 
 export async function balancesGet(

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1149,7 +1149,7 @@
     "message": "Cache leeren und neu synchronisieren"
   },
   "settings_resyncDescription": {
-    "message": "Alles vergessen, was für dieses Konto auf $1 synchronisiert wurde, und die Chain von Anfang an neu scannen. Nützlich, nachdem ein lokales Netzwerk zurückgesetzt wurde."
+    "message": "Alles vergessen, was für dieses Konto auf der aktuellen Chain synchronisiert wurde, und die Chain von Anfang an neu scannen."
   },
   "settings_resyncButton": {
     "message": "Leeren"

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1145,6 +1145,30 @@
   "settings_networkConfig": {
     "message": "Netzwerkkonfiguration"
   },
+  "settings_resync": {
+    "message": "Cache leeren und neu synchronisieren"
+  },
+  "settings_resyncDescription": {
+    "message": "Alles vergessen, was für dieses Konto auf $1 synchronisiert wurde, und die Chain von Anfang an neu scannen. Nützlich, nachdem ein lokales Netzwerk zurückgesetzt wurde."
+  },
+  "settings_resyncButton": {
+    "message": "Leeren"
+  },
+  "settings_resyncTitle": {
+    "message": "Cache leeren und neu synchronisieren?"
+  },
+  "settings_resyncBody": {
+    "message": "Moth löscht den synchronisierten Zustand dieses Kontos, zwischengespeicherte Guthaben, ausstehende Aktivitäten und die vorbereitete Referenz für $1 und synchronisiert dann vom Anfang der Chain. Auf der Chain ändert sich nichts, dein Guthaben bleibt, wo es ist. Bei einem zurückgesetzten Netzwerk zeigt das Guthaben die neue Chain."
+  },
+  "settings_resyncConfirm": {
+    "message": "Leeren & neu synchronisieren"
+  },
+  "settings_resyncWorking": {
+    "message": "Wird geleert…"
+  },
+  "settings_resyncError": {
+    "message": "Der Cache konnte nicht geleert werden. Versuche es erneut."
+  },
   "settings_sectionSecurity": {
     "message": "Sicherheit"
   },

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1145,6 +1145,30 @@
   "settings_networkConfig": {
     "message": "Configuración de red"
   },
+  "settings_resync": {
+    "message": "Borrar caché y resincronizar"
+  },
+  "settings_resyncDescription": {
+    "message": "Olvida todo lo sincronizado para esta cuenta en $1 y vuelve a escanear la cadena desde el principio. Úsalo después de reiniciar una red local."
+  },
+  "settings_resyncButton": {
+    "message": "Borrar"
+  },
+  "settings_resyncTitle": {
+    "message": "¿Borrar caché y resincronizar?"
+  },
+  "settings_resyncBody": {
+    "message": "Moth elimina el estado sincronizado de esta cuenta, los saldos en caché, la actividad pendiente y la referencia preparada para $1, y luego sincroniza desde el inicio de la cadena. Nada cambia en la cadena y tus fondos siguen donde están. En una red reiniciada, el saldo reflejará la nueva cadena."
+  },
+  "settings_resyncConfirm": {
+    "message": "Borrar y resincronizar"
+  },
+  "settings_resyncWorking": {
+    "message": "Borrando…"
+  },
+  "settings_resyncError": {
+    "message": "No se pudo borrar la caché. Inténtalo de nuevo."
+  },
   "settings_sectionSecurity": {
     "message": "Seguridad"
   },

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1149,7 +1149,7 @@
     "message": "Borrar caché y resincronizar"
   },
   "settings_resyncDescription": {
-    "message": "Olvida todo lo sincronizado para esta cuenta en $1 y vuelve a escanear la cadena desde el principio. Úsalo después de reiniciar una red local."
+    "message": "Olvida todo lo sincronizado para esta cuenta en la cadena actual y vuelve a escanear la cadena desde el principio."
   },
   "settings_resyncButton": {
     "message": "Borrar"

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1149,7 +1149,7 @@
     "message": "Vider le cache et resynchroniser"
   },
   "settings_resyncDescription": {
-    "message": "Oublier tout ce qui a été synchronisé pour ce compte sur $1 et parcourir de nouveau la chaîne depuis le début. À utiliser après la réinitialisation d’un réseau local."
+    "message": "Oublier tout ce qui a été synchronisé pour ce compte sur la chaîne actuelle et parcourir de nouveau la chaîne depuis le début."
   },
   "settings_resyncButton": {
     "message": "Vider"

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1145,6 +1145,30 @@
   "settings_networkConfig": {
     "message": "Configuration réseau"
   },
+  "settings_resync": {
+    "message": "Vider le cache et resynchroniser"
+  },
+  "settings_resyncDescription": {
+    "message": "Oublier tout ce qui a été synchronisé pour ce compte sur $1 et parcourir de nouveau la chaîne depuis le début. À utiliser après la réinitialisation d’un réseau local."
+  },
+  "settings_resyncButton": {
+    "message": "Vider"
+  },
+  "settings_resyncTitle": {
+    "message": "Vider le cache et resynchroniser ?"
+  },
+  "settings_resyncBody": {
+    "message": "Moth supprime l’état synchronisé de ce compte, les soldes en cache, l’activité en attente et la référence préparée pour $1, puis synchronise depuis le début de la chaîne. Rien ne change sur la chaîne et vos fonds restent où ils sont. Sur un réseau réinitialisé, le solde reflétera la nouvelle chaîne."
+  },
+  "settings_resyncConfirm": {
+    "message": "Vider et resynchroniser"
+  },
+  "settings_resyncWorking": {
+    "message": "Vidage…"
+  },
+  "settings_resyncError": {
+    "message": "Impossible de vider le cache. Réessayez."
+  },
   "settings_sectionSecurity": {
     "message": "Sécurité"
   },

--- a/packages/extension/tests/resync.test.ts
+++ b/packages/extension/tests/resync.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fakeBrowser } from 'wxt/testing';
+
+const syncCacheReset = vi.fn<() => Promise<void>>();
+vi.mock('../lib/background/offscreen-client', () => ({
+  offscreen: {
+    syncCacheReset: (...args: unknown[]) => syncCacheReset(...(args as [])),
+  },
+}));
+
+const stopSync = vi.fn<() => Promise<void>>();
+const clearSnapshot = vi.fn<() => Promise<void>>();
+const startSync = vi.fn<() => Promise<void>>();
+const broadcastSyncFailure = vi.fn();
+const beginOp = vi.fn();
+const endOp = vi.fn();
+vi.mock('../lib/background/sync-service', () => ({
+  stopSync: () => stopSync(),
+  clearSnapshot: () => clearSnapshot(),
+  startSync: (...args: unknown[]) => startSync(...(args as [])),
+  broadcastSyncFailure: (error: unknown) => broadcastSyncFailure(error),
+  getSnapshot: vi.fn(),
+  beginOp: () => beginOp(),
+  endOp: () => endOp(),
+  hasOpenPorts: vi.fn(() => true),
+  hasWorkInFlight: vi.fn(() => false),
+  broadcastSessionLocked: vi.fn(),
+  getSetupTabIds: vi.fn(() => []),
+  teardown: vi.fn(),
+}));
+
+import { resyncFromScratch } from '../lib/background/handlers';
+import { saveSession, type Session } from '../lib/background/session';
+import { updateSettings } from '../lib/background/settings';
+
+const SESSION: Session = {
+  walletName: 'alice',
+  seedHex: 'ab'.repeat(32),
+  address: 'mn_unshielded_undeployed',
+  addresses: {
+    nightExternal: { hex: '', bech32m: { undeployed: 'mn_unshielded_undeployed' } },
+  } as unknown as Session['addresses'],
+  shieldedCoinPublicKey: 'c0'.repeat(16),
+  shieldedEncryptionPublicKey: 'e0'.repeat(16),
+  network: 'undeployed',
+  unlockedAt: 1,
+};
+
+describe('resyncFromScratch', () => {
+  beforeEach(async () => {
+    fakeBrowser.reset();
+    syncCacheReset.mockReset().mockResolvedValue(undefined);
+    stopSync.mockReset().mockResolvedValue(undefined);
+    clearSnapshot.mockReset().mockResolvedValue(undefined);
+    startSync.mockReset().mockResolvedValue(undefined);
+    broadcastSyncFailure.mockReset();
+    beginOp.mockReset();
+    endOp.mockReset();
+    await updateSettings({ network: 'undeployed', customEndpoints: null });
+    await saveSession(SESSION);
+  });
+
+  it('stops, clears the account and network caches, drops the snapshot, then restarts sync', async () => {
+    await resyncFromScratch();
+
+    expect(stopSync).toHaveBeenCalledTimes(1);
+    expect(syncCacheReset).toHaveBeenCalledWith({
+      walletName: 'alice',
+      network: expect.objectContaining({ id: 'undeployed' }),
+    });
+    expect(clearSnapshot).toHaveBeenCalledTimes(1);
+    expect(startSync).toHaveBeenCalledWith(
+      expect.objectContaining({ walletName: 'alice', network: 'undeployed' }),
+      expect.objectContaining({ id: 'undeployed' }),
+    );
+
+    // Order matters: the engine writes its final state on stop, so a clear that
+    // ran first would be undone; and the panel must see the reset before the
+    // new sync's first balances arrive.
+    const order = [stopSync, syncCacheReset, clearSnapshot, startSync].map((fn) => fn.mock.invocationCallOrder[0]!);
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+  });
+
+  it('brackets the whole reset as one in-flight op so idle teardown cannot interrupt it', async () => {
+    await resyncFromScratch();
+    expect(beginOp).toHaveBeenCalledTimes(1);
+    expect(endOp).toHaveBeenCalledTimes(1);
+    expect(beginOp.mock.invocationCallOrder[0]!).toBeLessThan(stopSync.mock.invocationCallOrder[0]!);
+    expect(endOp.mock.invocationCallOrder[0]!).toBeGreaterThan(startSync.mock.invocationCallOrder[0]!);
+  });
+
+  it('restarts sync even when the clear fails, and surfaces the failure', async () => {
+    syncCacheReset.mockRejectedValue(new Error('IndexedDB unavailable'));
+
+    await expect(resyncFromScratch()).rejects.toThrow('IndexedDB unavailable');
+    expect(startSync).toHaveBeenCalledTimes(1);
+    expect(clearSnapshot).not.toHaveBeenCalled();
+    expect(endOp).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses when the wallet is locked, touching nothing', async () => {
+    fakeBrowser.reset();
+    await updateSettings({ network: 'undeployed', customEndpoints: null });
+
+    await expect(resyncFromScratch()).rejects.toThrow('Wallet is locked');
+    expect(stopSync).not.toHaveBeenCalled();
+    expect(syncCacheReset).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/tests/wallet-host-unlock.test.ts
+++ b/packages/extension/tests/wallet-host-unlock.test.ts
@@ -37,6 +37,7 @@ vi.mock('@shieldedtech/moth-browser', () => ({
   deriveWalletKeys: vi.fn(),
   clearSyncCache: vi.fn(),
   clearDustSyncCache: vi.fn(),
+  clearEmptyRefCache: vi.fn(),
   signMessage: vi.fn(),
   deriveActivity: vi.fn(),
   IdbSyncStateStore: class {},

--- a/packages/extension/tests/worker-rpc.test.ts
+++ b/packages/extension/tests/worker-rpc.test.ts
@@ -66,6 +66,7 @@ describe('HOST_METHODS', () => {
     'os/syncEnsure',
     'os/syncStop',
     'os/syncCacheClear',
+    'os/syncCacheReset',
     'os/balancesGet',
     'os/sendTokens',
     'os/estimateTransferFee',


### PR DESCRIPTION
## Problem

When a local Midnight network goes down and comes back up as a new chain from genesis, Moth "completely freaks out": every cached artefact — the account's synced state, its pending submissions, and the network's pre-seed reference that fresh syncs are seeded from — still describes the old chain, and the sync engine has no way to notice on its own. The only existing ways out were changing the indexer URL (which happens to trigger a resync) or removing and recreating the account.

## Change

Settings → Network gains **Clear cache and resync**, behind a confirmation dialog naming the network being cleared:

> Forget everything synced for this account on the current chain and scan the chain again from the start.

It works on any network — devnet, a testnet, or mainnet — not only a local one; nothing here is undeployed-specific.

Confirming:
1. Stops the sync engine.
2. Asks the offscreen host to drop everything for the active account on its network (`os/syncCacheReset`): sync state for every part and cache identity, pending submissions, the DUST-heal stamp, and the network's pre-seed reference (state, height, cursor witnesses, mnemonic, and the in-process memo — without clearing the memo, a worker that had already verified the reference would keep handing the stale one out).
3. Clears the cached balance snapshot so the panel shows the loading screen instead of stale numbers.
4. Restarts sync from genesis — even if the clear itself failed, so the wallet never ends up stopped and looking stuck.

The whole sequence is bracketed as one in-flight op so idle teardown can't close the offscreen document mid-reset.

Nothing is spent and nothing on chain changes.

### Core changes

- `clearEmptyRefCache(networkId, store)` in `sync/preseed.ts` — the piece a wallet-scoped clear alone can't reach.
- `clearSyncCache` now also evicts the ECDSA unshielded cache identity, which it previously left behind for wallets of that kind (found while wiring the reset).

## Tests

- `packages/core/tests/unit/sync/cache-reset.test.ts` — reference clear removes all parts/height/witnesses/mnemonic for the target network only, leaves the network with no usable reference, no-ops on a network never seen, and `clearSyncCache` evicts both cache identities.
- `packages/extension/tests/resync.test.ts` — stop → clear → snapshot-drop → restart ordering, op bracketing, sync restarts even when the clear fails (and the failure still surfaces), and the locked-wallet case touches nothing.
- Full suites: core 396 pass, extension 444 pass. `npm run compile` and `wxt build` succeed.

## Manual verification

Tested locally against a local stack: took the network down, brought it back up as a new chain from genesis, ran Clear from Settings, and confirmed the wallet resynced from the new chain rather than getting stuck on stale state.

Stacked on #118 (`feat/balance-approval-shows-spend`); the diff here is two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
