### PR TITLE
fix(dust): replace the SDK fee-balancing loop with one that terminates

### DIFF
--- a/.changeset/dust-fee-balancing-terminates.md
+++ b/.changeset/dust-fee-balancing-terminates.md
@@ -1,0 +1,34 @@
+---
+'@shieldedtech/moth-wallet': patch
+---
+
+Replace the wallet SDK's DUST fee-balancing loop with one that terminates.
+
+The SDK's `computeBalancingRecipe` (`wallet-sdk-dust-wallet` 4.2.0) re-selects
+dust coins until they cover the fee of the transaction they produce, with no
+iteration cap and no progress check. It also seeds its first pass with a
+negative dust imbalance and every later pass with a positive fee; the balancer
+reads the positive seed as a surplus, adds an output and selects nothing, so
+only the first pass can ever converge. A wallet holding several part-drained
+dust coins under-covers on that first pass and the loop then spins forever,
+building and proof-erasing a WASM transaction on the calling thread each time
+until the process runs out of memory.
+
+Moth now supplies its own transacting capability through the SDK's documented
+`V1Builder.withTransacting` seam (`sync/dust-transacting.ts`). It keeps the
+SDK's fee arithmetic — `dryRunFee` and `calculateFee`, the WASM parts — and
+replaces only the control flow: each pass covers the outstanding deficit from
+coins not yet selected, then re-prices the transaction with everything selected
+so far. A pass that does not converge has strictly grown the input set, so the
+loop is bounded by the number of coins; running out surfaces as the SDK's own
+`InsufficientFundsError`. Both `estimateFee` and `balanceTransactions` route
+through the replaced method, so the fee preview and the real spend take the
+same path. Coin selection order is unchanged.
+
+Trade-off: this couples Moth to the SDK's exported implementation class and
+three of its methods. The test suite pins that surface so an SDK upgrade that
+changes it fails in CI rather than silently reverting to the non-terminating
+loop. `effect` becomes a direct dependency of `@shieldedtech/moth-wallet` (it
+was already in the tree via the SDK) because the capability returns the SDK's
+`Either` values. The same loop is proposed upstream in
+`docs/upstream-issues/dust-fee-balancing-nontermination.md`.

--- a/docs/upstream-issues/dust-fee-balancing-nontermination.md
+++ b/docs/upstream-issues/dust-fee-balancing-nontermination.md
@@ -49,10 +49,13 @@ unrecoverable:
 
 The result is a loop that never exits and never fails. Each pass deserialises
 and `eraseProofs()` a fresh WASM transaction on the calling thread, so the
-process stops responding and its WASM heap grows until it is killed. Field
-reports on affected wallets put that growth at roughly 16 MB/s until process
-death; the traces in this report were produced with an analytic fee model, so
-that figure is reported rather than measured here.
+process stops responding and its memory grows until it is killed. Measured on
+a live devnet (node 1.0.1, ledger 8.1.0) with the process RSS sampled from
+outside every 5 s: **16.2 MB/s for the first two minutes, then a sustained
+~1.2 MB/s with no plateau** — 424 MB at the call, 2.3 GB after 2 min, 3.4 GB
+after 15 min when the run was killed. A moth wallet daemon idling beside it
+held 227–231 MB throughout. On a machine or worker with a smaller ceiling this
+is death within minutes; here it is unbounded growth.
 
 ## Mechanism, precisely
 
@@ -116,6 +119,13 @@ fee.
 This trace is reproducible as a unit test, no devnet required:
 `packages/core/tests/unit/sync/dust-coin-selection.test.ts` in
 [`shieldedtech/moth-wallet`](https://github.com/shieldedtech/moth-wallet).
+
+The same shape was then reproduced against a live devnet through the real WASM
+`dryRunFee`, with the real fee model of that chain (base 3.66e14, +3.36e14 per
+dust input). On a wallet holding 7.2e13, 1.9e14, 2.9e14, 1.0e15 and 8.5e15,
+the SDK loop never returned; a loop that seeds each pass with the outstanding
+deficit converged in three passes (51 ms), and with largest-first selection in
+one pass (13 ms). The full traces are in shieldedtech/moth-wallet#142.
 
 ## Why smallest-first is the wrong default for DUST
 

--- a/docs/upstream-issues/dust-fee-balancing-nontermination.md
+++ b/docs/upstream-issues/dust-fee-balancing-nontermination.md
@@ -1,7 +1,7 @@
 ---
 status: draft — ready to file
 target-repos: midnightntwrk/midnight-wallet
-last-updated: 2026-09-06
+last-updated: 2026-09-08
 ---
 
 # Draft upstream issue: DUST fee balancing cannot terminate, and only its first iteration can ever converge
@@ -163,23 +163,23 @@ reaching the defect, which is all a client can do from outside.
 
 ## What Moth changed on the client side in the meantime
 
-`shieldedtech/moth-wallet` sets largest-first fee-coin selection on its dust
-wallet, via the documented `V1Builder.withCoinSelection` extension point
-(`packages/core/src/sync/dust-coin-selection.ts`). Transaction construction,
-signing, and proving are untouched.
+`shieldedtech/moth-wallet` replaces the loop through the documented
+`V1Builder.withTransacting` seam
+(`packages/core/src/sync/dust-transacting.ts`). It keeps `dryRunFee` and
+`calculateFee` and changes only the control flow — each pass covers the
+outstanding deficit from coins not yet selected, then re-prices with everything
+selected so far — so every non-converging pass strictly grows the input set and
+the loop is bounded by the coin count. The same file can serve as the reference
+implementation for asks 1 and 2 above; the loop itself is about forty lines.
 
-**This is a mitigation, not a fix, and its limit is known.** Largest-first
-converges because the biggest coin overshoots the fee in a single pass. A
-wallet whose dust is spread evenly across coins that are *all* far below fee
-size has no such coin, needs several, and spins exactly as the default does —
-pinned as a test in the file above:
+With that loop, the SDK's own smallest-first selection converges on the wallet
+above in two passes (pass 1 selects eight coins and under-covers; pass 2 adds
+one more), and a wallet whose coins are *all* far below fee size converges too
+— the case no selection order can rescue.
 
-```
-=== uniformly tiny wallet + largest-first -> never-converged ===
-  iter 1: inputs=8 coverage=1410000000000000 newFee=1430000000000000 converged=false
-  iter 2: inputs=0 coverage=0               newFee=1400000000000000 converged=false
-  …identical forever…
-```
-
-Only the progress check in ask 1 closes that case, which is why this report is
-filed rather than left as a client-side workaround.
+Moth also sets largest-first fee-coin selection
+(`packages/core/src/sync/dust-coin-selection.ts`), which on its own converts
+most affected wallets into the one-pass case but cannot fix the loop: a
+uniformly tiny wallet still spins under any selection order when the loop is
+the SDK's. That is why this report asks for the loop change and not the
+default.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "@noble/ciphers": "^2.2.0",
     "@noble/hashes": "^2.2.0",
     "@scure/bip39": "^2.2.0",
-    "effect": "^3.20.0",
+    "effect": "^3.19.19",
     "graphql": "^16.10.0",
     "graphql-request": "^7.4.0",
     "graphql-ws": "^6.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,7 @@
     "@noble/ciphers": "^2.2.0",
     "@noble/hashes": "^2.2.0",
     "@scure/bip39": "^2.2.0",
+    "effect": "^3.20.0",
     "graphql": "^16.10.0",
     "graphql-request": "^7.4.0",
     "graphql-ws": "^6.0.0",

--- a/packages/core/src/sync/dust-transacting.ts
+++ b/packages/core/src/sync/dust-transacting.ts
@@ -1,0 +1,261 @@
+// A DUST fee-balancing loop that terminates, replacing the wallet SDK's.
+//
+// The SDK's `computeBalancingRecipe` (wallet-sdk-dust-wallet, Transacting.js)
+// re-selects coins until the fee of the resulting transaction is covered, but
+// has no progress check, and seeds its first pass with a negative imbalance
+// while seeding every later pass with a positive fee. The balancer reads a
+// positive seed as a surplus, adds an output and selects nothing, so any wallet
+// whose first pass under-covers its own fee spins forever — each pass building
+// and proof-erasing a WASM transaction on the calling thread until the process
+// dies. See docs/upstream-issues/dust-fee-balancing-nontermination.md.
+//
+// This module keeps the SDK's fee arithmetic (`dryRunFee`, `calculateFee` — the
+// WASM parts) and replaces only the control flow: each pass covers the current
+// deficit from coins not yet chosen, so every pass either converges or adds a
+// coin from a finite pool. Termination is a counting argument, not a timeout.
+//
+// It is wired through the documented `V1Builder.withTransacting` seam. The
+// coupling is to the SDK's exported implementation class and three of its
+// public methods; dust-transacting.test.ts pins those so a version bump fails
+// loudly rather than silently reverting to the SDK loop.
+
+import {Either} from 'effect';
+import type * as ledger from '@midnight-ntwrk/ledger-v8';
+import {Transacting, WalletError, type CoinsAndBalances, type CoreWallet, type Dust} from '@midnightntwrk/wallet-sdk/dust/v1';
+import {
+  getBalanceRecipe,
+  Imbalances,
+  InsufficientFundsError as BalancingInsufficientFundsError,
+} from '@midnightntwrk/wallet-sdk/capabilities/balancer';
+import {largestDustCoinFirst} from './dust-coin-selection.js';
+
+/** The smallest coin shape the loop needs; the SDK's `CoinWithValue<Dust>` satisfies it. */
+export interface FeeCoin {
+  readonly value: bigint;
+  readonly token: {readonly nonce: unknown};
+}
+
+/** One pass of the loop, reported to `onPass` for diagnostics and tests. */
+export interface DustFeePass {
+  /** Which selector this pass ran under; see `balanceDustFee` on why there can be two. */
+  readonly selector: 'configured' | 'largest-first-fallback';
+  readonly pass: number;
+  /** What the pass set out to cover: the fee target minus what was already selected. */
+  readonly deficit: bigint;
+  readonly added: number;
+  readonly inputs: number;
+  readonly coverage: bigint;
+  /** The fee of the transaction as it stands after this pass's inputs were added. */
+  readonly fee: bigint;
+  readonly converged: boolean;
+}
+
+export interface BalanceDustFeeArgs<C extends FeeCoin> {
+  readonly coins: ReadonlyArray<C>;
+  /**
+   * The transaction's dust imbalance at its base fee, in the ledger's sign
+   * convention: negative is a deficit the wallet must cover. This is what the
+   * SDK computes from `Transaction.imbalances` and seeds its first pass with.
+   */
+  readonly initialImbalance: bigint;
+  /** The fee the transaction would carry with these dust inputs attached. */
+  readonly feeFor: (inputs: ReadonlyArray<C>) => bigint;
+  readonly coinSelection: CoinsAndBalances.CoinSelection;
+  readonly onPass?: (pass: DustFeePass) => void;
+}
+
+export interface BalancedDustFee<C extends FeeCoin> {
+  readonly fee: bigint;
+  readonly inputs: ReadonlyArray<C>;
+}
+
+const sumValues = (coins: ReadonlyArray<FeeCoin>): bigint => coins.reduce((sum, coin) => sum + coin.value, 0n);
+
+/**
+ * Select dust inputs until they cover the fee of the transaction they produce.
+ *
+ * Each pass hands the balancer only the outstanding deficit, as a deficit, over
+ * the coins not yet selected, then re-prices the transaction with everything
+ * selected so far. Adding inputs can only raise the fee, so a pass that does not
+ * converge has strictly increased the fee and strictly grown the input set;
+ * with a finite pool that bounds the passes by the number of coins. Running out
+ * of coins surfaces as the balancer's own `InsufficientFundsError`.
+ *
+ * Runs the configured selector first and, only if that ends in insufficient
+ * funds, retries largest-first — see the note inside on why the additive loop
+ * is complete only from the top.
+ *
+ * WASM-free: `feeFor` is injected, so tests drive this with an analytic fee
+ * model and the wallet drives it with the SDK's `dryRunFee`.
+ */
+export function balanceDustFee<C extends FeeCoin>(args: BalanceDustFeeArgs<C>): BalancedDustFee<C> {
+  const {coins, initialImbalance, feeFor, coinSelection, onPass} = args;
+
+  // A non-negative imbalance means the transaction already carries enough dust
+  // of its own. Nothing to select; report the fee it will actually pay.
+  if (initialImbalance >= 0n) {
+    return {fee: feeFor([]), inputs: []};
+  }
+
+  // Adding a coin raises the fee by a fixed amount, so the loop is complete —
+  // finds a covering set whenever one exists — only when it takes coins from
+  // the top: the k largest coins dominate every other k-subset. Under a
+  // smallest-first selector it can end with the wallet's biggest coins unused
+  // and report insufficient funds where the biggest coin alone would have paid
+  // (seen on a devnet wallet holding 6.4e13 and 9.7e14 against a 7.3e14 fee).
+  // The configured selector still runs first so a wallet's preference is
+  // honoured whenever it works; largest-first is only the safety net.
+  try {
+    return attemptBalance(coins, initialImbalance, feeFor, coinSelection, 'configured', onPass);
+  } catch (err) {
+    if (!(err instanceof BalancingInsufficientFundsError)) throw err;
+    return attemptBalance(coins, initialImbalance, feeFor, largestDustCoinFirst, 'largest-first-fallback', onPass);
+  }
+}
+
+function attemptBalance<C extends FeeCoin>(
+  coins: ReadonlyArray<C>,
+  initialImbalance: bigint,
+  feeFor: (inputs: ReadonlyArray<C>) => bigint,
+  coinSelection: CoinsAndBalances.CoinSelection,
+  selector: DustFeePass['selector'],
+  onPass: ((pass: DustFeePass) => void) | undefined,
+): BalancedDustFee<C> {
+  const inputs: C[] = [];
+  let remaining: ReadonlyArray<C> = coins;
+  let fee = -initialImbalance;
+  // Every non-converging pass consumes at least one coin, so this cannot be
+  // reached; it turns a broken invariant into an error instead of a hang.
+  const maxPasses = coins.length + 1;
+
+  for (let pass = 1; pass <= maxPasses; pass++) {
+    const deficit = fee - sumValues(inputs);
+    if (deficit <= 0n) {
+      return {fee, inputs};
+    }
+
+    const recipe = getBalanceRecipe({
+      coins: remaining.map((coin) => ({type: 'dust', value: coin.value, token: coin.token})),
+      initialImbalances: Imbalances.fromEntry('dust', -deficit),
+      feeTokenType: 'dust',
+      coinSelection,
+      transactionCostModel: {inputFeeOverhead: 0n, outputFeeOverhead: 0n},
+      createOutput: (coin) => coin,
+      isCoinEqual: (a, b) => a.token.nonce === b.token.nonce,
+    });
+    // The balancer throws when the pool cannot cover the deficit, so an empty
+    // selection here would be a selector returning nothing on a non-empty pool.
+    // Either way there is no path to convergence.
+    if (recipe.inputs.length === 0) {
+      throw new BalancingInsufficientFundsError('dust');
+    }
+
+    const chosen = new Set(recipe.inputs.map((input) => input.token.nonce));
+    for (const coin of remaining) {
+      if (chosen.has(coin.token.nonce)) inputs.push(coin);
+    }
+    remaining = remaining.filter((coin) => !chosen.has(coin.token.nonce));
+
+    const coverage = sumValues(inputs);
+    const newFee = feeFor(inputs);
+    const converged = newFee <= coverage;
+    onPass?.({selector, pass, deficit, added: recipe.inputs.length, inputs: inputs.length, coverage, fee: newFee, converged});
+    if (converged) {
+      return {fee: newFee, inputs};
+    }
+    fee = newFee;
+  }
+
+  throw new Error(`DUST fee balancing did not converge after ${maxPasses} passes`);
+}
+
+/**
+ * Mirror of the SDK's module-private helper: each input pays as much of the fee
+ * as it can, in selection order, so the last input pays only the remainder.
+ */
+export function distributeFeeAcrossInputs<C extends FeeCoin>(inputs: ReadonlyArray<C>, fee: bigint): C[] {
+  let remaining = fee;
+  return inputs.map((input) => {
+    const deduction = remaining >= input.value ? input.value : remaining;
+    remaining -= deduction;
+    return {...input, value: deduction};
+  });
+}
+
+/** Mirror of the SDK's static `feeImbalance`: the dust entry of the transaction's imbalances at `totalFee`. */
+function dustImbalance(transaction: ledger.FinalizedTransaction | ledger.UnprovenTransaction, totalFee: bigint): bigint {
+  for (const [tokenType, imbalance] of transaction.imbalances(0, totalFee).entries()) {
+    if (tokenType.tag === 'dust') return imbalance;
+  }
+  return 0n;
+}
+
+type Configuration = Transacting.DefaultTransactingConfiguration;
+type Context = Transacting.DefaultTransactingContext;
+
+/**
+ * The SDK's transacting capability with `computeBalancingRecipe` replaced by
+ * `balanceDustFee`. `estimateFee` and `balanceTransactions` both route through
+ * that one method, so both the fee preview and the real spend take this path.
+ */
+export class TerminatingDustTransacting extends Transacting.TransactingCapabilityImplementation<ledger.FinalizedTransaction> {
+  readonly #onPass: ((pass: DustFeePass) => void) | undefined;
+
+  constructor(config: Configuration, getContext: () => Context, onPass?: (pass: DustFeePass) => void) {
+    super(
+      config.networkId,
+      config.costParameters,
+      () => getContext().coinSelection,
+      () => getContext().coinsAndBalancesCapability,
+      () => getContext().keysCapability,
+    );
+    this.#onPass = onPass;
+  }
+
+  override computeBalancingRecipe(
+    secretKey: ledger.DustSecretKey,
+    state: CoreWallet,
+    transactions: ReadonlyArray<ledger.FinalizedTransaction | ledger.UnprovenTransaction>,
+    ttl: Date,
+    currentTime: Date,
+    ledgerParams: ledger.LedgerParameters,
+  ): Either.Either<
+    {fee: bigint; recipeInputs: ReadonlyArray<CoinsAndBalances.CoinWithValue<Dust>>},
+    WalletError.InsufficientFundsError | WalletError.OtherWalletError
+  > {
+    return Either.try({
+      try: () => {
+        const initialImbalance = transactions.reduce(
+          (total, transaction) => total + dustImbalance(transaction, this.calculateFee(transaction, ledgerParams)),
+          0n,
+        );
+        const coins = this.getCoins().getAvailableCoinsWithGeneratedDust(state, currentTime);
+        const {fee, inputs} = balanceDustFee({
+          coins,
+          initialImbalance,
+          coinSelection: this.getCoinSelection(),
+          feeFor: (chosen) => this.dryRunFee(chosen, transactions, secretKey, state, ttl, currentTime, ledgerParams),
+          onPass: this.#onPass,
+        });
+        return {fee, recipeInputs: distributeFeeAcrossInputs(inputs, fee)};
+      },
+      // Same mapping as the SDK, so callers see the same error types they do today.
+      catch: (err) =>
+        err instanceof BalancingInsufficientFundsError
+          ? new WalletError.InsufficientFundsError({message: err.message, tokenType: err.tokenType})
+          : new WalletError.OtherWalletError({
+              message: err instanceof Error ? err.message : 'Dust balancing failed',
+              cause: err,
+            }),
+    });
+  }
+}
+
+/**
+ * Factory in the shape `V1Builder.withTransacting` expects — the same shape as
+ * the SDK's own `makeDefaultTransactingCapability`.
+ */
+export const terminatingDustTransacting =
+  (options: {onPass?: (pass: DustFeePass) => void} = {}) =>
+  (config: Configuration, getContext: () => Context): TerminatingDustTransacting =>
+    new TerminatingDustTransacting(config, getContext, options.onPass);

--- a/packages/core/src/sync/dust-transacting.ts
+++ b/packages/core/src/sync/dust-transacting.ts
@@ -82,8 +82,9 @@ const sumValues = (coins: ReadonlyArray<FeeCoin>): bigint => coins.reduce((sum, 
  * of coins surfaces as the balancer's own `InsufficientFundsError`.
  *
  * Runs the configured selector first and, only if that ends in insufficient
- * funds, retries largest-first — see the note inside on why the additive loop
- * is complete only from the top.
+ * funds and the configured selector is not already largest-first, retries
+ * largest-first — see the note inside on why the additive loop is complete only
+ * from the top.
  *
  * WASM-free: `feeFor` is injected, so tests drive this with an analytic fee
  * model and the wallet drives it with the SDK's `dryRunFee`.
@@ -109,6 +110,11 @@ export function balanceDustFee<C extends FeeCoin>(args: BalanceDustFeeArgs<C>): 
     return attemptBalance(coins, initialImbalance, feeFor, coinSelection, 'configured', onPass);
   } catch (err) {
     if (!(err instanceof BalancingInsufficientFundsError)) throw err;
+    // Nothing to retry when the configured selector already is largest-first —
+    // which is what wallet-sync.ts wires, so this is the common case. A second
+    // attempt would select the same coins in the same order, re-run `dryRunFee`
+    // once per pass for the same answer, and report every pass twice.
+    if (coinSelection === largestDustCoinFirst) throw err;
     return attemptBalance(coins, initialImbalance, feeFor, largestDustCoinFirst, 'largest-first-fallback', onPass);
   }
 }

--- a/packages/core/src/sync/wallet-sync.ts
+++ b/packages/core/src/sync/wallet-sync.ts
@@ -28,6 +28,7 @@ import {ensureEmptyRefCache, preSeedNewWallet} from './preseed.js';
 import {InMemorySyncStateStore, syncStateKey, type SyncStateStore, type WalletPart} from './sync-store.js';
 import {dedupingShieldedBuilder, dedupingDustBuilder} from './sdk-dedup.js';
 import {largestDustCoinFirst} from './dust-coin-selection.js';
+import {terminatingDustTransacting} from './dust-transacting.js';
 import {overallSyncProgress, type SubWallet} from './progress.js';
 import {partsToSeed} from './preseed-parts.js';
 import type {WalletKeys} from './operations.js';
@@ -593,13 +594,15 @@ export async function startWalletSync(
     indexerClientConnection: {indexerHttpUrl, indexerWsUrl},
     txHistoryStorage,
   } as Parameters<typeof DustWallet>[0];
-  // Largest-first fee-coin selection replaces the SDK's smallest-first default,
-  // whose balancing loop cannot terminate on a wallet holding many part-drained
-  // dust coins (see sync/dust-coin-selection.ts). Chained here rather than
-  // inside dedupingDustBuilder so that module stays about the dedup fix alone;
-  // both the restore and start-with-secret-key paths below share this builder.
+  // Two fixes for the SDK's dust fee balancing, both chained onto the one
+  // builder the restore and start-with-secret-key paths below share, and kept
+  // out of dedupingDustBuilder so that module stays about the dedup fix alone:
+  // largest-first coin selection (sync/dust-coin-selection.ts) and a balancing
+  // loop that terminates (sync/dust-transacting.ts).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const dustBuilder = (dedupingDustBuilder() as any).withCoinSelection(() => largestDustCoinFirst);
+  const dustBuilder = (dedupingDustBuilder() as any)
+    .withCoinSelection(() => largestDustCoinFirst)
+    .withTransacting(terminatingDustTransacting());
   let dustWallet: DustWallet | undefined;
   const savedDust = await loadCachedState(store, name, network.id, 'dust');
   if (savedDust) {

--- a/packages/core/tests/unit/sync/dust-transacting.test.ts
+++ b/packages/core/tests/unit/sync/dust-transacting.test.ts
@@ -1,0 +1,272 @@
+import {describe, it, expect, vi} from 'vitest';
+import {Either} from 'effect';
+import {Transacting, WalletError, CoinsAndBalances} from '@midnightntwrk/wallet-sdk/dust/v1';
+import {
+  balanceDustFee,
+  distributeFeeAcrossInputs,
+  TerminatingDustTransacting,
+  terminatingDustTransacting,
+  type DustFeePass,
+  type FeeCoin,
+} from '../../../src/sync/dust-transacting.js';
+
+type Coin = {value: bigint; token: {nonce: string}};
+const coin = (value: bigint, n: number): Coin => ({value, token: {nonce: String(n).padStart(64, '0')}});
+
+// The SDK's default selector, smallest coin first — the order that walks the
+// SDK's own loop into non-termination. Used here to show the loop, not the
+// selector, is what decides whether balancing ends.
+const smallestFirst = CoinsAndBalances.chooseCoin;
+
+// Analytic stand-in for `dryRunFee`: a base cost plus a per-dust-spend
+// increment, the one property of the real fee that matters to the loop.
+const FEE_BASE = 1_400_000_000_000_000n;
+const FEE_PER_SPEND = 3_750_000_000_000n;
+const feeFor = (inputs: ReadonlyArray<FeeCoin>): bigint => FEE_BASE + FEE_PER_SPEND * BigInt(inputs.length);
+
+// Twelve part-drained coins beside two near their generation cap — the wallet
+// shape on which the SDK loop spins (see dust-coin-selection.test.ts).
+const drained = Array.from({length: 12}, (_, k) => coin(176_250_000_000_000n, k));
+const full = [coin(50_000_000_000_000_000n, 90), coin(30_000_000_000_000_000n, 91)];
+
+describe('balanceDustFee', () => {
+  it('converges with smallest-first on the wallet the SDK loop spins on', () => {
+    const passes: DustFeePass[] = [];
+    const result = balanceDustFee({
+      coins: [...drained, ...full],
+      initialImbalance: -feeFor([]),
+      feeFor,
+      coinSelection: smallestFirst,
+      onPass: (p) => passes.push(p),
+    });
+
+    // Pass 1 selects eight drained coins and under-covers the fee they cost —
+    // the exact state the SDK loop never escapes. Pass 2 covers the shortfall
+    // with one more coin and converges.
+    expect(passes.map((p) => ({pass: p.pass, added: p.added, converged: p.converged}))).toEqual([
+      {pass: 1, added: 8, converged: false},
+      {pass: 2, added: 1, converged: true},
+    ]);
+    expect(result.inputs).toHaveLength(9);
+    expect(result.fee).toBe(feeFor(result.inputs));
+    expect(result.fee).toBeLessThanOrEqual(result.inputs.reduce((s, c) => s + c.value, 0n));
+  });
+
+  it('converges on a uniformly tiny wallet, which no selection order can rescue', () => {
+    const uniformlyTiny = Array.from({length: 12}, (_, k) => coin(176_250_000_000_000n, k));
+    const passes: DustFeePass[] = [];
+    const result = balanceDustFee({
+      coins: uniformlyTiny,
+      initialImbalance: -feeFor([]),
+      feeFor,
+      coinSelection: smallestFirst,
+      onPass: (p) => passes.push(p),
+    });
+
+    expect(passes.at(-1)?.converged).toBe(true);
+    expect(passes.length).toBeLessThanOrEqual(uniformlyTiny.length);
+    expect(result.inputs.reduce((s, c) => s + c.value, 0n)).toBeGreaterThanOrEqual(result.fee);
+  });
+
+  it('never re-selects a coin and grows the input set every pass', () => {
+    const passes: DustFeePass[] = [];
+    const result = balanceDustFee({
+      coins: [...drained, ...full],
+      initialImbalance: -feeFor([]),
+      feeFor,
+      coinSelection: smallestFirst,
+      onPass: (p) => passes.push(p),
+    });
+    const nonces = result.inputs.map((c) => c.token.nonce);
+    expect(new Set(nonces).size).toBe(nonces.length);
+    for (let i = 1; i < passes.length; i++) {
+      expect(passes[i]!.inputs).toBeGreaterThan(passes[i - 1]!.inputs);
+      expect(passes[i]!.fee).toBeGreaterThan(passes[i - 1]!.fee - FEE_PER_SPEND); // fee is monotone in inputs
+    }
+  });
+
+  it('fails with the balancer insufficient-funds error when the pool cannot cover the fee', () => {
+    expect(() =>
+      balanceDustFee({coins: [coin(1n, 0), coin(2n, 1)], initialImbalance: -feeFor([]), feeFor, coinSelection: smallestFirst}),
+    ).toThrowError(/dust/i);
+  });
+
+  it('rescues a selector that picks nothing from a non-empty pool via the fallback', () => {
+    // Under the SDK loop a selector returning undefined is an immediate
+    // InsufficientFundsError; here the largest-first fallback gets a turn first.
+    const picksNothing: CoinsAndBalances.CoinSelection = () => undefined;
+    const passes: DustFeePass[] = [];
+    const result = balanceDustFee({
+      coins: [...full],
+      initialImbalance: -feeFor([]),
+      feeFor,
+      coinSelection: picksNothing,
+      onPass: (p) => passes.push(p),
+    });
+    expect(passes.map((p) => p.selector)).toEqual(['largest-first-fallback']);
+    expect(result.inputs).toHaveLength(1);
+  });
+
+  it('selects nothing when the transaction already carries enough dust', () => {
+    const feeSpy = vi.fn(feeFor);
+    const result = balanceDustFee({coins: [...full], initialImbalance: 5n, feeFor: feeSpy, coinSelection: smallestFirst});
+    expect(result.inputs).toEqual([]);
+    expect(result.fee).toBe(feeFor([]));
+    expect(feeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to largest-first when smallest-first strands the coin that could pay', () => {
+    // Real coin set from a devnet wallet minutes after registration, with the
+    // real fee model of that chain: base 3.66e14, +3.36e14 per dust input.
+    // Smallest-first takes 6.4e13, must add 9.7e14, and fee(2)=1.037e15 exceeds
+    // the wallet's entire 1.031e15 — but 9.7e14 alone covers fee(1)=7.3e14.
+    const devnetFee = (inputs: ReadonlyArray<FeeCoin>): bigint => 365_895_829_713_385n + 335_638_367_806_065n * BigInt(inputs.length);
+    const wallet = [coin(64_165_147_200_000n, 0), coin(967_238_395_877_943n, 1)];
+    const passes: DustFeePass[] = [];
+    const result = balanceDustFee({
+      coins: wallet,
+      initialImbalance: -devnetFee([]),
+      feeFor: devnetFee,
+      coinSelection: smallestFirst,
+      onPass: (p) => passes.push(p),
+    });
+    expect(passes.map((p) => [p.selector, p.pass, p.inputs, p.converged])).toEqual([
+      ['configured', 1, 2, false],
+      ['largest-first-fallback', 1, 1, true],
+    ]);
+    expect(result.inputs.map((c) => c.value)).toEqual([967_238_395_877_943n]);
+    expect(result.fee).toBe(devnetFee(result.inputs));
+  });
+
+  it('reports insufficient funds when no order of the pool can pay', () => {
+    // Coins so small the balancer throws before a pass completes, under both
+    // the configured selector and the fallback; the error is the SDK's own.
+    expect(() =>
+      balanceDustFee({coins: [coin(1n, 0), coin(2n, 1)], initialImbalance: -feeFor([]), feeFor, coinSelection: smallestFirst}),
+    ).toThrowError(/dust/i);
+  });
+
+  it('converges on the first pass when one coin covers the fee', () => {
+    const passes: DustFeePass[] = [];
+    const largestFirst: CoinsAndBalances.CoinSelection = (coins) =>
+      [...coins].sort((a, b) => (b.value > a.value ? 1 : b.value < a.value ? -1 : 0)).at(0);
+    balanceDustFee({
+      coins: [...drained, ...full],
+      initialImbalance: -feeFor([]),
+      feeFor,
+      coinSelection: largestFirst,
+      onPass: (p) => passes.push(p),
+    });
+    expect(passes).toHaveLength(1);
+    expect(passes[0]).toMatchObject({added: 1, converged: true});
+  });
+});
+
+describe('distributeFeeAcrossInputs', () => {
+  it('drains inputs in order and charges the last one only the remainder', () => {
+    const out = distributeFeeAcrossInputs([coin(10n, 0), coin(10n, 1), coin(10n, 2)], 25n);
+    expect(out.map((c) => c.value)).toEqual([10n, 10n, 5n]);
+    expect(out.map((c) => c.token.nonce)).toEqual([0, 1, 2].map((n) => String(n).padStart(64, '0')));
+  });
+});
+
+// A fake ledger transaction: the only thing `computeBalancingRecipe` asks of it
+// directly is its dust imbalance at a given fee.
+const fakeTransaction = (): unknown => ({
+  imbalances: (_segment: number, fee: bigint) => new Map([[{tag: 'dust'}, -fee]]),
+});
+
+// Test double over the real class: swaps the two WASM-backed methods for the
+// analytic fee model and leaves everything else — including the override under
+// test and its error mapping — exactly as shipped.
+class TestableTransacting extends TerminatingDustTransacting {
+  override calculateFee(): bigint {
+    return feeFor([]);
+  }
+  override dryRunFee(recipeInputs: ReadonlyArray<FeeCoin>): bigint {
+    return feeFor(recipeInputs);
+  }
+}
+
+const context = (coins: ReadonlyArray<Coin>, coinSelection: CoinsAndBalances.CoinSelection = smallestFirst) =>
+  () =>
+    ({
+      coinSelection,
+      coinsAndBalancesCapability: {getAvailableCoinsWithGeneratedDust: () => coins},
+      keysCapability: {},
+    }) as unknown as Transacting.DefaultTransactingContext;
+
+const config = {networkId: 'undeployed', costParameters: {feeBlocksMargin: 5}} as unknown as Transacting.DefaultTransactingConfiguration;
+const ledgerArgs = [undefined, undefined, [fakeTransaction()], new Date(), new Date(), undefined] as unknown as Parameters<
+  TerminatingDustTransacting['computeBalancingRecipe']
+>;
+
+describe('TerminatingDustTransacting', () => {
+  it('returns a recipe whose distributed inputs sum exactly to the fee', () => {
+    const passes: DustFeePass[] = [];
+    const cap = new TestableTransacting(config, context([...drained, ...full]), (p) => passes.push(p));
+    const result = cap.computeBalancingRecipe(...ledgerArgs);
+
+    expect(Either.isRight(result)).toBe(true);
+    if (!Either.isRight(result)) return;
+    expect(passes).toHaveLength(2);
+    expect(result.right.fee).toBe(feeFor(result.right.recipeInputs));
+    expect(result.right.recipeInputs.reduce((s, c) => s + c.value, 0n)).toBe(result.right.fee);
+  });
+
+  it('maps an uncoverable fee to the SDK InsufficientFundsError, not a hang', () => {
+    const cap = new TestableTransacting(config, context([coin(1n, 0)]));
+    const result = cap.computeBalancingRecipe(...ledgerArgs);
+    expect(Either.isLeft(result)).toBe(true);
+    if (!Either.isLeft(result)) return;
+    expect(result.left).toBeInstanceOf(WalletError.InsufficientFundsError);
+    expect(result.left).toMatchObject({tokenType: 'dust'});
+  });
+
+  it('maps any other failure to OtherWalletError with the cause attached', () => {
+    class Exploding extends TestableTransacting {
+      override dryRunFee(): bigint {
+        throw new Error('ledger exploded');
+      }
+    }
+    const result = new Exploding(config, context([...full])).computeBalancingRecipe(...ledgerArgs);
+    expect(Either.isLeft(result)).toBe(true);
+    if (!Either.isLeft(result)) return;
+    expect(result.left).toBeInstanceOf(WalletError.OtherWalletError);
+    expect(result.left.message).toBe('ledger exploded');
+  });
+
+  it('reaches both estimateFee and balanceTransactions through the override', () => {
+    // The fix only holds if the SDK still routes both entry points through
+    // computeBalancingRecipe. A spy on the override is the direct check.
+    const cap = new TestableTransacting(config, context([...full]));
+    const spy = vi.spyOn(cap, 'computeBalancingRecipe');
+    const estimate = cap.estimateFee(...(ledgerArgs as unknown as Parameters<typeof cap.estimateFee>));
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(Either.isRight(estimate)).toBe(true);
+    // balanceTransactions goes on to build a real ledger intent; a rejected
+    // Either from the spy is enough to prove the routing without WASM.
+    spy.mockReturnValueOnce(Either.left(new WalletError.OtherWalletError({message: 'routed', cause: undefined})));
+    const balanced = cap.balanceTransactions(...(ledgerArgs as unknown as Parameters<typeof cap.balanceTransactions>));
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(Either.isLeft(balanced) && balanced.left.message).toBe('routed');
+  });
+
+  it('builds through the factory shape V1Builder.withTransacting expects', () => {
+    const cap = terminatingDustTransacting()(config, context([...full]));
+    expect(cap).toBeInstanceOf(TerminatingDustTransacting);
+    expect(cap).toBeInstanceOf(Transacting.TransactingCapabilityImplementation);
+  });
+});
+
+describe('SDK surface this module depends on', () => {
+  // These are the internals the override reaches for. If an SDK bump removes
+  // or renames one, this fails here instead of at a user's first transfer.
+  it('still exposes the implementation class and the members the override uses', () => {
+    const proto = Transacting.TransactingCapabilityImplementation.prototype as Record<string, unknown>;
+    for (const member of ['computeBalancingRecipe', 'dryRunFee', 'calculateFee', 'estimateFee', 'balanceTransactions']) {
+      expect(typeof proto[member], member).toBe('function');
+    }
+    expect(Transacting.TransactingCapabilityImplementation.length).toBe(5);
+  });
+});

--- a/packages/core/tests/unit/sync/dust-transacting.test.ts
+++ b/packages/core/tests/unit/sync/dust-transacting.test.ts
@@ -9,6 +9,7 @@ import {
   type DustFeePass,
   type FeeCoin,
 } from '../../../src/sync/dust-transacting.js';
+import {largestDustCoinFirst} from '../../../src/sync/dust-coin-selection.js';
 
 type Coin = {value: bigint; token: {nonce: string}};
 const coin = (value: bigint, n: number): Coin => ({value, token: {nonce: String(n).padStart(64, '0')}});
@@ -144,6 +145,50 @@ describe('balanceDustFee', () => {
     expect(() =>
       balanceDustFee({coins: [coin(1n, 0), coin(2n, 1)], initialImbalance: -feeFor([]), feeFor, coinSelection: smallestFirst}),
     ).toThrowError(/dust/i);
+  });
+
+  // A pool whose coins together meet the initial fee exactly, so pass 1 selects
+  // all of them and prices them, but the fee those spends cost then exceeds what
+  // they cover and nothing is left to add. Unaffordable under every order.
+  const exhausting = Array.from({length: 4}, (_, k) => coin(350_000_000_000_000n, k));
+
+  it('skips the fallback when the configured selector already is largest-first', () => {
+    // wallet-sync.ts configures largest-first, so this is the common insufficient-
+    // funds path. Retrying would select the same coins in the same order, re-run
+    // the fee model for the same answer, and report every pass twice.
+    const feeSpy = vi.fn(feeFor);
+    const passes: DustFeePass[] = [];
+    expect(() =>
+      balanceDustFee({
+        coins: exhausting,
+        initialImbalance: -feeFor([]),
+        feeFor: feeSpy,
+        coinSelection: largestDustCoinFirst,
+        onPass: (p) => passes.push(p),
+      }),
+    ).toThrowError(/dust/i);
+
+    expect(passes.map((p) => p.selector)).toEqual(['configured']);
+    expect(feeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('still runs the fallback for a selector that is not largest-first', () => {
+    // The guard above must be specific to the identical-selector case, not a
+    // blanket disable: the same pool under smallest-first still gets its retry.
+    const feeSpy = vi.fn(feeFor);
+    const passes: DustFeePass[] = [];
+    expect(() =>
+      balanceDustFee({
+        coins: exhausting,
+        initialImbalance: -feeFor([]),
+        feeFor: feeSpy,
+        coinSelection: smallestFirst,
+        onPass: (p) => passes.push(p),
+      }),
+    ).toThrowError(/dust/i);
+
+    expect(passes.map((p) => p.selector)).toEqual(['configured', 'largest-first-fallback']);
+    expect(feeSpy).toHaveBeenCalledTimes(2);
   });
 
   it('converges on the first pass when one coin covers the fee', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2915,7 +2915,7 @@ __metadata:
     "@scure/bip39": "npm:^2.2.0"
     "@types/node": "npm:^25.6.0"
     "@types/ws": "npm:^8"
-    effect: "npm:^3.20.0"
+    effect: "npm:^3.19.19"
     fast-check: "npm:3.23.2"
     graphql: "npm:^16.10.0"
     graphql-request: "npm:^7.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2915,6 +2915,7 @@ __metadata:
     "@scure/bip39": "npm:^2.2.0"
     "@types/node": "npm:^25.6.0"
     "@types/ws": "npm:^8"
+    effect: "npm:^3.20.0"
     fast-check: "npm:3.23.2"
     graphql: "npm:^16.10.0"
     graphql-request: "npm:^7.4.0"


### PR DESCRIPTION
Follows #141 (largest-first selection), now merged, and targets `main` directly. #141 is the default that keeps most wallets out of the bug's reach; this PR is the fix. They compose, and the reasons they belong together are below.

## What this does

Moth supplies its own DUST transacting capability through the SDK's documented `V1Builder.withTransacting` seam ([dust-transacting.ts](packages/core/src/sync/dust-transacting.ts)). It subclasses the SDK's exported `TransactingCapabilityImplementation` and overrides exactly one method, `computeBalancingRecipe`. Everything else — `dryRunFee` and `calculateFee` (the WASM fee arithmetic), transaction construction, signing, proving — is the SDK's, untouched. `estimateFee` and `balanceTransactions` both route through the replaced method, so the fee preview and the real spend take the same path.

## Why the loop and not just the default

The SDK's `computeBalancingRecipe` (`wallet-sdk-dust-wallet` 4.2.0) is an `Effect.iterate` whose only exit is `newFee <= coverage`. It has no iteration cap, no progress check, and a sign bug: pass 1 is seeded with the transaction's dust **imbalance** (negative), every later pass with the recomputed **fee** (positive). The balancer reads a positive seed as a surplus, adds an output and selects **zero inputs**, so only pass 1 can ever converge; every pass after a failed pass 1 is byte-identical and builds + proof-erases a fresh WASM transaction on the calling thread until the process dies. #141 makes pass 1 succeed on most wallets by taking the biggest coin. It cannot make the loop correct: a wallet whose coins are all below fee size still spins under any selection order (pinned as a test in #141).

## The replacement loop

```
inputs = []; fee = -initialImbalance             # the deficit, positive
loop (at most coins.length + 1 passes):
  deficit = fee - sum(inputs); if deficit <= 0: return
  add = balancer(remaining coins, seed = -deficit)   # always a deficit → always selects
  if add is empty: InsufficientFunds                 # progress check
  inputs += add; remaining -= add
  fee = dryRunFee(inputs)                            # real WASM fee with these inputs
  if fee <= sum(inputs): return
```

Adding an input can only raise the fee, so a pass that does not converge has strictly grown the input set. With a finite pool that bounds the passes by the number of coins — termination is a counting argument, not a timeout. Running out of coins surfaces as the SDK's own `InsufficientFundsError`, mapped exactly as the SDK maps it, so callers see the error types they see today.

**Completeness needs largest-first, so there is a fallback.** Measured on the devnet below, each dust input adds ~3.36e14 to the fee — a dust spend roughly doubles it. An additive loop under smallest-first can therefore take a small coin, be forced to add the big one, and find fee(2) exceeds the whole wallet, when the big coin alone would have covered fee(1). That is not hypothetical: a real devnet wallet holding 6.4e13 and 9.7e14 against a 7.3e14 fee did exactly that. From the top, the k largest coins dominate every other k-subset, so the additive loop from largest-first finds a covering set whenever one exists. `balanceDustFee` therefore runs the configured selector first (honouring a wallet's preference when it works) and, only if that ends in insufficient funds, retries largest-first before reporting the error. The retry is **skipped when the configured selector already is largest-first** — which is what `wallet-sync.ts` wires, so that was the common insufficient-funds path: a second attempt would select the same coins in the same order, re-run `dryRunFee` once per pass for the same answer, and report every pass twice. The guard is an identity check on the shipped selector, so a caller that wraps it degrades to taking the retry rather than losing it. The devnet case above, and both sides of that guard, are unit tests.

## Trade-offs, stated plainly

- **Coupling to SDK internals.** This reaches for the SDK's exported implementation class, its 5-argument constructor, and the public methods `dryRunFee`, `calculateFee`, `computeBalancingRecipe`, `estimateFee`, `balanceTransactions`. Renames in an SDK bump would break it. Mitigation: [dust-transacting.test.ts](packages/core/tests/unit/sync/dust-transacting.test.ts) pins that surface and spies the routing, so the bump fails in CI rather than silently reverting to the SDK loop. Same trade the repo already made in `sdk-dedup.ts`, for the same reason.
- **`effect` becomes a direct dependency of `@shieldedtech/moth-wallet`.** The capability returns the SDK's `Either` values; the SDK's `Either.map` checks its own type id, so hand-rolled objects would not pass. The range is `^3.19.19`, matching what every SDK package declares — a floor above the SDK's is what could force a second copy of `effect` into the tree, and a second copy is precisely what would break `Either` across the boundary. `effect` was already in the tree via the SDK; both ranges resolve to one copy at 3.21.4, so the lockfile change is one line.
- **It cannot be rescued from outside.** `computeBalancingRecipe` runs under `Effect.runSync`, so no timeout wrapper reaches a spin; the check must live inside the loop. There is no lighter alternative.
- **Not the upstream fix.** The doc in `docs/upstream-issues/` now describes this loop as the reference for the two asks (a progress check; one sign convention across passes). I'd send the identical ~40 lines to `midnightntwrk/midnight-wallet`.

## Evidence — reproduced on a real devnet, through the real WASM fee loop

Both PRs so far rested on a unit reproduction with a modelled fee oracle. This one was verified against a live chain that moth's `ledger-v8` pin can actually replay: an isolated devnet (node `1.0.1`, indexer `4.3.7`, proof-server `8.1.0` — the matched set for ledger 8; the `2.x-rc` line emits `midnight:event[v14]` which the pin cannot decode, see the note at the end) on ports 9974/8118/6330, funded through moth itself by importing the genesis seed. 128 events replayed, zero decode errors. Nothing was submitted by the probes; the daemon transfers below are real.

**Real fee model, measured via `dryRunFee` on genesis (5 coins × 2.5e23):** base fee `365895829713385`, fee with one dust input `726710322685961`. Each dust input adds **~3.36e14** — a dust spend roughly doubles the fee. This is what makes tiny coins unable to pay for themselves and the SDK loop so easy to trip.

**A/B on one wallet, identical coin snapshot (14:45:19), same base fee, three processes:**

| coin | value |
|---|---|
| 0 | 72336250000000 |
| 1 | 186420850000000 |
| 2 | 290585050000000 |
| 3 | 1002728404300000 |
| 4 | 8492770475240316 |

```
arm=sdk      computeBalancingRecipe: START 14:45:19.761
             … no return; killed by the 150 s timeout (status 137)

arm=fixed    (Moth loop, SDK smallest-first — isolates the loop change)
  [pass 1] deficit=365895829713385 added=3 inputs=3 coverage=549342150000000   fee=1347947773935472 converged=false
  [pass 2] deficit=798605623935472 added=1 inputs=4 coverage=1552070554300000  fee=1658034457410542 converged=false
  [pass 3] deficit=105963903110542 added=1 inputs=5 coverage=10044841029540316 fee=1968121140885613 converged=true
             DONE in 51 ms — fee=1968121140885613 inputs=5

arm=shipped  (Moth loop + largest-first, what wallet-sync.ts wires)
  [pass 1] deficit=365895829713385 added=1 inputs=1 coverage=8492770475240316  fee=726585136297800 converged=true
             DONE in 13 ms — fee=726585136297800 inputs=1
```

Pass 1 of the fixed arm is exactly the state the SDK never leaves: three smallest coins, 5.49e14 against the 1.35e15 those three spends cost. The SDK loop's pass 2 is seeded with `+1.35e15`, selects nothing, and repeats forever. The fixed loop's pass 2 is seeded with the *deficit* and keeps going. Note the fee: the ascending path converges at 1.97e15 with 5 inputs, largest-first at 7.27e14 with 1 — the same transaction costs 2.7× more when the loop is asked to pay from small coins, which is the second reason #141 belongs underneath this.

**The spin's memory signature — this is what `main` does today.** The `sdk` arm is `main`'s exact configuration (SDK loop, SDK selector). Re-run alone for 15 minutes with the node process's RSS sampled from outside every 5 s (the loop is synchronous, so the process cannot report on itself), and an idle moth wallet daemon sampled beside it as the baseline:

```
   time   spinning SDK loop   idle moth daemon
11:40:58        423 MB            227 MB     ← computeBalancingRecipe called
11:41:44       1094 MB            227 MB
11:42:29       1900 MB            227 MB     16.2 MB/s over the first two minutes
11:43:14       2304 MB            228 MB
11:45:30       2556 MB            230 MB
11:48:32       2848 MB            231 MB     then ~1.2 MB/s, sustained
11:51:33       3099 MB              –        (daemon exited on its own 15-min idle auto-lock)
11:55:50       3432 MB              –        killed by my 900 s timeout, still climbing
```

It does not plateau: after the initial burst the growth slows to ~1.2 MB/s and stays there — 3.4 GB at 15 minutes on a 92 GB machine, so it never hit a ceiling here. In an extension worker or on a small host that is death within minutes, which matches the field report. The two fixed arms on the same wallet in the same session: `fixed` 2 passes / 20 ms, `shipped` 1 pass / 10 ms, RSS flat at 414–415 MB throughout (that figure is the probe's synced dust wallet, not growth).

**End to end through the daemon (`moth daemon transfer`, shipped build):** twelve consecutive fee-paying transfers from a 7-coin wallet, **12/12 accepted**, ~3.0 s client round-trip each, daemon `building → proving → submitting` in ~350 ms. The fee coin's `seq` went 6 → 12 across them: one successor per spend, no fragmentation. The same twelve on a build *without* the largest-first fallback (my loop + SDK ascending) went 6/12, the failures all instant `Insufficient funds` — the false negative the fallback exists to close, on a wallet that could pay.

**Not exercised here:** the browser extension path (same core module, not run in a worker); public-network parameters; the out-of-memory end state itself (the 92 GB host never reached it).

## Two things worth knowing if you reproduce this

- A DUST registration **rotates** the NIGHT UTXOs it includes into a guaranteed and a fallible output, so registering 14 UTXOs in one `dust register` yields 2 dust coins. Registration is address-level after that: later NIGHT UTXOs of the key generate on their own, each backing its own dust coin. To get several coins, fund several UTXOs *after* registering.
- The local `2.0.0-rc.4` stacks on this machine emit `midnight:event[v14]`; moth's `@midnight-ntwrk/ledger-v8` 8.1.0 expects `v9` and fails at event 1, and `SDK_NOISE` swallows that error as `Wallet.Sync`, so the wallet reports 100 % synced with zero dust. Separate issue; not touched here.

## Checks

- `packages/core`: 393 tests pass (41 files), 16 of them new
- `tsc --noEmit` clean; `core` and `browser` rebuild clean
- pre-commit: `trailing-whitespace`, `end-of-file-fixer`, `check-merge-conflict`, `detect-private-key`, `gitleaks`, `release-workflow-policy` pass on the changed files; `actionlint` cannot install in this sandbox (Go toolchain download blocked) and no workflow files change
