### PR TITLE
fix(sync): stop the dedup filter punching holes in a replay

### DIFF
--- a/.changeset/dedup-nonlinear-insert.md
+++ b/.changeset/dedup-nonlinear-insert.md
@@ -1,0 +1,44 @@
+---
+'@shieldedtech/moth-wallet': patch
+---
+
+Stop the dedup filter from punching holes in a replay, and say what a non-linear
+insert actually means.
+
+`partitionByAppliedIndex` filtered the whole batch by predicate, dropping every
+event with `id <= appliedIndex` wherever it sat. For an ascending batch that is
+the intended boundary-duplicate filter. For an out-of-order one it removes an
+already-applied event from the *middle* and hands the SDK a replay with a gap —
+and the ledger tree then rejects the insert:
+
+```
+values inserted non-linearly into dust generation tree;
+expected to insert index 337423, but received 337429.
+```
+
+Note the direction: the SDK bug this wrapper exists to work around re-sends a
+boundary event, so the tree receives an index *lower* than it expects. This is
+the mirror image — an index *higher* than expected, because events the tree
+needed never arrived. The workaround for one could produce the other, and only
+for the part whose cursor and tree had drifted apart, which is why a single
+sub-wallet would stall while the others finished.
+
+The filter now drops only a leading contiguous run of already-applied events.
+When an already-applied id appears after a fresh one the batch is not the
+ascending stream the filter assumes, so nothing is dropped and the SDK's own
+(more conservative) handling decides. The existing test named "drops only the
+already-applied prefix" described this behaviour already; the implementation now
+matches it.
+
+Non-linear insert failures are also no longer bare WASM strings surfacing four
+layers down with no mention of sync state. They now carry the cursor and batch
+that produced them and say that retrying cannot help — the same batch replays
+from the same cursor forever — and that the fix is to clear that part's cache:
+
+```
+appliedIndex=1291234, replayed 2 event(s) 1291235..1291240,
+0 dropped as already applied. Clear this wallet part's sync cache and resync.
+```
+
+The original error is preserved as `cause`. Unrelated errors pass through
+untouched.

--- a/packages/core/src/sync/sdk-dedup.ts
+++ b/packages/core/src/sync/sdk-dedup.ts
@@ -62,12 +62,64 @@ interface Capability<S, U> {
 function partitionByAppliedIndex<U extends Updateish>(
   updates: ReadonlyArray<U>,
   appliedIndex: bigint,
-): {fresh: ReadonlyArray<U>; droppedCount: number} {
-  const fresh: U[] = [];
-  for (const u of updates) {
-    if (BigInt(u.id) > appliedIndex) fresh.push(u);
+): {fresh: ReadonlyArray<U>; droppedCount: number; outOfOrder: boolean} {
+  // Prefix only. The previous form filtered the whole array by predicate, which
+  // for an out-of-order batch removes an already-applied event from the MIDDLE
+  // and hands the SDK a replay with a hole in it — the ledger tree then rejects
+  // the insert as non-linear, four layers down, naming none of this.
+  let i = 0;
+  while (i < updates.length && BigInt(updates[i]!.id) <= appliedIndex) i++;
+  const fresh = updates.slice(i);
+  // An already-applied id after the first fresh one means this batch is not the
+  // ascending stream the filter assumes, so its result cannot be trusted.
+  const outOfOrder = fresh.some((u) => BigInt(u.id) <= appliedIndex);
+  return {fresh, droppedCount: i, outOfOrder};
+}
+
+const NON_LINEAR = /inserted non-linearly/i;
+
+/**
+ * Turn the ledger's bare non-linear-insert message into something that names
+ * the cause and the way out.
+ *
+ * The tree rejects the insert because the events it needed never reached it.
+ * Retrying cannot help — the same batch replays from the same cursor — so a
+ * wallet in this state loops on one error forever. The cursor and batch shape
+ * are the evidence for which side dropped them, so they go in the message.
+ */
+function enrichNonLinear<U extends Updateish>(
+  err: unknown,
+  ctx: {appliedIndex: bigint; updates: ReadonlyArray<U>; droppedCount: number},
+): unknown {
+  const message = err instanceof Error ? err.message : String(err);
+  if (!NON_LINEAR.test(message)) return err;
+  const ids = ctx.updates.map((u) => BigInt(u.id));
+  const range = ids.length === 0 ? '(empty batch)' : `${ids[0]}..${ids[ids.length - 1]}`;
+  const enriched = new Error(
+    `${message}\n` +
+      `The sync cache is inconsistent with the event stream and will not recover on ` +
+      `retry — the same batch replays from the same cursor. ` +
+      `appliedIndex=${ctx.appliedIndex}, replayed ${ids.length} event(s) ${range}, ` +
+      `${ctx.droppedCount} dropped as already applied. ` +
+      `Clear this wallet part's sync cache and resync to recover.`,
+  );
+  (enriched as Error & {cause?: unknown}).cause = err;
+  return enriched;
+}
+
+/** Call the SDK, enriching a non-linear-insert failure with the cursor context. */
+function applyGuarded<S, U extends Updateish>(
+  base: Capability<S, U>,
+  state: S & {progress: {appliedIndex: bigint}},
+  wrapped: WrappedUpdate<U>,
+  updates: ReadonlyArray<U>,
+  droppedCount: number,
+): readonly [S, {changes: unknown[]; protocolVersion: number}] {
+  try {
+    return base.applyUpdate(state, updates === wrapped.updates ? wrapped : {...wrapped, updates});
+  } catch (err) {
+    throw enrichNonLinear(err, {appliedIndex: state.progress.appliedIndex, updates, droppedCount});
   }
-  return {fresh, droppedCount: updates.length - fresh.length};
 }
 
 function makeDedupingApplyUpdate<S extends {progress: {appliedIndex: bigint; [k: string]: unknown}; protocolVersion: number | bigint}, U extends Updateish>(
@@ -79,11 +131,21 @@ function makeDedupingApplyUpdate<S extends {progress: {appliedIndex: bigint; [k:
       return base.applyUpdate(state, wrapped);
     }
 
-    const {fresh, droppedCount} = partitionByAppliedIndex(wrapped.updates, state.progress.appliedIndex);
+    const {fresh, droppedCount, outOfOrder} = partitionByAppliedIndex(
+      wrapped.updates,
+      state.progress.appliedIndex,
+    );
+
+    if (outOfOrder) {
+      // Not the ascending stream this filter assumes. Dropping a mid-batch event
+      // here is what creates the hole the tree rejects, so drop nothing and let
+      // the SDK decide — its own skip path is the conservative one.
+      return applyGuarded(base, state, wrapped, wrapped.updates, 0);
+    }
 
     if (droppedCount === 0) {
       // No duplicates — fast path, defer entirely to the SDK.
-      return base.applyUpdate(state, wrapped);
+      return applyGuarded(base, state, wrapped, wrapped.updates, 0);
     }
 
     if (fresh.length === 0) {
@@ -100,7 +162,7 @@ function makeDedupingApplyUpdate<S extends {progress: {appliedIndex: bigint; [k:
 
     // Partial overlap — hand only the fresh suffix to the SDK so its
     // own appliedIndex advancement still reflects the batch tail.
-    return base.applyUpdate(state, {...wrapped, updates: fresh});
+    return applyGuarded(base, state, wrapped, fresh, droppedCount);
   };
 }
 
@@ -177,4 +239,5 @@ export function dedupingDustBuilder(): unknown {
 export const __TEST_ONLY__ = {
   partitionByAppliedIndex,
   makeDedupingApplyUpdate,
+  enrichNonLinear,
 };

--- a/packages/core/tests/unit/sync/sdk-dedup.test.ts
+++ b/packages/core/tests/unit/sync/sdk-dedup.test.ts
@@ -122,3 +122,96 @@ describe('makeDedupingApplyUpdate', () => {
     expect(base.applyUpdate).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('out-of-order batches (regression: dust generation tree hole)', () => {
+  const makeState = (appliedIndex: bigint): FakeState => ({
+    progress: {appliedIndex},
+    protocolVersion: 1,
+  });
+
+  it('flags a batch whose already-applied event follows a fresh one', () => {
+    // Filtering by predicate would remove id 3 from the MIDDLE and hand the SDK
+    // [5, 7] — a replay with a hole the ledger tree rejects as non-linear.
+    const r = partitionByAppliedIndex(
+      [{id: 5, maxId: 10}, {id: 3, maxId: 10}, {id: 7, maxId: 10}],
+      4n,
+    );
+    expect(r.outOfOrder).toBe(true);
+    expect(r.droppedCount).toBe(0);
+  });
+
+  it('does not filter an out-of-order batch — forwards it whole to the SDK', () => {
+    const batch = [{id: 5, maxId: 10}, {id: 3, maxId: 10}, {id: 7, maxId: 10}];
+    const base = {applyUpdate: vi.fn().mockReturnValue([makeState(7n), {changes: [], protocolVersion: 1}])};
+    const apply = makeDedupingApplyUpdate(base as never, (st) => st);
+
+    apply(makeState(4n), {updates: batch} as never);
+
+    expect(base.applyUpdate).toHaveBeenCalledTimes(1);
+    const forwarded = base.applyUpdate.mock.calls[0]![1] as {updates: unknown[]};
+    expect(forwarded.updates).toHaveLength(3);
+  });
+
+  it('reports outOfOrder false for an ascending batch', () => {
+    const r = partitionByAppliedIndex([{id: 3, maxId: 9}, {id: 5, maxId: 9}], 4n);
+    expect(r.outOfOrder).toBe(false);
+    expect(r.fresh.map((u) => Number(u.id))).toEqual([5]);
+  });
+});
+
+describe('non-linear insert errors', () => {
+  const makeState = (appliedIndex: bigint): FakeState => ({
+    progress: {appliedIndex},
+    protocolVersion: 1,
+  });
+
+  const LEDGER_ERROR =
+    'values inserted non-linearly into dust generation tree; ' +
+    'expected to insert index 337423, but received 337429.';
+
+  it('explains the failure and names the recovery, preserving the cause', () => {
+    const original = new Error(LEDGER_ERROR);
+    const base = {applyUpdate: vi.fn().mockImplementation(() => { throw original; })};
+    const apply = makeDedupingApplyUpdate(base as never, (st) => st);
+
+    let thrown: unknown;
+    try {
+      apply(makeState(1291234n), {
+        updates: [{id: 1291235, maxId: 1478078}, {id: 1291240, maxId: 1478078}],
+      } as never);
+    } catch (e) {
+      thrown = e;
+    }
+
+    const err = thrown as Error & {cause?: unknown};
+    expect(err.message).toContain(LEDGER_ERROR);
+    expect(err.message).toContain('will not recover on retry');
+    expect(err.message).toContain('appliedIndex=1291234');
+    expect(err.message).toContain('1291235..1291240');
+    expect(err.message).toContain('Clear this wallet part');
+    expect(err.cause).toBe(original);
+  });
+
+  it('leaves unrelated errors untouched', () => {
+    const original = new Error('indexer connection reset');
+    const base = {applyUpdate: vi.fn().mockImplementation(() => { throw original; })};
+    const apply = makeDedupingApplyUpdate(base as never, (st) => st);
+
+    expect(() => apply(makeState(5n), {updates: [{id: 6, maxId: 9}]} as never)).toThrow(original);
+  });
+
+  it('reports how many events were dropped as already applied', () => {
+    const base = {applyUpdate: vi.fn().mockImplementation(() => { throw new Error(LEDGER_ERROR); })};
+    const apply = makeDedupingApplyUpdate(base as never, (st) => st);
+
+    let thrown: unknown;
+    try {
+      apply(makeState(10n), {
+        updates: [{id: 9, maxId: 20}, {id: 10, maxId: 20}, {id: 11, maxId: 20}],
+      } as never);
+    } catch (e) {
+      thrown = e;
+    }
+    expect((thrown as Error).message).toContain('2 dropped as already applied');
+  });
+});


### PR DESCRIPTION
partitionByAppliedIndex filtered the whole batch by predicate, dropping every
event with id <= appliedIndex wherever it sat. For an ascending batch that is
the intended boundary-duplicate filter. For an out-of-order one it removes an
already-applied event from the middle and hands the SDK a replay with a gap,
which the ledger tree rejects:

  values inserted non-linearly into dust generation tree;
  expected to insert index 337423, but received 337429.

Note the direction. The SDK bug this wrapper works around re-sends a boundary
event, so the tree receives an index LOWER than expected. This is the mirror
image -- higher than expected, because events the tree needed never arrived.
The workaround for one could produce the other, and only for the part whose
cursor and tree had drifted, which is why one sub-wallet stalls while the
others finish.

The filter now drops only a leading contiguous run. When an already-applied id
follows a fresh one the batch is not the ascending stream the filter assumes,
so nothing is dropped and the SDK's own handling decides. The existing test
named "drops only the already-applied prefix" described this already; the
implementation now matches it.

Non-linear inserts also no longer surface as bare WASM strings with no mention
of sync state. They carry the cursor and batch that produced them, say that
retrying cannot help, and name the fix. Original kept as cause.

Signed-off-by: bob blessing-hartley <bobblessinghartley@gmail.com>
