### PR TITLE
fix(extension): make Paste work outside Chrome and stop dropping address underscores

### DIFF
--- a/.changeset/mono-underscore-visible.md
+++ b/.changeset/mono-underscore-visible.md
@@ -1,0 +1,19 @@
+---
+'@shieldedtech/moth-extension': patch
+---
+
+Keep the underscores in an address visible, by naming a real monospace face
+ahead of the generic one.
+
+`--font-mono` ended in `ui-monospace, 'SF Mono', Menlo, monospace`, which lists
+only faces that exist on macOS. Everywhere else it fell through to the generic
+`monospace`, which on most Linux desktops resolves to DejaVu Sans Mono — and
+inside an `<input>` at 14px Chromium renders that face's underscore as no
+pixels at all, so `mn_addr_undeployed1…` read as `mn addr undeployed1…`. An
+address is exactly the string where a silently dropped character matters.
+
+The loss is specific to the combination: the same face renders the underscore
+in a plain element, and at 13px or 15px in the same input. Line-height,
+padding and box height do not move it, so the font stack is the only lever.
+Consolas covers Windows and Liberation Mono and Noto Sans Mono cover Linux,
+each of which renders the underscore at every size in the 12–16px range.

--- a/.changeset/paste-button-clipboard-permission.md
+++ b/.changeset/paste-button-clipboard-permission.md
@@ -1,0 +1,25 @@
+---
+'@shieldedtech/moth-extension': patch
+---
+
+Declare `clipboardRead`, so the Paste button on a recipient address works
+outside Chrome.
+
+Both Paste affordances — the one on the recipient field in Send and the DUST
+designation dialog (`components/moth/address-picker.tsx`), and the seed-phrase
+one in setup — call `navigator.clipboard.readText()`, but the manifest never
+asked for the permission that read requires. Chrome serves the read to an
+extension page off a user gesture regardless of whether it was declared, so the
+omission was invisible there and the buttons worked. Stricter Chromium builds
+enforce the declaration: on Brave the promise rejected, and the picker's
+`catch` discarded the rejection without touching the field or saying anything,
+so Paste was a button that did nothing.
+
+The rejection is now logged rather than swallowed. It still leaves the field
+alone — a keyboard paste was never affected and remains the fallback — but a
+refused read raises no UI of its own, so silence made a permission problem
+indistinguishable from a dead button.
+
+A guard test resolves the manifest for both targets and asserts the permission
+is present, since the only builds that would otherwise notice its absence are
+the ones we do not test on.

--- a/packages/extension/assets/globals.css
+++ b/packages/extension/assets/globals.css
@@ -221,7 +221,10 @@
 
   --font-sans: 'Instrument Sans', system-ui, sans-serif;
   --font-display: 'Bricolage Grotesque', var(--font-sans);
-  --font-mono: ui-monospace, 'SF Mono', Menlo, monospace;
+  /* The generic `monospace` is DejaVu Sans Mono on most Linux desktops, whose
+     underscore renders as no pixels inside an <input> at 14px — an address
+     then reads `mn addr …`. Keep a real face ahead of the generic. */
+  --font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, 'Liberation Mono', 'Noto Sans Mono', monospace;
 }
 
 body {

--- a/packages/extension/components/moth/address-picker.tsx
+++ b/packages/extension/components/moth/address-picker.tsx
@@ -40,8 +40,10 @@ export function AddressPicker({
   const paste = async () => {
     try {
       onChange((await navigator.clipboard.readText()).trim());
-    } catch {
-      /* clipboard denied */
+    } catch (error) {
+      // A refused read raises no UI of its own, so report it rather than leave
+      // the button looking dead. The field is untouched; Ctrl+V still works.
+      console.warn('Clipboard read denied; Paste unavailable:', error);
     }
   };
 

--- a/packages/extension/tests/manifest-permissions.test.ts
+++ b/packages/extension/tests/manifest-permissions.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import config from '../wxt.config';
+
+/** The manifest is generated per target, so resolve it the way WXT does. */
+function permissionsFor(browser: string): string[] {
+  const manifest = config.manifest as (env: { browser: string }) => { permissions: string[] };
+  return manifest({ browser }).permissions;
+}
+
+describe('manifest permissions', () => {
+  // Chrome serves clipboard reads to an extension page whether or not the
+  // permission is declared, so only stricter builds catch a missing entry.
+  it.each(['chrome', 'firefox'])('declares clipboardRead on %s, which Paste reads through', (browser) => {
+    expect(permissionsFor(browser)).toContain('clipboardRead');
+  });
+});

--- a/packages/extension/wxt.config.ts
+++ b/packages/extension/wxt.config.ts
@@ -55,6 +55,10 @@ export default defineConfig({
       // them: it grants header rewriting on hosts already declared below, and
       // no new access.
       'declarativeNetRequestWithHostAccess',
+      // Required by the Paste buttons (recipient field, setup seed phrase),
+      // which read the clipboard. Chrome allows that read from an extension
+      // page undeclared; stricter Chromium builds such as Brave refuse it.
+      'clipboardRead',
       // Chrome-only; Firefox gets sidebar_action from the sidepanel entrypoint.
       ...(browser === 'firefox' ? [] : ['sidePanel', 'offscreen']),
     ],


### PR DESCRIPTION
# Overview

Two defects on the recipient-address field, both found while pasting a
destination address into Send on Brave. They are unrelated in mechanism but
sit on the same control, so they are fixed together.

### 1. The Paste button did nothing outside Chrome

`AddressPicker` reads the clipboard with `navigator.clipboard.readText()`, but
the manifest never declared `clipboardRead`. Chrome serves that read to an
extension page off a user gesture whether or not the permission is declared,
so the omission was invisible there and the button worked. Stricter Chromium
builds enforce the declaration: on Brave the promise rejected, and the
picker's `catch` discarded the rejection without touching the field or
reporting anything — a button that did nothing, with nothing in the console.

The same permission also backs the seed-phrase Paste in setup, which had the
same latent failure.

The rejection is now logged rather than swallowed. It still leaves the field
alone (a keyboard paste was never affected and remains the fallback), but a
refused read raises no UI of its own, so silence made a permission problem
indistinguishable from a dead button.

`clipboardRead` adds a "Read data you copy and paste" install warning. The
extension is not on the Chrome Web Store and is loaded unpacked, so this costs
nothing today; if it is ever published, moving it to `optional_permissions`
and requesting it from the Paste click is the alternative.

### 2. Underscores in an address were invisible

`--font-mono` ended in `ui-monospace, 'SF Mono', Menlo, monospace` — every
named face exists only on macOS, so everywhere else it fell through to the
generic `monospace`. On most Linux desktops that resolves to DejaVu Sans Mono,
and inside an `<input>` at 14px Chromium draws that face's underscore as **no
pixels at all**:

```
before   mn addr undeployed1ps8wgx74zp6h
after    mn_addr_undeployed1ps8wgx74zp6h
```

On an address field a silently dropped character changes the string the user
is reading back against their source, which is the whole point of showing it
in a monospace face.

The loss needs the entire combination, which is what made it look arbitrary:
the same face renders the underscore in a plain element, and at 13px or 15px
in the same input. Line-height (tested 20/22/24/28/normal/1.45), padding and
box height all leave it unchanged, so the font stack is the only lever.
Consolas covers Windows; Liberation Mono and Noto Sans Mono cover Linux. All
three draw the underscore across 12-16px, verified in both Chrome and Brave.

This affects every monospace surface, not just Send — the address-book picker,
the DUST designation dialog and the hex-seed field had the same gap.

## Testing

- `packages/extension`: 470 unit tests and `tsc --noEmit` pass; `wxt build`
  clean, and the emitted `chrome-mv3/manifest.json` carries `clipboardRead`.
- New guard test `tests/manifest-permissions.test.ts` resolves the manifest
  for both targets and asserts the permission is present. Confirmed it fails
  when the permission is removed, so it is a real guard.
- The font fix was verified by rendering the field headlessly in Chrome and
  Brave at 1x and measuring the rasterised pixels — the underscore goes from
  zero lit pixels to a drawn stroke at every size from 12 to 16px.
- Both fixes were confirmed by hand in Brave on an unpacked build.

No regression test accompanies the font change: a font-stack regression only
reproduces in a real rasteriser with a particular face installed, so a unit
test would assert nothing meaningful. The reasoning is recorded in a comment
next to the declaration instead, so the stack is not "simplified" back.

The stack still depends on the host having one of the named faces. A machine
with only DejaVu falls back and the bug returns. The app already bundles
Instrument Sans and Bricolage Grotesque via `@fontsource` for exactly this
reason; bundling a mono face is the durable fix and is left as a follow-up
since it adds a dependency and is a design choice.

## Submission Checklist

- [x] Useful pull request description
- [x] Tests are provided (if possible)
- [x] Key commits have useful messages
- [x] Every non-merge, non-bot commit has a matching DCO `Signed-off-by` trailer
- [x] All check jobs of the CI have succeeded
- [x] Self-reviewed the diff
- [ ] Reviewer requested
- [x] Update README.md file (if relevant) — not relevant
- [x] Update documentation (if relevant) — changesets included for both fixes
- [x] No new todos introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)
