### PR TITLE
fix(dust): pay fees from the largest DUST coin first

### DIFF
--- a/.changeset/dust-fee-largest-coin-first.md
+++ b/.changeset/dust-fee-largest-coin-first.md
@@ -1,0 +1,38 @@
+---
+'@shieldedtech/moth-wallet': patch
+---
+
+Pay DUST fees from the largest coin first, so fee balancing terminates.
+
+The wallet SDK's dust fee balancer (`wallet-sdk-dust-wallet` 4.2.0,
+`computeBalancingRecipe`) loops until the coins it selected cover the fee that
+selecting them produced, with no iteration cap and no progress check. Its
+default selector takes the smallest coin first, so a wallet holding several
+part-drained DUST coins spends a handful of them, which enlarges the
+transaction, which raises the fee past what those coins cover — and the loop
+never exits. It also never fails: only the first pass can converge, because
+that pass is seeded with a negative dust imbalance while every later pass is
+seeded with a positive fee, which sends the balancer down its add-an-output
+branch and selects no inputs at all. Each pass deserialises and erases proofs
+on a fresh WASM transaction while holding the thread, so the wallet stops
+responding and its WASM heap grows until the process dies.
+
+Moth now sets largest-first selection on the dust wallet through the SDK's
+documented `V1Builder.withCoinSelection` extension point
+(`sync/dust-coin-selection.ts`), on both the restore-from-cache and
+start-from-secret-key paths. One coin near its generation cap covers a fee
+outright, so the first pass converges — which is the only pass that can.
+
+This costs nothing in DUST fragmentation: a dust spend is one-in-one-out (the
+ledger nullifies the coin and mints a successor worth the remainder), coin
+count is pinned to the number of registered NIGHT UTXOs, and a coin's value
+regenerates toward its cap. Draining the fullest coin therefore rotates across
+backing UTXOs on its own as the drained ones refill, and produces a smaller
+transaction than spending eight coins to reach the same fee.
+
+**This is a mitigation, not a fix.** A wallet whose dust is spread evenly
+across coins that are all far below fee size still spins, because no single
+coin covers the fee — pinned as a test, and filed upstream with the iteration
+traces in `docs/upstream-issues/dust-fee-balancing-nontermination.md`, which
+asks for the progress check that would close it. Transaction construction,
+signing, and proving are unchanged.

--- a/docs/upstream-issues/dust-fee-balancing-nontermination.md
+++ b/docs/upstream-issues/dust-fee-balancing-nontermination.md
@@ -1,0 +1,185 @@
+---
+status: draft — ready to file
+target-repos: midnightntwrk/midnight-wallet
+last-updated: 2026-09-06
+---
+
+# Draft upstream issue: DUST fee balancing cannot terminate, and only its first iteration can ever converge
+
+This is a ready-to-paste GitHub issue body. It concerns the wallet SDK's dust
+fee-balancing loop, not the ledger or the node. Moth ships a client-side
+mitigation (linked at the bottom) that makes the terminating case the common
+one; it does not and cannot fix the loop itself.
+
+---
+
+## Title
+
+`computeBalancingRecipe` spins forever when the first balancing pass under-covers its own fee, because every later pass is fed a fee where the first was fed an imbalance
+
+## Environment
+
+| Component | Version |
+|---|---|
+| `@midnightntwrk/wallet-sdk` | `1.2.0` |
+| `@midnightntwrk/wallet-sdk-dust-wallet` | `4.2.0` |
+| `@midnightntwrk/wallet-sdk-capabilities` | `3.3.1` |
+| `@midnight-ntwrk/ledger-v8` | `8.1.0` |
+
+## Summary
+
+`TransactingCapabilityImplementation.computeBalancingRecipe`
+(`dist/v1/Transacting.js`) balances a DUST fee with an `Effect.iterate` loop
+whose only exit is `converged: newFee <= recipeAmountCoverage` — the selected
+coins covering the fee that selecting them produced. There is no iteration cap
+and no progress check.
+
+That loop has two independent defects, and the second makes the first
+unrecoverable:
+
+1. **Only the first pass can converge.** Pass 1 is seeded with
+   `initialFees`, derived from `transaction.imbalances(0, totalFee)`, which for
+   dust is **negative** (a deficit). Every later pass is seeded with
+   `currentFee = newFee` from `dryRunFee(...)`, which is a **positive** fee. The
+   balancer treats those as opposite requests.
+2. **Smallest-first selection walks straight into it.** The default selector
+   sorts ascending, so a wallet holding many part-drained dust coins spends a
+   handful of them, which enlarges the transaction, which raises the fee above
+   what those coins cover — landing in the dead zone created by (1).
+
+The result is a loop that never exits and never fails. Each pass deserialises
+and `eraseProofs()` a fresh WASM transaction on the calling thread, so the
+process stops responding and its WASM heap grows until it is killed. Field
+reports on affected wallets put that growth at roughly 16 MB/s until process
+death; the traces in this report were produced with an analytic fee model, so
+that figure is reported rather than measured here.
+
+## Mechanism, precisely
+
+With `transactionCostModel` both overheads `0n` and `targetImbalances` empty —
+exactly what `computeBalancingRecipe` passes — `doBalance` in
+`capabilities/dist/balancer/Balancer.js` reduces to:
+
+```js
+const shouldAddOutput = tokenType === counterOffer.feeTokenType &&
+  imbalanceAmount >= 0n;   // getTargetImbalance() + outputFeeOverhead === 0n
+```
+
+So the sign of the seed decides the whole pass:
+
+| Pass | Seeded with | Sign | Branch taken | Inputs selected |
+|---|---|---|---|---|
+| 1 | `imbalances(0, fee)['dust']` | negative | add inputs | as many as needed |
+| 2+ | `dryRunFee(...)` | positive | **add an output** | **none** |
+
+A pass that selects no inputs has coverage `0n`, so `newFee <= 0n` is false and
+`converged` stays false. It also leaves no state for the next pass to differ
+on: `currentFee` settles to `dryRunFee([])` and every subsequent pass is
+byte-identical to the one before it. Nothing can break the cycle.
+
+This is confirmed rather than inferred. `Transaction.imbalances(0, fee)` on a
+freshly built intent returns the negative value:
+
+```
+$ node -e "…Transaction.fromParts('undeployed').addIntent(…).imbalances(0, 1430000000000000n)"
+entries: [ [ 'dust', '-1430000000000000' ] ]
+```
+
+## Evidence — the iteration trace
+
+Driving the **real** `getBalanceRecipe` and the **real** default selector
+(`dust-wallet/dist/v1/CoinsAndBalances.js` `chooseCoin`, ascending) through the
+same loop shape as `computeBalancingRecipe`, with `dryRunFee` replaced by
+`fee(n) = 1.4e15 + 3.75e12 × n` — its one relevant property is that the fee
+grows with the number of dust spends.
+
+Wallet: 12 part-drained coins of `176250000000000` each, beside two near their
+generation cap (`5e16`, `3e16`). Total dust `8.2e16`, far more than any fee.
+
+```
+=== SDK default (smallest-first) -> never-converged ===
+  iter 1: feeIn=-1400000000000000 inputs=8 coverage=1410000000000000 newFee=1430000000000000 converged=false
+  iter 2: feeIn=1430000000000000  inputs=0 coverage=0               newFee=1400000000000000 converged=false
+  iter 3: feeIn=1400000000000000  inputs=0 coverage=0               newFee=1400000000000000 converged=false
+  iter 4: feeIn=1400000000000000  inputs=0 coverage=0               newFee=1400000000000000 converged=false
+  …identical forever…
+
+=== largest-first -> converged ===
+  iter 1: feeIn=-1400000000000000 inputs=1 coverage=50000000000000000 newFee=1403750000000000 converged=true
+```
+
+Pass 1 selects eight coins covering `1.41e15` against the `1.43e15` that
+spending eight coins costs — short by `2e13`. Pass 2 selects nothing. Every
+pass after it is identical. The wallet is not short of DUST: it holds 57× the
+fee.
+
+This trace is reproducible as a unit test, no devnet required:
+`packages/core/tests/unit/sync/dust-coin-selection.test.ts` in
+[`shieldedtech/moth-wallet`](https://github.com/shieldedtech/moth-wallet).
+
+## Why smallest-first is the wrong default for DUST
+
+DUST is not a UTXO set that fragments. A `QualifiedDustOutput` is bound to a
+backing NIGHT UTXO, its spendable value is
+`updatedValue(ctime, initialValue, genInfo, now, params)` — a meter that
+regenerates toward `genInfo.value * nightDustRatio` — and a spend is
+one-in-one-out: `DustLocalState.spend` nullifies the coin and mints a
+`successorUtxo` with a reduced value and the next sequential nonce. Coin count
+is pinned to the number of registered NIGHT UTXOs regardless of selection
+order.
+
+So a "small" dust coin is not a fragment awaiting consolidation; it is a
+recently-drained coin that is refilling. Selecting those first has no upside
+and two costs: it needs many coins to reach a fee, which inflates the
+transaction and therefore the fee itself, and it is what puts pass 1 in the
+position of under-covering. Largest-first needs one coin, produces the smaller
+transaction, and rotates across backing UTXOs naturally as the drained ones
+regenerate.
+
+## What we are asking for
+
+1. **A progress check in the loop.** A pass that selects **no inputs**, or one
+   whose fee is **unchanged** from the previous pass, has no path to
+   convergence and should fail with `InsufficientFundsError` rather than
+   iterate. Either condition alone would have turned every occurrence of this
+   into an immediate, correct, actionable error. An iteration cap would also
+   bound the damage, but the two conditions above are exact — they are not a
+   heuristic.
+2. **Reconcile the seed's sign and units across passes.** Pass 1 is handed a
+   signed imbalance and passes 2+ a positive fee. Whichever convention is
+   intended, the loop should use one, so that later passes are capable of
+   selecting inputs at all. As it stands passes 2+ are dead code that merely
+   burns a WASM transaction each.
+3. **Reconsider the default selector for the fee token.** Ascending order suits
+   a token whose small coins are fragments worth consolidating. It does not suit
+   one whose coins are regenerating meters bound to backing UTXOs, where the
+   count is fixed and consuming many of them only enlarges the transaction.
+   `chooseCoin` also compares with `Number(a.value - b.value)`; the sign of that
+   cast is correct for the magnitudes involved, but DUST values exceed 2^53 and
+   a bigint comparison would remove the question.
+
+Items 1 and 2 are the fix. Item 3 is a default that stops most wallets from
+reaching the defect, which is all a client can do from outside.
+
+## What Moth changed on the client side in the meantime
+
+`shieldedtech/moth-wallet` sets largest-first fee-coin selection on its dust
+wallet, via the documented `V1Builder.withCoinSelection` extension point
+(`packages/core/src/sync/dust-coin-selection.ts`). Transaction construction,
+signing, and proving are untouched.
+
+**This is a mitigation, not a fix, and its limit is known.** Largest-first
+converges because the biggest coin overshoots the fee in a single pass. A
+wallet whose dust is spread evenly across coins that are *all* far below fee
+size has no such coin, needs several, and spins exactly as the default does —
+pinned as a test in the file above:
+
+```
+=== uniformly tiny wallet + largest-first -> never-converged ===
+  iter 1: inputs=8 coverage=1410000000000000 newFee=1430000000000000 converged=false
+  iter 2: inputs=0 coverage=0               newFee=1400000000000000 converged=false
+  …identical forever…
+```
+
+Only the progress check in ask 1 closes that case, which is why this report is
+filed rather than left as a client-side workaround.

--- a/packages/core/src/sync/dust-coin-selection.ts
+++ b/packages/core/src/sync/dust-coin-selection.ts
@@ -1,0 +1,36 @@
+// DUST fee-coin selection for the dust wallet's balancing loop.
+//
+// WASM-free on purpose: the selector is pure bigint arithmetic, so it can be
+// unit-tested without loading the ledger — the same split as progress.ts.
+
+import type {CoinsAndBalances} from '@midnightntwrk/wallet-sdk/dust/v1';
+
+/**
+ * Picks the highest-value DUST coin to pay a fee from, replacing the SDK's
+ * smallest-first default.
+ *
+ * `computeBalancingRecipe` re-runs selection in a loop that exits only once the
+ * selected coins cover the fee that selecting them produced. Smallest-first
+ * spends many coins to reach the fee, which raises the fee; the loop's second
+ * iteration is then fed a positive fee where the first was fed a negative
+ * imbalance, so it selects nothing and spins forever, deserialising a WASM
+ * transaction per pass. Choosing the largest coin makes the first iteration
+ * cover the fee outright, which is the one case that terminates. See
+ * docs/upstream-issues/dust-fee-balancing-nontermination.md.
+ *
+ * A DUST spend is one-in-one-out — the ledger nullifies the coin and mints a
+ * successor worth the remainder — so draining the fullest coin neither splits
+ * coins nor grows the UTXO set, and rotates naturally as drained coins
+ * regenerate.
+ */
+export const largestDustCoinFirst: CoinsAndBalances.CoinSelection = (coins) =>
+  coins
+    // A zero-value coin cannot pay any part of a fee, and the SDK's default
+    // selector excludes it too; keeping the filter preserves the
+    // insufficient-funds path on a wallet whose dust has not yet generated.
+    .filter((coin) => coin.value > 0n)
+    // Sorting the array `filter` just returned, so the caller's is untouched.
+    // Compared as bigints rather than cast through Number: DUST values run well
+    // past 2^53, so a numeric difference is not exactly representable.
+    .sort((a, b) => (b.value > a.value ? 1 : b.value < a.value ? -1 : 0))
+    .at(0);

--- a/packages/core/src/sync/wallet-sync.ts
+++ b/packages/core/src/sync/wallet-sync.ts
@@ -27,6 +27,7 @@ import {formatDustBalance} from '../wallet/balance-format.js';
 import {ensureEmptyRefCache, preSeedNewWallet} from './preseed.js';
 import {InMemorySyncStateStore, syncStateKey, type SyncStateStore, type WalletPart} from './sync-store.js';
 import {dedupingShieldedBuilder, dedupingDustBuilder} from './sdk-dedup.js';
+import {largestDustCoinFirst} from './dust-coin-selection.js';
 import {overallSyncProgress, type SubWallet} from './progress.js';
 import {partsToSeed} from './preseed-parts.js';
 import type {WalletKeys} from './operations.js';
@@ -592,8 +593,13 @@ export async function startWalletSync(
     indexerClientConnection: {indexerHttpUrl, indexerWsUrl},
     txHistoryStorage,
   } as Parameters<typeof DustWallet>[0];
+  // Largest-first fee-coin selection replaces the SDK's smallest-first default,
+  // whose balancing loop cannot terminate on a wallet holding many part-drained
+  // dust coins (see sync/dust-coin-selection.ts). Chained here rather than
+  // inside dedupingDustBuilder so that module stays about the dedup fix alone;
+  // both the restore and start-with-secret-key paths below share this builder.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const dustBuilder = dedupingDustBuilder() as any;
+  const dustBuilder = (dedupingDustBuilder() as any).withCoinSelection(() => largestDustCoinFirst);
   let dustWallet: DustWallet | undefined;
   const savedDust = await loadCachedState(store, name, network.id, 'dust');
   if (savedDust) {

--- a/packages/core/tests/unit/sync/dust-coin-selection.test.ts
+++ b/packages/core/tests/unit/sync/dust-coin-selection.test.ts
@@ -1,0 +1,160 @@
+import {describe, it, expect} from 'vitest';
+import {getBalanceRecipe, Imbalances} from '@midnightntwrk/wallet-sdk/capabilities/balancer';
+import {CoinsAndBalances} from '@midnightntwrk/wallet-sdk/dust/v1';
+import {largestDustCoinFirst} from '../../../src/sync/dust-coin-selection.js';
+
+type Coin = {type: string; value: bigint; token: {nonce: string}};
+
+const nonce = (n: number): {nonce: string} => ({nonce: String(n).padStart(64, '0')});
+const coin = (value: bigint, n: number): Coin => ({type: 'dust', value, token: nonce(n)});
+
+describe('largestDustCoinFirst', () => {
+  it('picks the largest from a mix of tiny and huge values', () => {
+    const coins = [
+      coin(1n, 0),
+      coin(176_250_000_000_000n, 1),
+      coin(50_000_000_000_000_000n, 2),
+      coin(30_000_000_000_000_000n, 3),
+      coin(2n, 4),
+    ];
+    expect(largestDustCoinFirst(coins)?.value).toBe(50_000_000_000_000_000n);
+  });
+
+  it('orders values that collide when cast individually to Number', () => {
+    // 2^60 is exactly representable as a double and 2^60 + 1 is not, so
+    // `Number(a.value) - Number(b.value)` is 0 for this pair and a comparator
+    // written that way would keep the smaller coin at the head. The smaller one
+    // is listed first so that mistake fails this assertion rather than passing
+    // by luck.
+    const coins = [coin(1_152_921_504_606_846_976n, 0), coin(1_152_921_504_606_846_977n, 1)];
+    expect(Number(coins[0]!.value)).toBe(Number(coins[1]!.value));
+    expect(largestDustCoinFirst(coins)?.value).toBe(1_152_921_504_606_846_977n);
+  });
+
+  it('ignores zero-value coins and reports nothing when every coin is empty', () => {
+    expect(largestDustCoinFirst([coin(0n, 0), coin(7n, 1), coin(0n, 2)])?.value).toBe(7n);
+    expect(largestDustCoinFirst([coin(0n, 0), coin(0n, 1)])).toBeUndefined();
+    expect(largestDustCoinFirst([])).toBeUndefined();
+  });
+
+  it('leaves the caller-owned coin array untouched', () => {
+    const coins = [coin(1n, 0), coin(9n, 1), coin(5n, 2)];
+    largestDustCoinFirst(coins);
+    expect(coins.map((c) => c.value)).toEqual([1n, 9n, 5n]);
+  });
+});
+
+// Regression guard for the upstream non-termination this selector works around:
+// see docs/upstream-issues/dust-fee-balancing-nontermination.md.
+//
+// This drives the REAL `getBalanceRecipe` and the REAL SDK default selector
+// through the same loop shape as
+// `TransactingCapabilityImplementation.computeBalancingRecipe`. Only the fee
+// oracle is modelled — the SDK's `dryRunFee` builds and erases a WASM
+// transaction, which is exactly the cost that makes the spin fatal, and which a
+// unit test has no business doing. The fee model reproduces its one relevant
+// property: the fee grows with the number of dust spends.
+describe('dust fee balancing loop', () => {
+  const FEE_BASE = 1_400_000_000_000_000n;
+  const FEE_PER_SPEND = 3_750_000_000_000n;
+  const feeFor = (inputCount: number): bigint => FEE_BASE + FEE_PER_SPEND * BigInt(inputCount);
+
+  type Iteration = {inputs: number; coverage: bigint; newFee: bigint; converged: boolean};
+
+  const runLoop = (
+    coins: readonly Coin[],
+    coinSelection: typeof largestDustCoinFirst,
+    maxIterations = 8,
+  ): {iterations: Iteration[]; outcome: 'converged' | 'insufficient-funds' | 'never-converged'} => {
+    // Iteration 1 is fed the ledger's dust imbalance, which is negative; every
+    // later iteration is fed the previous pass's fee, which is positive. That
+    // sign flip is the upstream defect this loop exists to demonstrate.
+    let currentFee = -feeFor(0);
+    const iterations: Iteration[] = [];
+    for (let i = 0; i < maxIterations; i++) {
+      let recipe;
+      try {
+        recipe = getBalanceRecipe({
+          coins: coins.map((c) => ({type: 'dust', value: c.value, token: c.token})),
+          initialImbalances: Imbalances.fromEntry('dust', currentFee),
+          feeTokenType: 'dust',
+          coinSelection,
+          transactionCostModel: {inputFeeOverhead: 0n, outputFeeOverhead: 0n},
+          createOutput: (c) => c,
+          isCoinEqual: (a, b) => a.token.nonce === b.token.nonce,
+        } as Parameters<typeof getBalanceRecipe>[0]);
+      } catch {
+        return {iterations, outcome: 'insufficient-funds'};
+      }
+      const inputs = recipe.inputs as ReadonlyArray<{value: bigint}>;
+      const coverage = inputs.reduce((sum, input) => sum + input.value, 0n);
+      const newFee = feeFor(inputs.length);
+      const converged = newFee <= coverage;
+      iterations.push({inputs: inputs.length, coverage, newFee, converged});
+      if (converged) return {iterations, outcome: 'converged'};
+      currentFee = newFee;
+    }
+    return {iterations, outcome: 'never-converged'};
+  };
+
+  // Twelve part-drained coins whose combined value comfortably covers any fee,
+  // beside two that have generated close to their cap.
+  const drained = Array.from({length: 12}, (_, k) => coin(176_250_000_000_000n, k));
+  const full = [coin(50_000_000_000_000_000n, 90), coin(30_000_000_000_000_000n, 91)];
+  const wallet = [...drained, ...full];
+
+  it('never terminates under the SDK default, selecting nothing after the first pass', () => {
+    const {iterations, outcome} = runLoop(wallet, CoinsAndBalances.chooseCoin);
+
+    expect(outcome).toBe('never-converged');
+
+    // Pass 1 spends eight drained coins and still falls short of the fee that
+    // spending eight coins costs.
+    expect(iterations[0]).toMatchObject({inputs: 8, converged: false});
+    expect(iterations[0]!.coverage).toBeLessThan(iterations[0]!.newFee);
+
+    // Every later pass is handed a positive fee, takes the balancer's
+    // add-an-output branch instead of selecting inputs, and so is identical to
+    // the one before it. Nothing about the loop state can change again.
+    for (const iteration of iterations.slice(1)) {
+      expect(iteration).toMatchObject({inputs: 0, coverage: 0n, converged: false});
+    }
+  });
+
+  it('converges on the first pass under largest-first', () => {
+    const {iterations, outcome} = runLoop(wallet, largestDustCoinFirst);
+
+    expect(outcome).toBe('converged');
+    expect(iterations).toHaveLength(1);
+    expect(iterations[0]!.inputs).toBe(1);
+    expect(iterations[0]!.coverage).toBe(50_000_000_000_000_000n);
+  });
+
+  it('still cannot terminate when every coin is far smaller than the fee', () => {
+    // The boundary of this workaround, pinned deliberately. Largest-first
+    // converges because taking the biggest coin overshoots the fee in one pass;
+    // a wallet whose dust is spread evenly across coins that are all far below
+    // fee size has no such coin, needs eight of them, and spins exactly as the
+    // SDK default does. Only a progress check upstream fixes that case — see
+    // docs/upstream-issues/dust-fee-balancing-nontermination.md.
+    const uniformlyTiny = Array.from({length: 12}, (_, k) => coin(176_250_000_000_000n, k));
+    const {iterations, outcome} = runLoop(uniformlyTiny, largestDustCoinFirst);
+
+    expect(outcome).toBe('never-converged');
+    expect(iterations[0]).toMatchObject({inputs: 8, converged: false});
+
+    // One coin at fee size is enough to recover the terminating case.
+    const withOneFeeSizedCoin = [coin(1_500_000_000_000_000n, 99), ...uniformlyTiny];
+    expect(runLoop(withOneFeeSizedCoin, largestDustCoinFirst)).toMatchObject({
+      outcome: 'converged',
+      iterations: [{inputs: 1, converged: true}],
+    });
+  });
+
+  it('still reports insufficient funds when no coin can cover the fee', () => {
+    // Largest-first must not paper over a genuinely unaffordable transaction:
+    // the loop has to reach the balancer's insufficient-funds path, not spin.
+    const {outcome} = runLoop([coin(1n, 0), coin(2n, 1)], largestDustCoinFirst);
+    expect(outcome).toBe('insufficient-funds');
+  });
+});


### PR DESCRIPTION
## What this changes

Moth's dust wallet now picks the **largest** DUST coin to pay a fee from, instead of the SDK's smallest-first default. One new module (`packages/core/src/sync/dust-coin-selection.ts`) and one line at the single builder site in `wallet-sync.ts`, chained via the SDK's documented `V1Builder.withCoinSelection` extension point so both the restore-from-cache and start-from-secret-key paths get it.

No ledger version pins or anything else touched.

## Why — the root cause is worse than "the wrong default"

`computeBalancingRecipe` (`wallet-sdk-dust-wallet` 4.2.0, `dist/v1/Transacting.js`) balances a fee with an `Effect.iterate` loop whose only exit is `converged: newFee <= recipeAmountCoverage`. There is no iteration cap and no progress check. Reading it closely, **only the first pass can ever converge**:

| Pass | Seeded with | Sign | Balancer branch | Inputs selected |
|---|---|---|---|---|
| 1 | `transaction.imbalances(0, totalFee)['dust']` | negative | add inputs | as many as needed |
| 2+ | `dryRunFee(...)` | positive | **add an output** | **none** |

With `transactionCostModel` overheads `0n` and `targetImbalances` empty — exactly what `computeBalancingRecipe` passes — `doBalance` reduces to `shouldAddOutput = imbalanceAmount >= 0n`. So a positive seed takes the add-an-output branch, selects zero inputs, and yields coverage `0n`. `currentFee` then settles at `dryRunFee([])` and every later pass is byte-identical to the one before it. Nothing can break the cycle.

Smallest-first is what walks a wallet into that dead zone: spending eight part-drained coins to reach a fee enlarges the transaction, which raises the fee past what those eight coins cover, so pass 1 fails to converge — and passes 2+ cannot. Largest-first makes pass 1 converge outright, which is the only pass that can.

The sign convention is verified, not inferred — against the real ledger WASM:

```
$ Transaction.fromParts('undeployed').addIntent(…).imbalances(0, 1430000000000000n)
entries: [ [ 'dust', '-1430000000000000' ] ]
```

## Evidence — reproduced, and what that does and does not cover

`packages/core/tests/unit/sync/dust-coin-selection.test.ts` (8 tests) drives the **real** `getBalanceRecipe` and the **real** SDK default selector (`dust-wallet/dist/v1/CoinsAndBalances.js` `chooseCoin`) through the same loop shape as `computeBalancingRecipe`. Wallet: 12 part-drained coins of `176250000000000` beside two near their cap (`5e16`, `3e16`) — 57× the fee in total DUST.

```
=== SDK default (smallest-first) -> never-converged ===
  iter 1: feeIn=-1400000000000000 inputs=8 coverage=1410000000000000 newFee=1430000000000000 converged=false
  iter 2: feeIn=1430000000000000  inputs=0 coverage=0               newFee=1400000000000000 converged=false
  iter 3: feeIn=1400000000000000  inputs=0 coverage=0               newFee=1400000000000000 converged=false
  …identical forever…

=== largest-first -> converged ===
  iter 1: feeIn=-1400000000000000 inputs=1 coverage=50000000000000000 newFee=1403750000000000 converged=true
```

**What was exercised:** the balancer, the coin selection, the loop's exit condition and its per-pass state — all real SDK code — plus the imbalance sign against real ledger WASM. The spiral reproduces deterministically, and largest-first converges on pass 1.

**What was not exercised:** `dryRunFee` is replaced by an analytic model (`fee(n) = 1.4e15 + 3.75e12 × n`), reproducing its one relevant property — the fee grows with the number of dust spends. So the WASM deserialise/`eraseProofs` work per pass, which is what makes the spin fatal rather than merely wrong, is not driven here. **No live devnet run was completed**, so no live wallet was observed balancing in one iteration. The ~16 MB/s WASM heap growth is carried from field reports, and is labelled as such in the upstream doc rather than presented as measured.

I stood up an isolated devnet (own compose, ports 9974/8118/6330, images pinned to the same matched set as the local stacks) specifically to avoid touching the two long-running stacks on this machine — DUST registration is the operation that can wedge a chain permanently per `docs/upstream-issues/dust-ledger-wedge-invalid-dust-spend-proof.md`. Two environment blockers stopped the run, both orthogonal to this change and worth a separate look:

- `midnight-wallet-cli@latest` (0.5.2) fails genesis sync against the pinned indexer image with `SYNC_TIMEOUT`, on an event-schema decode error. This is the funding path the daemon integration tier documents and uses.
- On a freshly built stack, the genesis wallet holds 250M NIGHT but zero DUST, and `moth daemon dust register` reports nothing to register — so genesis cannot pay a fee to fund anything.

The stack and its volumes are torn down and both pre-existing stacks are untouched.

## The limit of this workaround, pinned as a test

Largest-first converges because the biggest coin overshoots the fee in one pass. A wallet whose dust is spread evenly across coins that are **all** far below fee size has no such coin, needs several, and spins exactly as the default does:

```
=== uniformly tiny wallet + largest-first -> never-converged ===
  iter 1: inputs=8 coverage=1410000000000000 newFee=1430000000000000 converged=false
  iter 2: inputs=0 coverage=0               newFee=1400000000000000 converged=false
```

Only a progress check upstream closes that. This PR does not claim otherwise.

## Does this let tiny DUST accumulate?

No — DUST cannot fragment. A `QualifiedDustOutput` is bound to a backing NIGHT UTXO; `DustLocalState.spend` nullifies the coin and mints a `successorUtxo` with a reduced value and the next sequential nonce — **one in, one out**, under either selection order. Coin count is pinned to the number of registered NIGHT UTXOs, and a coin's spendable value is `updatedValue(...)`, a meter regenerating toward `genInfo.value * nightDustRatio`.

So a "small" dust coin is not a fragment awaiting consolidation, it is a recently-drained coin refilling on its own. Largest-first always drains whichever coin is currently fullest, so it rotates across backing UTXOs as drained ones regenerate, and produces a smaller transaction than spending eight coins to reach the same fee.

## Also in this PR

`docs/upstream-issues/dust-fee-balancing-nontermination.md` — a ready-to-file issue against `midnightntwrk/midnight-wallet` carrying the traces above, asking for (1) a progress check: a pass selecting no inputs, or one whose fee is unchanged, should fail with insufficient funds rather than iterate; (2) a single sign/units convention across passes, so passes 2+ can select inputs at all; (3) reconsidering smallest-first as the default for a fee token whose coins are regenerating meters rather than fragments.

## Checks

- `packages/core`: 377 tests pass (40 files), including the 8 new ones
- `tsc --noEmit` clean on `packages/core`; `core` and `browser` rebuild clean
- `pre-commit` hooks pass on the changed files (`trailing-whitespace`, `end-of-file-fixer`, `check-merge-conflict`, `detect-private-key`, `gitleaks`, `release-workflow-policy`). `actionlint` could not install — its Go toolchain download is blocked in this sandbox; no workflow files are touched by this PR.
